### PR TITLE
Fix configuration: CI and Gradle Plugin groupId

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,10 @@ on:
     # When following these names for our internal branches,
     # twice executions (push and pull_request) will be avoided
     branches-ignore:
-      - fix/*
-      - feature/*
-      - doc/*
+      - 'fix*'
+      - 'feature*'
+      - 'doc*'
+      - 'release*'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,17 @@
 name: Build
 
-on: [push, pull_request]
+on:
+  push:
+    # Build is checked before publication
+    branches-ignore:
+      - master
+  pull_request:
+    # When following these names for our internal branches,
+    # twice executions (push and pull_request) will be avoided
+    branches-ignore:
+      - 'fix/*'
+      - 'feature/*'
+      - 'doc/*'
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,9 @@ on:
     # When following these names for our internal branches,
     # twice executions (push and pull_request) will be avoided
     branches-ignore:
-      - 'fix/*'
-      - 'feature/*'
-      - 'doc/*'
+      - fix/*
+      - feature/*
+      - doc/*
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ on:
     # When following these names for our internal branches,
     # twice executions (push and pull_request) will be avoided
     branches-ignore:
-      - 'fix*'
-      - 'feature*'
-      - 'doc*'
-      - 'release*'
+      - 'fix/**'
+      - 'feature/**'
+      - 'doc/**'
+      - 'release/**'
 
 jobs:
   build:

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -14,7 +14,7 @@ repositories {
 apply plugin: 'kotlin'
 
 group = 'io.arrow-kt'
-version = '0.10.2'
+version = '0.10.3-rc-1'
 def pluginId = 'io.arrow-kt.arrow'
 
 dependencies {
@@ -68,9 +68,5 @@ pluginBundle {
     arrow {
       displayName = "Arrow compiler plugin"
     }
-  }
-
-  mavenCoordinates {
-    groupId = 'arrow.meta.plugin.gradle'
   }
 }


### PR DESCRIPTION
After some checks, everything is ok with our Gradle plugin and I'm going to publish another version with the right groupId.

I also fixed the CI to avoid duplicated checks. If we follow these branch names:

- `fix/...`
- `feature/...`
- `doc/...`
- `release/...`

checks won't be executed twice.