### PR TITLE
Exclude unnecessary files from Jekyll built site

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -19,7 +19,7 @@ markdown: kramdown
 sass:
     style: compressed
 #-------------------------
-exclude: ['config.ru', 'Gemfile', 'Gemfile.lock', 'vendor', 'Procfile', 'Rakefile']
+exclude: ['config.ru', 'Gemfile', 'Gemfile.lock', 'vendor', 'Procfile', 'Rakefile', 'build', 'build.gradle', 'gradle.properties']
 #-------------------------
 defaults:
   - scope:


### PR DESCRIPTION
This will make the final site to be generated to not serve these files/dirs, as they are not necessary.