### PR TITLE
`buildMeta` & `publishAndRunIde` build tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,3 +22,18 @@ allprojects {
     jcenter()
   }
 }
+
+task buildMeta {
+  dependsOn 'clean'
+  dependsOn 'build'
+  dependsOn ':gradle-plugin:publishArrowPluginMarkerMavenPublicationToMavenLocal'
+  dependsOn ':gradle-plugin:publishPluginMavenPublicationToMavenLocal'
+  tasks.findByPath(':gradle-plugin:publishArrowPluginMarkerMavenPublicationToMavenLocal').mustRunAfter 'build'
+  tasks.findByPath(':gradle-plugin:publishPluginMavenPublicationToMavenLocal').mustRunAfter 'build'
+}
+
+task publishAndRunIde {
+  dependsOn ':buildMeta'
+  dependsOn ':idea-plugin:runIde'
+  tasks.findByPath(':idea-plugin:runIde').mustRunAfter ':buildMeta'
+}


### PR DESCRIPTION
Ports the build tasks from the old location and rewrites them to refer to the local module tasks.