### PR TITLE
`testing-plugin` proposal

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -8,6 +8,10 @@ dependencies {
     compile "io.arrow-kt:arrow-ank:$VERSION_NAME"
 }
 
+repositories {
+    maven { url "https://jitpack.io" }
+}
+
 task printcp {
     doLast {
         println sourceSets.main.runtimeClasspath.each { println it }

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -6,10 +6,21 @@ apply plugin: 'java'
 apply plugin: 'kotlin'
 apply plugin: 'org.jetbrains.intellij'
 
+repositories {
+  maven { url "https://jitpack.io" }
+}
+
 dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compile "org.celtric.kotlin:kotlin-html:0.1.4"
   compile project(path: ':compiler-plugin', configuration: 'shadow')
+
+  testImplementation project(":testing-plugin")
+  testRuntimeOnly project(":compiler-plugin")
+
+  testRuntimeOnly "io.arrow-kt:arrow-annotations:$VERSION_NAME"
+  testRuntimeOnly "io.arrow-kt:arrow-core-data:$VERSION_NAME"
+  testRuntimeOnly "io.arrow-kt:arrow-optics:$VERSION_NAME"
 }
 
 compileKotlin {

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -14,13 +14,11 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   compile "org.celtric.kotlin:kotlin-html:0.1.4"
   compile project(path: ':compiler-plugin', configuration: 'shadow')
-
   testImplementation project(":testing-plugin")
   testRuntimeOnly project(":compiler-plugin")
 
   testRuntimeOnly "io.arrow-kt:arrow-annotations:$VERSION_NAME"
   testRuntimeOnly "io.arrow-kt:arrow-core-data:$VERSION_NAME"
-  testRuntimeOnly "io.arrow-kt:arrow-optics:$VERSION_NAME"
 }
 
 compileKotlin {
@@ -58,6 +56,7 @@ runIde {
 
 test {
   testLogging.showStandardStreams = true
+  systemProperty "CURRENT_VERSION", "$VERSION_NAME"
 }
 
 apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeclassesTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeclassesTest.kt
@@ -1,5 +1,6 @@
 package arrow.meta.ide.plugins.typeclasses
 
+import arrow.meta.plugin.testing.CompilationStatus
 import arrow.meta.plugin.testing.CompilerPlugin
 import arrow.meta.plugin.testing.Dependency
 import arrow.meta.plugin.testing.acquire
@@ -21,7 +22,7 @@ class TypeclassesTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBuilder<*>>
       val arrowCoreData = Dependency("arrow-core-data:$currentVersion")
       addCompilerPlugins(compilerPlugin) + addDependencies(arrowAnnotations, arrowCoreData)
     }
-    return Assert.assertNotNull(result)
+    return Assert.assertTrue(result.actualStatus == CompilationStatus.OK)
   }
 
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeclassesTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeclassesTest.kt
@@ -1,0 +1,6 @@
+package arrow.meta.ide.plugins.typeclasses
+
+class TypeclassesTest {
+  fun `resourceTest`(): Nothing =
+    TODO("Here we test resource acquisition from `testing-plugin`")
+}

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeclassesTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeclassesTest.kt
@@ -1,6 +1,27 @@
 package arrow.meta.ide.plugins.typeclasses
 
-class TypeclassesTest {
-  fun `resourceTest`(): Nothing =
-    TODO("Here we test resource acquisition from `testing-plugin`")
+import arrow.meta.plugin.testing.CompilerPlugin
+import arrow.meta.plugin.testing.Dependency
+import arrow.meta.plugin.testing.acquire
+import com.intellij.testFramework.builders.EmptyModuleFixtureBuilder
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
+import org.junit.Assert
+import org.junit.Test
+
+class TypeclassesTest : CodeInsightFixtureTestCase<EmptyModuleFixtureBuilder<*>>() {
+  @Test
+  fun test() {
+    Assert.assertNotNull(myFixture) // Just to test that the HeavyTestEnvironment is setUp
+    val result = acquire(
+      TypeclassesTestCode.c1
+    ) {
+      val currentVersion = System.getProperty("CURRENT_VERSION")
+      val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
+      val arrowAnnotations = Dependency("arrow-annotations:$currentVersion")
+      val arrowCoreData = Dependency("arrow-core-data:$currentVersion")
+      addCompilerPlugins(compilerPlugin) + addDependencies(arrowAnnotations, arrowCoreData)
+    }
+    return Assert.assertNotNull(result)
+  }
+
 }

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -9,14 +9,14 @@ data class CompilerPlugin(
   val dependencies: List<Dependency>
 )
 
-typealias CompilerTestInterpreter = (CompilerTest) -> Unit
+typealias CompilerTestInterpreter<A> = (CompilerTest) -> CompilationAssertions<A>
 
 data class CompilerTest(
   val config: Companion.() -> List<Config> = { emptyList() },
   val code: Companion.() -> Source, // TODO: Sources
   val assert: Companion.() -> Assert = { Assert.emptyAssert }
 ) {
-  fun run(interpret: CompilerTestInterpreter): Unit =
+  fun <A> run(interpret: CompilerTestInterpreter<A>): CompilationAssertions<A> =
     interpret(this)
 
   companion object : ConfigSyntax by Config, AssertSyntax by Assert {

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/TestingLibraryWrapper.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/TestingLibraryWrapper.kt
@@ -18,6 +18,12 @@ internal data class CompilationResult(
   val generatedFiles: List<File>
 )
 
+data class CompilationResource(
+  val actualStatus: CompilationStatus,
+  val classesDirectory: File,
+  val generatedFiles: List<File>
+)
+
 internal fun compile(data: CompilationData): CompilationResult =
   compilationResultFrom(KotlinCompilation().apply {
     sources = data.source.map { SourceFile.kotlin("Example.kt", it) }

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/TestingLibraryWrapper.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/TestingLibraryWrapper.kt
@@ -14,7 +14,8 @@ internal data class CompilationResult(
   val actualStatus: CompilationStatus,
   val log: String,
   val actualGeneratedFilePath: Path,
-  val classesDirectory: File
+  val classesDirectory: File,
+  val generatedFiles: List<File>
 )
 
 internal fun compile(data: CompilationData): CompilationResult =
@@ -30,7 +31,8 @@ private fun compilationResultFrom(internalResult: KotlinCompilation.Result): Com
     actualStatus = exitStatusFrom(internalResult.exitCode),
     log = internalResult.messages,
     actualGeneratedFilePath = Paths.get(internalResult.outputDirectory.parent, "sources", "$DEFAULT_FILENAME.meta"),
-    classesDirectory = internalResult.outputDirectory
+    classesDirectory = internalResult.outputDirectory,
+    generatedFiles = internalResult.generatedFiles.toList()
   )
 
 private fun exitStatusFrom(exitCode: KotlinCompilation.ExitCode): CompilationStatus =


### PR DESCRIPTION
@raulraja cc @rachelcarmena 
This PR tries to turn the return-type of `assertThis` into an GADT. 

Furthemore, extends `CompilationResult` with the property `generatedFiles`, which we need for this PR including `classesDirectory`. 
In the following commit, we'll attempt to extend the algebra to provide these Properties. 

What is the best approach for this?
 Should we create a new `assertThis` like function, who does the resource acquisition.
Or something else. 

docs need the additional Gradle settings, in order to execute `./gradlew clean :idea-plugin:test`
@jansorg though the Test passes, the compilation returns an `InternalError`, due to ClassCastException.
Here is the Stacktrace:
```
java.lang.ClassCastException: org.jetbrains.kotlin.idea.KotlinFileType cannot be cast to org.jetbrains.kotlin.com.intellij.openapi.fileTypes.FileType
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.registerApplicationServices(KotlinCoreEnvironment.kt:657)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.createApplicationEnvironment(KotlinCoreEnvironment.kt:523)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.getOrCreateApplicationEnvironmentForProduction(KotlinCoreEnvironment.kt:476)
	at org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment$Companion.createForProduction(KotlinCoreEnvironment.kt:430)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.createCoreEnvironment(K2JVMCompiler.kt:253)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:151)
	at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:54)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:84)
	at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:42)
	at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:104)
	at com.tschuchort.compiletesting.KotlinCompilation.compileKotlin(KotlinCompilation.kt:545)
	at com.tschuchort.compiletesting.KotlinCompilation.compile(KotlinCompilation.kt:713)
	at arrow.meta.plugin.testing.TestingLibraryWrapperKt.compile(TestingLibraryWrapper.kt:32)
	at arrow.meta.plugin.testing.CompilationAssertionsKt.acquire(CompilationAssertions.kt:22)
	at arrow.meta.ide.plugins.typeclasses.TypeclassesTest.test(TypeclassesTest.kt:16)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at junit.framework.TestCase.runTest(TestCase.java:176)
	at com.intellij.testFramework.UsefulTestCase.lambda$runTest$12(UsefulTestCase.java:338)
	at com.intellij.testFramework.UsefulTestCase.lambda$invokeTestRunnable$13(UsefulTestCase.java:375)
	at com.intellij.testFramework.EdtTestUtilKt.runInEdtAndWait(EdtTestUtil.kt:44)
	at com.intellij.testFramework.UsefulTestCase.invokeTestRunnable(UsefulTestCase.java:374)
	at com.intellij.testFramework.UsefulTestCase.runTest(UsefulTestCase.java:357)
	at com.intellij.testFramework.UsefulTestCase.defaultRunBare(UsefulTestCase.java:392)
	at com.intellij.testFramework.EdtTestUtil$Companion$runInEdtAndWait$1.invoke(EdtTestUtil.kt:18)
	at com.intellij.testFramework.EdtTestUtil$Companion$runInEdtAndWait$1.invoke(EdtTestUtil.kt:13)
	at com.intellij.testFramework.EdtTestUtilKt$runInEdtAndWait$1.run(EdtTestUtil.kt:50)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:312)
	at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:152)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java:433)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:416)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:399)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
	at java.awt.EventQueue.access$500(EventQueue.java:97)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.awt.EventQueue$3.run(EventQueue.java:703)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:817)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:766)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:405)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:704)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:404)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)

```