### PR TITLE
Dependencies: unify versions of arrow-annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ allprojects {
   repositories {
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
+    maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
     mavenCentral()
     jcenter()
   }

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -11,10 +11,8 @@ dependencies {
     testImplementation project(":testing-plugin")
     testRuntimeOnly project(":compiler-plugin")
 
-    // TODO: waiting for an Arrow release in Maven Central
-    // testRuntimeOnly "io.arrow-kt:arrow-annotations:x.x.x"
-    testRuntimeOnly "com.github.arrow-kt.arrow:arrow-annotations:rr-meta-prototype-integration-SNAPSHOT"
-    testRuntimeOnly "io.arrow-kt:arrow-core-data:0.10.2"
+    testRuntimeOnly "io.arrow-kt:arrow-annotations:$VERSION_NAME"
+    testRuntimeOnly "io.arrow-kt:arrow-core-data:$VERSION_NAME"
 }
 
 compileKotlin {
@@ -54,6 +52,7 @@ repositories {
 
 test {
   testLogging.showStandardStreams = true
+  systemProperty "CURRENT_VERSION", "$VERSION_NAME"
 }
 
 apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/higherkind/HigherkindTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/higherkind/HigherkindTest.kt
@@ -8,15 +8,10 @@ import org.junit.Test
 
 class HigherkindTest {
 
-  //
-  // TODO: waiting for the arrow-annotations release which contains higherkind annotation
-  //    classpaths = listOf(classpathOf("arrow-annotations:x.x.x"))
-  //
-
   @Test
   fun `initial test`() {
     val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
-    val arrowAnnotations = Dependency("arrow-annotations:rr-meta-prototype-integration-SNAPSHOT")
+    val arrowAnnotations = Dependency("arrow-annotations:${System.getProperty("CURRENT_VERSION")}")
 
     assertThis(CompilerTest(
       config = {

--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/lens/LensTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/lens/LensTest.kt
@@ -11,9 +11,10 @@ class LensTest {
   @Test
   fun `Initial lens test`() {
 
+    val currentVersion = System.getProperty("CURRENT_VERSION")
     val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
-    val arrowAnnotations = Dependency("arrow-annotations:rr-meta-prototype-integration-SNAPSHOT")
-    val arrowOptics = Dependency("arrow-optics:0.10.2")
+    val arrowAnnotations = Dependency("arrow-annotations:$currentVersion")
+    val arrowOptics = Dependency("arrow-optics:$currentVersion")
     val codeSnippet = """
       | 
       | //metadebug

--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/TypeClassesTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/TypeClassesTest.kt
@@ -11,9 +11,10 @@ class TypeClassesTest {
 
   @Test
   fun `simple case`() {
+    val currentVersion = System.getProperty("CURRENT_VERSION")
     val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
-    val arrowAnnotations = Dependency("arrow-annotations:rr-meta-prototype-integration-SNAPSHOT")
-    val arrowCoreData = Dependency("arrow-core-data:0.10.2")
+    val arrowAnnotations = Dependency("arrow-annotations:$currentVersion")
+    val arrowCoreData = Dependency("arrow-core-data:$currentVersion")
     val codeSnippet = """
       | import arrow.Kind
       | import arrow.given

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -5,9 +5,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     compile project(':compiler-plugin')
     compile project(':idea-plugin')
-//    compile project(':arrow-ank')
-//    compile group: 'io.arrow-kt', name: 'arrow-ank', version: '0.10.2'
-    compile "io.arrow-kt:arrow-ank:0.10.2"
+    compile "io.arrow-kt:arrow-ank:$VERSION_NAME"
 }
 
 task printcp {

--- a/testing-plugin/build.gradle
+++ b/testing-plugin/build.gradle
@@ -25,9 +25,7 @@ dependencies {
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit_vintage_version"
     testRuntimeOnly project(":compiler-plugin")
 
-    // TODO: waiting for Arrow release in Maven Central
-    // testRuntimeOnly "io.arrow-kt:arrow-annotations:x.x.x"
-    testRuntimeOnly "com.github.arrow-kt.arrow:arrow-annotations:rr-meta-prototype-integration-SNAPSHOT"
+    testRuntimeOnly "io.arrow-kt:arrow-annotations:$VERSION_NAME"
 }
 
 compileKotlin {
@@ -43,15 +41,13 @@ test {
         exceptionFormat 'full'
         events "passed", "skipped", "failed", "standardOut", "standardError"
     }
+    systemProperty "CURRENT_VERSION", "$VERSION_NAME"
 }
 
 // TODO: Temporary configuration
 // - A temporary version from a fork of
 //     com.github.tschuchortdev:kotlin-compile-testing
 //   is needed until it's published with the contribution
-// - The last version of arrow-annotations for the branch
-//     rr-meta-prototype-integration
-//   is needed until it's published in Maven Central
 repositories {
     maven { url "https://jitpack.io" }
 }

--- a/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/ExampleTest.kt
+++ b/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/ExampleTest.kt
@@ -69,7 +69,7 @@ class ExampleTest {
   @Test
   fun `checks the meta debug output given a configuration`() {
     val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
-    val arrowAnnotations = Dependency("arrow-annotations:rr-meta-prototype-integration-SNAPSHOT")
+    val arrowAnnotations = Dependency("arrow-annotations:${System.getProperty("CURRENT_VERSION")}")
 
     assertThis(CompilerTest(
       config = {


### PR DESCRIPTION
* Remove the use of **arrow-annotations** from `rr-meta-prototype-integration` branch
* All the arrow dependencies have the same version from `gradle.properties` (`VERSION_NAME`)
* That version is provided to tests through a system property to define the tests configuration.
* Remove all the TODOs and comments related to the use of `rr-meta-prototype-integration` branch