### PR TITLE
Testing improvements + Property Quotes

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/Property.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/Property.kt
@@ -1,0 +1,42 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.modalityModifierType
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
+
+/**
+ * A [KtProperty] [Quote] with a custom template destructuring [PropertyScope]
+ */
+fun Meta.property(
+  match: KtProperty.() -> Boolean,
+  map: PropertyScope.(KtProperty) -> Transform<KtProperty>
+): ExtensionPhase =
+  quote(match, map) { PropertyScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtProperty]
+ */
+class PropertyScope(
+  override val value: KtProperty,
+  val modality: Name? = value.modalityModifierType()?.value?.let(Name::identifier),
+  val visibility: Name? = value.visibilityModifierType()?.value?.let(Name::identifier),
+  val `(typeParameters)`: ScopedList<KtTypeParameter> = ScopedList(prefix = "<", value = value.typeParameters, postfix = ">"),
+  val receiver: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.receiverTypeReference), postfix = "."),
+  val name: Name? = value.nameAsName,
+  val `(valueParameters)`: ScopedList<KtParameter> = ScopedList(
+    prefix = "(",
+    value = value.valueParameters,
+    postfix = ")",
+    forceRenderSurroundings = true
+  ),
+  val returnType: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.typeReference), prefix = " : "),
+  val getter : PropertyAccessorScope = PropertyAccessorScope(value.getter),
+  val setter : PropertyAccessorScope = PropertyAccessorScope(value.setter)
+) : Scope<KtProperty>(value)
+

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/PropertyAccesor.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/PropertyAccesor.kt
@@ -1,0 +1,41 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import arrow.meta.phases.analysis.body
+import arrow.meta.phases.analysis.bodySourceAsExpression
+import org.jetbrains.kotlin.name.Name
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.psi.KtPropertyAccessor
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeReference
+import org.jetbrains.kotlin.psi.psiUtil.modalityModifierType
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
+
+/**
+ * A [KtPropertyAccessor] [Quote] with a custom template destructuring [PropertyAccessorScope]
+ */
+fun Meta.propertyAccessor(
+  match: KtPropertyAccessor.() -> Boolean,
+  map: PropertyAccessorScope.(KtPropertyAccessor) -> Transform<KtPropertyAccessor>
+): ExtensionPhase =
+  quote(match, map) { PropertyAccessorScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtNamedFunction]
+ */
+class PropertyAccessorScope(
+  override val value: KtPropertyAccessor?,
+  val modality: Name? = value?.modalityModifierType()?.value?.let(Name::identifier),
+  val visibility: Name? = value?.visibilityModifierType()?.value?.let(Name::identifier),
+  val `(valueParameters)`: ScopedList<KtParameter> = ScopedList(
+    prefix = "(",
+    value = value?.valueParameters ?: emptyList(),
+    postfix = ")",
+    forceRenderSurroundings = true
+  )
+) : Scope<KtPropertyAccessor>(value)
+

--- a/testing-plugin/build.gradle
+++ b/testing-plugin/build.gradle
@@ -15,6 +15,7 @@ dependencies {
 
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compileOnly "io.github.classgraph:classgraph:$class_graph_version"
+    compileOnly project(":compiler-plugin")
     implementation "org.assertj:assertj-core:$assertj_version"
 
     // TODO: temporary dependency until PR is approved and published

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilationData.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilationData.kt
@@ -7,8 +7,24 @@ enum class CompilationStatus {
   SCRIPT_EXECUTION_ERROR
 }
 
+/**
+ * Compilation data is a Monoid that can accumulate in it's element as it's
+ * composed and fushioned with other CompilationData elements
+ */
 data class CompilationData(
-  val compilerPlugins: List<String>,
+  val compilerPlugins: List<String> = emptyList(),
   val dependencies: List<String> = emptyList(),
-  val source: String
-)
+  val source: List<String> = emptyList()
+) {
+
+  operator fun plus(other: CompilationData): CompilationData =
+    copy(
+      compilerPlugins = compilerPlugins + other.compilerPlugins,
+      dependencies = dependencies + other.dependencies,
+      source = source + other.source
+    )
+
+  companion object {
+    val empty: CompilationData = CompilationData()
+  }
+}

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -1,5 +1,7 @@
 package arrow.meta.plugin.testing
 
+import arrow.meta.Plugin
+
 data class Source(val text: String)
 data class Dependency(val mavenCoordinates: String)
 data class CompilerPlugin(
@@ -10,42 +12,57 @@ data class CompilerPlugin(
 typealias CompilerTestInterpreter = (CompilerTest) -> Unit
 
 data class CompilerTest(
-  val config: CompilerTest.Companion.() -> List<Config> = { emptyList() },
-  val code: CompilerTest.Companion.() -> Source, // TODO: Sources
-  val assert: CompilerTest.Companion.() -> Assert = { Assert.emptyAssert }
+  val config: Companion.() -> List<Config> = { emptyList() },
+  val code: Companion.() -> Source, // TODO: Sources
+  val assert: Companion.() -> Assert = { Assert.emptyAssert }
 ) {
   fun run(interpret: CompilerTestInterpreter): Unit =
     interpret(this)
 
-  companion object : Config.Syntax by Config, Assert.Syntax by Assert {
+  companion object : ConfigSyntax by Config, AssertSyntax by Assert {
     operator fun invoke(f: Companion.() -> CompilerTest): CompilerTest =
       f(this)
   }
 }
 
+interface ConfigSyntax {
+  val emptyConfig: Config
+  fun addCompilerPlugins(vararg element: CompilerPlugin): Config =
+    Config.Many(listOf(Config.AddCompilerPlugins(element.toList())))
+
+  fun addMetaPlugin(vararg element: Plugin): Config =
+    Config.Many(listOf(Config.AddMetaPlugins(element.toList())))
+
+  fun addDependencies(vararg element: Dependency): Config =
+    Config.Many(listOf(Config.AddDependencies(element.toList())))
+
+  operator fun Config.plus(other: Config): List<Config> =
+    listOf(this, other)
+
+  fun List<Config>.toConfig(): Config =
+    Config.Many(this)
+}
+
 sealed class Config {
   data class AddCompilerPlugins(val plugins: List<CompilerPlugin>) : Config()
+  data class AddMetaPlugins(val plugins: List<Plugin>) : Config()
   data class AddDependencies(val dependencies: List<Dependency>) : Config()
   data class Many(val configs: List<Config>) : Config()
   object Empty : Config()
-  interface Syntax {
-    val emptyConfig: Config
-    fun addCompilerPlugins(vararg element: CompilerPlugin): Config =
-      Many(listOf(AddCompilerPlugins(element.toList())))
 
-    fun addDependencies(vararg element: Dependency): Config =
-      Many(listOf(AddDependencies(element.toList())))
-
-    operator fun Config.plus(other: Config): List<Config> =
-      listOf(this, other)
-
-    fun List<Config>.toConfig(): Config =
-      Many(this)
-  }
-
-  companion object : Syntax {
+  companion object : ConfigSyntax {
     override val emptyConfig: Config = Config.emptyConfig
   }
+}
+
+interface AssertSyntax {
+  val emptyAssert: Assert
+  val compiles: Assert
+  val fails: Assert
+  fun failsWith(f: (String) -> Boolean): Assert = Assert.FailsWith(f)
+  fun quoteOutputMatches(source: Source): Assert = Assert.QuoteOutputMatches(source)
+  infix fun Source.evalsTo(value: Any?): Assert = Assert.EvalsTo(this, value)
+  val String.source: Source get() = Source(this)
 }
 
 sealed class Assert {
@@ -59,17 +76,7 @@ sealed class Assert {
   data class EvalsTo(val source: Source, val output: Any?) : Assert()
   data class FailsWith(val f: (String) -> Boolean) : Assert()
 
-  interface Syntax {
-    val emptyAssert: Assert
-    val compiles: Assert
-    val fails: Assert
-    fun failsWith(f: (String) -> Boolean): Assert = FailsWith(f)
-    fun quoteOutputMatches(source: Source): Assert = QuoteOutputMatches(source)
-    infix fun Source.evalsTo(value: Any?): Assert = EvalsTo(this, value)
-    val String.source: Source get() = Source(this)
-  }
-
-  companion object : Syntax {
+  companion object : AssertSyntax {
     override val emptyAssert: Assert = Assert.Empty
     override val compiles: Assert = CompilationResult.Compiles
     override val fails: Assert = Assert.CompilationResult.Fails

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/TestingLibraryWrapper.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/TestingLibraryWrapper.kt
@@ -19,7 +19,7 @@ internal data class CompilationResult(
 
 internal fun compile(data: CompilationData): CompilationResult =
   compilationResultFrom(KotlinCompilation().apply {
-    sources = listOf(SourceFile.kotlin("Example.kt", data.source))
+    sources = data.source.map { SourceFile.kotlin("Example.kt", it) }
     classpaths = data.dependencies.map { classpathOf(it) }
     pluginClasspaths = data.compilerPlugins.map { classpathOf(it) }
   }.compile())


### PR DESCRIPTION
The following PR includes a new `Quote` for `KtProperty` and `KtPropertyAccessor` with built-in template `Scope`.

Additionally, it replaces the testing interpreter to be stack safe and prepares the framework for the inclusion of custom ad-hoc Quote based plugins that can run on tests.