### PR TITLE
Documentation

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -1,4 +1,4 @@
-name: Publish artifacts
+name: Publish Artifacts
 
 on:
   push:

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -47,6 +47,10 @@ jobs:
         gem --version
         echo "$( gem list | grep bundler )"
         bundle install --gemfile docs/Gemfile --path vendor/bundle
+        MAYOR_MINOR_VERSION=$(grep -e "^VERSION_NAME=.*$" gradle.properties | cut -d= -f2 | cut -d. -f1-2)
+        echo $MAYOR_MINOR_VERSION
         bundle exec jekyll build -s docs -d docs/build/_site
         echo "Publish in S3..."
+        # Waiting for AWS configuration to active this part:
+        # aws s3 sync docs/build/_site s3://$S3_BUCKET/$MAYOR_MINOR_VERSION > aws_sync_jekyll.log
         aws s3 sync docs/build/_site s3://$S3_BUCKET > aws_sync_jekyll.log

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Arrow Meta
 
-Functional companion to Kotlin's Compiler & IDE
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-meta-compiler-plugin%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-compiler-plugin/)
+[![Latest Gradle Plugin Version](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20Gradle%20Plugin%20version&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fio%2Farrow-kt%2Farrow%2Fio.arrow-kt.arrow.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/io.arrow-kt.arrow)
+![Publish artifacts](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Artifacts/badge.svg)
+![Publish documentation](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Documentation/badge.svg)
+[![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
-[![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Farrow-kt%2Farrow-meta%2Fbadge%3Fref%3Dmaster&style=flat)](https://actions-badge.atrox.dev/arrow-kt/arrow-meta/goto?ref=master)
+Functional companion to Kotlin's Compiler & IDE
 
 ## Documentation
 
@@ -62,11 +67,7 @@ function that returns Unit and prints our message.
 
 ## Use cases
 
-## Contributing
-
-## License
-
-## Credits
+## Build and run in your local environment
 
 **Build and run tests**
 
@@ -78,4 +79,32 @@ function that returns Unit and prints our message.
 
 ```
 ./gradlew publishAndRunIde -Dorg.gradle.debug=true -Dkotlin.compiler.execution.strategy="in-process"
+```
+
+## Credits
+
+## Contributing
+
+Arrow Meta is an inclusive community powered by awesome individuals like you. As an actively growing ecosystem, Arrow Meta and its associated libraries and toolsets are in need of new contributors! We have issues suited for all levels, from entry to advanced, and our maintainers are happy to provide 1:1 mentoring. All are welcome in Arrow Meta.
+
+If you’re looking to contribute, have questions, or want to keep up-to-date about what’s happening, please follow us here and say hello!
+
+- [#arrow-meta on Kotlin Slack](https://kotlinlang.slack.com/)
+
+## Licence
+
+```
+Copyright (C) 2017 The Λrrow Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,9 +1,16 @@
 # Documentation
 
-From root directory:
+## Build and run in your local environment
+
+Run `build-and-run-website.sh` script which is located in `scripts` directory.
+
+It can be executed from any directory:
 
 ```
-$> ./gradlew dokka :docs:runAnk
-$> bundle install --gemfile docs/Gemfile --path vendor/bundle
-$> BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll serve -s docs
+$> ./scripts/build-and-run-website.sh
+```
+
+```
+$> cd scripts
+$> ./build-and-run-website.sh
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,4 +4,14 @@ title: Quick Start
 permalink: /
 ---
 
-Welcome to Λrrow Meta
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-meta-compiler-plugin%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-compiler-plugin/)
+[![Latest Gradle Plugin Version](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20Gradle%20Plugin%20version&metadataUrl=https%3A%2F%2Fplugins.gradle.org%2Fm2%2Fio%2Farrow-kt%2Farrow%2Fio.arrow-kt.arrow.gradle.plugin%2Fmaven-metadata.xml)](https://plugins.gradle.org/plugin/io.arrow-kt.arrow)
+![Publish artifacts](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Artifacts/badge.svg)
+![Publish documentation](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Documentation/badge.svg)
+[![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0)
+
+# Functional companion to Kotlin's Compiler & IDE
+
+Arrow Meta is a meta-programming library that cooperates with the Kotlin compiler in all it's phases bringing its full power to the community.
+Writing compiler plugins, source transformations, IDEA plugins, linters, type search engines, automatic code refactoring,... are just a few of the use cases of the things that can be accomplished with Meta.

--- a/scripts/build-and-run-website.sh
+++ b/scripts/build-and-run-website.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+cd $(dirname $0)/.. 
+./gradlew dokka :docs:runAnk
+bundle install --gemfile docs/Gemfile --path vendor/bundle
+BUNDLE_GEMFILE=docs/Gemfile bundle exec jekyll serve -s docs

--- a/scripts/commons.sh
+++ b/scripts/commons.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+function show_banner()
+{
+    echo '..........................................................'
+    echo '                                    __  __      _         ' 
+    echo '     /\                            |  \/  |    | |        ' 
+    echo '    /  \   _ __ _ __ _____      __ | \  / | ___| |_ __ _  ' 
+    echo '   / /\ \ | `__| `__/ _ \ \ /\ / / | |\/| |/ _ \ __/ _` | ' 
+    echo '  / /  \ \| |  | | | (_) \ V  V /  | |  | |  __/ || (_| | ' 
+    echo ' /_/    \_\_|  |_|  \___/ \_/\_/   |_|  |_|\___|\__\__,_| '
+    echo '..........................................................'
+    echo " - $1 -"
+    echo '..........................................................'
+    echo ''
+    echo ''
+    echo '             |                        |'
+    echo '             |                        |'
+    echo '             |                        |'
+    echo '             |<------- -------------> |'
+    echo '             |        |               |'
+    echo '             |        |               |'
+    echo '             |        |               |'
+    echo '             |--------                |'
+    echo '             |     release/version    |'
+    echo '             |                        |'
+    echo '             |                        |'
+    echo '           master            release/gradle-plugin '
+    echo ''
+    echo ''
+    echo ' When merging on release/gradle-plugin:'
+    echo '   publication in Gradle Plugin Repository is triggered'
+    echo ''
+    echo ' When merging on master:'
+    echo '   publication in oss.jfrog.org (for snapshots) or Bintray (for releases) is triggered'
+    echo '..........................................................'
+    echo ''
+    echo ''
+}
+
+function jump_to_master_and_pull()
+{
+    read -p "Jump to master branch and pull. Accept? [Enter] " -n 1 KEY
+    if [ "$KEY" != "" ]; then
+        echo -e "\nAborted"
+        exit 0
+    fi
+    echo -e "\nJumping to master branch and pulling (it can take a few seconds)..."
+    git checkout master
+    if [[ $? -ne 0 ]]; then
+        echo "Check the error and try again"
+        exit $0
+    fi
+    git pull origin master
+}

--- a/scripts/release-candidate-gradle-plugin.sh
+++ b/scripts/release-candidate-gradle-plugin.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+. ./scripts/commons.sh
+
+function ask_for_new_version()
+{
+    ACTUAL_VERSION=$(grep -e "^version = .*$" gradle-plugin/build.gradle | cut -d' ' -f3)
+    echo -e "\n$ACTUAL_VERSION found!"
+    read -p "What's the next release candidate? " EXPECTED_VERSION
+    echo "Expected: $EXPECTED_VERSION"
+}
+
+function update_file()
+{
+    echo -e "\nUpdating the version in gradle-plugin/build.gradle ..."
+    sed -i "s/version = $ACTUAL_VERSION/version = '$EXPECTED_VERSION'/g" gradle-plugin/build.gradle
+}
+
+function create_release_branch()
+{
+    echo -e "\nCreating a new branch ..."
+    git checkout -b release/$EXPECTED_VERSION
+    git add gradle-plugin/build.gradle
+    git commit -m "Gradle Plugin: release candidate $EXPECTED_VERSION"
+    git push origin release/$EXPECTED_VERSION
+}
+
+show_banner "RELEASE CANDIDATE FOR GRADLE PLUGIN"
+jump_to_master_and_pull
+ask_for_new_version
+update_file
+create_release_branch
+
+echo -e "\nDone!"
+echo -e "\nNext steps:\n"
+echo " - Pull request from release/$EXPECTED_VERSION to release/gradle-plugin"
+echo " - Pull request from release/$EXPECTED_VERSION to master"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+cd $(dirname $0)/..
+. ./scripts/commons.sh
+
+function ask_for_new_versions()
+{
+    GRADLE_PLUGIN_ACTUAL_VERSION=$(grep -e "^version = .*$" gradle-plugin/build.gradle | cut -d' ' -f3)
+    ACTUAL_VERSION=$(grep -e "^VERSION_NAME=.*$" gradle.properties | cut -d= -f2)
+    echo -e "\n$GRADLE_PLUGIN_ACTUAL_VERSION found for Gradle Plugin!"
+    echo "$ACTUAL_VERSION found for the rest of artifacts!"
+    read -p "What's the next release version for Gradle Plugin (without -rc-)? " GRADLE_PLUGIN_EXPECTED_VERSION
+    read -p "What's the next release version for the rest of artifacts? " EXPECTED_VERSION
+    echo "Expected versions:"
+    echo " - $GRADLE_PLUGIN_EXPECTED_VERSION for Gradle Plugin"
+    echo " - $EXPECTED_VERSION for the rest of artifacts"
+}
+
+function update_files()
+{
+    echo -e "\nUpdating the version in gradle-plugin/build.gradle ..."
+    sed -i "s/version = $GRADLE_PLUGIN_ACTUAL_VERSION/version = '$GRADLE_PLUGIN_EXPECTED_VERSION'/g" gradle-plugin/build.gradle
+    echo -e "\nUpdating the version in gradle.properties ..."
+    sed -i "s/VERSION_NAME=$ACTUAL_VERSION/VERSION_NAME=$EXPECTED_VERSION/g" gradle.properties
+}
+
+function create_release_branch()
+{
+    echo -e "\nCreating a new branch ..."
+    git checkout -b release/$EXPECTED_VERSION
+    git add gradle-plugin/build.gradle
+    git add gradle.properties
+    git commit -m "Release $EXPECTED_VERSION and $GRADLE_PLUGIN_EXPECTED_VERSION for Gradle Plugin"
+    git push origin release/$EXPECTED_VERSION
+}
+
+show_banner "RELEASE PROCESS"
+jump_to_master_and_pull
+ask_for_new_versions
+update_files
+create_release_branch
+
+echo -e "\nDone!"
+echo -e "\nNext steps:\n"
+echo " - Pull request from release/$EXPECTED_VERSION to release/gradle-plugin"
+echo " - Pull request from release/$EXPECTED_VERSION to master"
+
+#TODO: Finish with the whole process, extract changelog, etc.


### PR DESCRIPTION
## Goal

Several improvements about documentation:

- Get the version from `gradle.properties` and create a folder for the website with that version to sync with S3 bucket. In this way, we can use the same S3 bucket for all the versions. I've checked it in a personal repository before. cc: @franciscodr 
- "Contributing" and "License" sections.
- Add badges at `README` and the website main page.
    - Latest snapshot
    - Latest Gradle Plugin version
    - Publish artifacts status
    - Publish documentation status
    - Kotlin version
    - License
- Script to build and run the website in a local environment and not to have to follow instructions in a document: `scripts/build-and-run-website.sh`
- Having scripts to create release branches:
    - To publish release candidates for Gradle Plugin: `scripts/release-candidate-gradle-plugin.sh`
    - To publish release for Gradle Plugin and the rest of the artifacts (I'll continue it with the rest of steps): `scripts/release.sh`

## Screenshots

### Badges

![Screenshot from 2019-11-06 11-28-08](https://user-images.githubusercontent.com/22792183/68290670-9e52cc00-0088-11ea-9849-eb5724b530d6.png)

### Scripts

Information which is shown when running them, before showing the detected versions and asking for the new versions:

#### Release candidates for Gradle Plugin

![Screenshot from 2019-11-06 09-53-39](https://user-images.githubusercontent.com/22792183/68283242-7d37ae80-007b-11ea-9c19-dd4be2e1898b.png)

#### Release for Gradle Plugin and the rest of the artifacts

![Screenshot from 2019-11-06 09-53-53](https://user-images.githubusercontent.com/22792183/68283243-7d37ae80-007b-11ea-8ea4-5ad927846a57.png)

Those scripts **detect the current versions**, **ask for the next versions** and **push the branch** to prepare the initial pull request.