### PR TITLE
Configuration: publish artifacts

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -1,0 +1,31 @@
+name: Publish artifacts
+
+on:
+  push:
+    branches:
+    - master
+
+jobs:
+  publish_artifacts:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+        architecture: x64
+    - name: Build with Gradle
+      env:
+        JAVA_OPTS: -Xms512m -Xmx1024m
+      run: |
+        ./gradlew clean build
+    - name: Publish artifacts
+      env:
+        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
+        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+      run: |
+        ./gradlew uploadArchives
+        echo "$(cat gradle.properties | grep VERSION_NAME | cut -d'=' -f2) deployed!"

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ plugins {
   id 'org.jetbrains.kotlin.jvm' version '1.3.50'
   id 'org.jetbrains.kotlin.kapt' version '1.3.50'
   id 'com.github.johnrengelman.shadow' version '5.0.0'
+  id 'com.jfrog.bintray' version "1.8.4"
 }
 
 def pathApiDocs = "${rootDir}/docs/docs/apidocs"
@@ -39,6 +40,9 @@ allprojects {
 }
 
 subprojects { project ->
+
+  group = GROUP
+  version = VERSION_NAME
 
   apply plugin: 'kotlin'
   apply plugin: 'org.jetbrains.dokka'
@@ -64,7 +68,22 @@ subprojects { project ->
       // Suffix which is used to append the line number to the URL. Use #L for GitHub
       suffix = "#L"
     }
+  }
 
+  apply plugin: 'com.jfrog.bintray'
+
+  bintray {
+      publish = true
+      user = project.hasProperty('bintrayUser') ? project.property('bintrayUser') : System.getenv('BINTRAY_USER')
+      key = project.hasProperty('bintrayApiKey') ? project.property('bintrayApiKey') : System.getenv('BINTRAY_API_KEY')
+      configurations = ['archives']
+      pkg {
+          repo = 'arrow-kt'
+          name = project.name
+          userOrg = POM_DEVELOPER_ID
+          licenses = ['Apache-2.0']
+          vcsUrl = 'https://github.com/arrow-kt/arrow-meta.git'
+      }
   }
 }
 

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -55,3 +55,5 @@ repositories {
 test {
   testLogging.showStandardStreams = true
 }
+
+apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/compiler-plugin/gradle.properties
+++ b/compiler-plugin/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow Meta Compiler Plugin
+POM_ARTIFACT_ID=arrow-meta-compiler-plugin
+POM_PACKAGING=jar

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -34,3 +34,5 @@ ank {
 //}
 
 compileKotlin.kotlinOptions.freeCompilerArgs += ["-Xskip-runtime-version-check"]
+
+apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/docs/gradle.properties
+++ b/docs/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow Meta Docs
+POM_ARTIFACT_ID=arrow-meta-docs
+POM_PACKAGING=jar

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -2,7 +2,6 @@ plugins {
   id 'java-gradle-plugin'
   id 'maven-publish'
   id 'com.gradle.plugin-publish' version "0.10.1"
-  id 'com.jfrog.bintray' version "1.8.4"
 }
 apply plugin: 'kotlin'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,22 @@
+# Package definitions
+GROUP=io.arrow-kt
+VERSION_NAME=0.10.3-SNAPSHOT
+# Gradle options
+org.gradle.jvmargs=-Xmx4g
+org.gradle.parallel=true
+# Kotlin configuration
+kotlin.incremental=true
+# Kotlin Test configuration
+#Parallelism needs to be set to 1 since the concurrent tests in arrow-effects become flaky otherwise
+kotlintest.parallelism=1
+# Pomfile definitions
+POM_DESCRIPTION=Arrow Meta
+POM_URL=https://github.com/arrow-kt/arrow-meta/
+POM_SCM_URL=https://github.com/arrow-kt/arrow-meta/
+POM_SCM_CONNECTION=scm:git:git://github.com/arrow-kt/arrow-meta.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/arrow-kt/arrow-meta.git
+POM_LICENCE_NAME=The Apache Software License, Version 2.0
+POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
+POM_LICENCE_DIST=repo
+POM_DEVELOPER_ID=arrow-kt
+POM_DEVELOPER_NAME=The Arrow Authors

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -48,3 +48,5 @@ runIde {
 test {
   testLogging.showStandardStreams = true
 }
+
+apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/idea-plugin/gradle.properties
+++ b/idea-plugin/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow IDEA Plugin
+POM_ARTIFACT_ID=arrow-meta-idea-plugin
+POM_PACKAGING=jar

--- a/testing-plugin/build.gradle
+++ b/testing-plugin/build.gradle
@@ -64,3 +64,5 @@ jar {
         attributes["Implementation-Version"] = project.version
     }
 }
+
+apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/testing-plugin/gradle.properties
+++ b/testing-plugin/gradle.properties
@@ -1,0 +1,4 @@
+# Maven publishing configuration
+POM_NAME=Arrow Meta Testing Plugin
+POM_ARTIFACT_ID=arrow-meta-testing-plugin
+POM_PACKAGING=jar


### PR DESCRIPTION
## Changes
* Add **Github Actions** to publish artifacts:
  * `io/arrow-kt/arrow-meta-testing-plugin`
  * `io/arrow-kt/arrow-meta-idea-plugin`
  * `io/arrow-kt/arrow-meta-compiler-plugin`
  * `io/arrow-kt/arrow-meta-docs`
* **NOTE**. Old shell scripts are not used (`deploy-scripts`  directory). Just an additional command in Github Actions.
* Add Bintray configuration
* Use `gradle-mvn-push` to upload archives in the same way as Arrow
* Add `gradle.properties` for every artifact except for `gradle-plugin` because it has its own way to be published: #41 

## Configuration
* [Add secrets](https://help.github.com/en/github/automating-your-workflow-with-github-actions/virtual-environments-for-github-actions#creating-and-using-secrets-encrypted-variables): `BINTRAY_USER`, `BINTRAY_API_KEY` 