### PR TITLE
Proposal on `ja-heavy-testing`

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -20,7 +20,8 @@ dependencies {
     exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib-jdk8"
   }
   compile project(path: ':compiler-plugin', configuration: 'shadow')
-  implementation(project(":testing-plugin")) {
+  compileOnly "io.github.classgraph:classgraph:4.8.47"
+  implementation("com.github.arrow-kt:kotlin-compile-testing:1.3.0") {
     // already provided by the kotlin-plugin
     exclude group: "org.jetbrains.kotlin", module: "kotlin-compiler-embeddable"
     exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/dsl/synthetic/SyntheticResolutionTestSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/dsl/synthetic/SyntheticResolutionTestSyntax.kt
@@ -2,9 +2,7 @@ package arrow.meta.ide.testing.dsl.synthetic
 
 import arrow.meta.ide.testing.Source
 import arrow.meta.ide.testing.env.IdeTestTypeSyntax
-import arrow.meta.plugin.testing.Config
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 
@@ -12,7 +10,6 @@ interface SyntheticResolutionTestSyntax {
   fun IdeTestTypeSyntax.traverseResolution(
     code: Source,
     srcFileName: String = "Source.kt",
-    compilerConfig: List<Config>,
     module: Module,
     myFixture: CodeInsightTestFixture,
     srcDirName: String = "src",
@@ -20,7 +17,7 @@ interface SyntheticResolutionTestSyntax {
     f: (PsiElement) -> PsiElement?
   ): List<PsiElement> =
     heavyTest {
-      code.ideHeavySetup(module, myFixture, srcDirName, buildDirName, srcFileName, compilerConfig)?.traversable
+      code.ideHeavySetup(module, myFixture, srcDirName, buildDirName, srcFileName)?.traversable
         ?.mapNotNull(f)
     } ?: emptyList()
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeClassResolutionTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/typeclasses/TypeClassResolutionTest.kt
@@ -3,7 +3,6 @@ package arrow.meta.ide.plugins.typeclasses
 import arrow.meta.ide.testing.IdeTest
 import arrow.meta.ide.testing.env.IdeHeavyTestSetUp
 import arrow.meta.ide.testing.env.testResult
-import arrow.meta.ide.testing.env.types.defaultConfig
 import arrow.meta.ide.testing.resolves
 import org.jetbrains.kotlin.nj2k.postProcessing.type
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -20,8 +19,7 @@ class TypeClassResolutionTest : IdeHeavyTestSetUp() {
         traverseResolution(
           code = code,
           myFixture = myFixture,
-          module = myModule,
-          compilerConfig = defaultConfig(System.getProperty("CURRENT_VERSION"))
+          module = myModule
         ) {
           it.takeIf { p -> p.safeAs<KtDeclaration>()?.type() is ErrorType }
         }


### PR DESCRIPTION
## Goal

This is a pull request on `ja-heavy-testing`:
* To use `kotlin-compile-testing` in `idea-plugin`
* To avoid #63 

## Details

I think `idea-plugin` doesn't need to use `testing-plugin` but `kotlin-compile-testing`:

![details-testing-library](https://user-images.githubusercontent.com/22792183/68107674-e4235f00-fee5-11e9-8848-e53f14cfeee6.jpg)