### PR TITLE
Separates Interpreter from the DSL

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
@@ -87,7 +87,6 @@ import org.jetbrains.kotlin.storage.StorageManager
 import org.jetbrains.kotlin.synthetic.JavaSyntheticPropertiesScope
 import org.jetbrains.kotlin.synthetic.SyntheticScopeProviderExtension
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.checker.KotlinTypeChecker
 import java.lang.reflect.Field
 import java.lang.reflect.Modifier
 import java.util.*
@@ -95,6 +94,8 @@ import java.util.*
 interface InternalRegistry : ConfigSyntax {
 
   fun intercept(ctx: CompilerContext): List<Plugin>
+
+  fun CompilerContext.registerIdeExclusivePhase(currentPhase: ExtensionPhase) {}
 
   private fun registerPostAnalysisContextEnrichment(project: Project, ctx: CompilerContext) {
     cli {
@@ -605,7 +606,7 @@ interface InternalRegistry : ConfigSyntax {
       }
     )
 
-  fun CompilerContext.registerIdeExclusivePhase(currentPhase: ExtensionPhase): Unit {}
+
 }
 
 /**

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/IdeMetaPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/IdeMetaPlugin.kt
@@ -3,7 +3,6 @@ package arrow.meta.ide
 import arrow.meta.MetaPlugin
 import arrow.meta.Plugin
 import arrow.meta.ide.dsl.IdeSyntax
-import arrow.meta.phases.CompilerContext
 import arrow.meta.ide.internal.registry.IdeInternalRegistry
 import arrow.meta.ide.plugins.comprehensions.comprehensionsIdePlugin
 import arrow.meta.ide.plugins.higherkinds.higherKindsIdePlugin
@@ -11,9 +10,10 @@ import arrow.meta.ide.plugins.initial.initialIdeSetUp
 import arrow.meta.ide.plugins.nothing.nothingIdePlugin
 import arrow.meta.ide.plugins.optics.opticsIdePlugin
 import arrow.meta.ide.plugins.typeclasses.typeclassesIdePlugin
+import arrow.meta.phases.CompilerContext
 import kotlin.contracts.ExperimentalContracts
 
-class IdeMetaPlugin : MetaPlugin(), IdeInternalRegistry, IdeSyntax {
+open class IdeMetaPlugin : MetaPlugin(), IdeInternalRegistry, IdeSyntax {
   @ExperimentalContracts
   override fun intercept(ctx: CompilerContext): List<Plugin> =
     super.intercept(ctx) +

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
@@ -1,7 +1,6 @@
 package arrow.meta.ide.dsl.editor.action
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.dsl.utils.ideRegistry
 import arrow.meta.ide.phases.editor.AnActionExtensionProvider
 import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
@@ -12,63 +11,51 @@ import com.intellij.openapi.application.ModalityState
 import javax.swing.Icon
 
 // TODO: Check Default of actionId
-interface AnActionSyntax : AnActionExtensionProvider {
+interface AnActionSyntax {
   fun IdeMetaPlugin.addAnAction(
     actionId: String,
     action: AnAction
   ): ExtensionPhase =
-    ideRegistry {
-      register(actionId, action)
-    }
+    AnActionExtensionProvider.RegisterAction(actionId, action)
 
   fun IdeMetaPlugin.replaceAnAction(
     actionId: String,
     newAction: AnAction
   ): ExtensionPhase =
-    ideRegistry {
-      replace(actionId, newAction)
-    }
+    AnActionExtensionProvider.ReplaceAction(actionId, newAction)
 
   fun IdeMetaPlugin.unregisterAnAction(
     actionId: String
   ): ExtensionPhase =
-    ideRegistry {
-      println("Unregistered $actionId")
-      unregister(actionId)
-    }
+    AnActionExtensionProvider.UnregisterAction(actionId)
 
   fun IdeMetaPlugin.addTimerListener(
     delay: Int,
     modalityState: ModalityState,
     run: () -> Unit
   ): ExtensionPhase =
-    ideRegistry {
-      println("TimerListener is registered")
-      addTimerListener(delay, this@AnActionSyntax.timerListener(modalityState, run))
-    }
+    AnActionExtensionProvider.AddTimerListener(delay, this@AnActionSyntax.timerListener(modalityState, run))
 
   fun IdeMetaPlugin.addTransparentTimerListener(
     delay: Int,
     modalityState: ModalityState,
     run: () -> Unit
   ): ExtensionPhase =
-    ideRegistry {
-      addTransparentTimerListener(delay, this@AnActionSyntax.timerListener(modalityState, run))
-    }
+    AnActionExtensionProvider.AddTransparentTimerListener(delay, this@AnActionSyntax.timerListener(modalityState, run))
 
   fun IdeMetaPlugin.removeTransparentTimerListener(
     listener: TimerListener
   ): ExtensionPhase =
-    ideRegistry {
-      removeTransparentTL(listener)
-    }
+    AnActionExtensionProvider.RemoveTransparentTimerListener(listener)
+
 
   fun IdeMetaPlugin.removeTimerListener(
     listener: TimerListener
   ): ExtensionPhase =
-    ideRegistry {
-      removeTL(listener)
-    }
+    AnActionExtensionProvider.RemoveTimerListener(listener)
+
+  // TODO: This should result into a List<String> with ActionManager.getInstance().getActionIds(prefix).toList()
+  fun IdeMetaPlugin.collectActionIds(prefix: String): ExtensionPhase = AnActionExtensionProvider.CollectActionIds(prefix)
 
   /**
    * TODO: Add more costume attributes: ShortCuts etc.

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
@@ -11,7 +11,7 @@ import com.intellij.openapi.application.ModalityState
 import javax.swing.Icon
 
 // TODO: Check Default of actionId
-interface AnActionSyntax {
+interface AnActionSyntax : AnActionUtilitySyntax {
   fun IdeMetaPlugin.addAnAction(
     actionId: String,
     action: AnAction
@@ -53,9 +53,6 @@ interface AnActionSyntax {
     listener: TimerListener
   ): ExtensionPhase =
     AnActionExtensionProvider.RemoveTimerListener(listener)
-
-  // TODO: This should result into a List<String> with ActionManager.getInstance().getActionIds(prefix).toList()
-  fun IdeMetaPlugin.collectActionIds(prefix: String): ExtensionPhase = AnActionExtensionProvider.CollectActionIds(prefix)
 
   /**
    * TODO: Add more costume attributes: ShortCuts etc.

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
@@ -1,7 +1,7 @@
 package arrow.meta.ide.dsl.editor.action
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.phases.editor.AnActionExtensionProvider
+import arrow.meta.ide.phases.editor.action.AnActionExtensionProvider
 import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.openapi.actionSystem.AnAction

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionUtilitySyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionUtilitySyntax.kt
@@ -1,0 +1,9 @@
+package arrow.meta.ide.dsl.editor.action
+
+import arrow.meta.ide.dsl.utils.toNotNullable
+import com.intellij.openapi.actionSystem.ActionManager
+
+interface AnActionUtilitySyntax {
+  fun collectActionIds(prefix: String): List<String> =
+    ActionManager.getInstance().getActionIds(prefix).toList().toNotNullable()
+}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionUtilitySyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionUtilitySyntax.kt
@@ -1,7 +1,6 @@
 package arrow.meta.ide.dsl.editor.inspection
 
 import arrow.meta.phases.ExtensionPhase
-import arrow.meta.ide.IdeMetaPlugin
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.openapi.extensions.ExtensionPointName
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
@@ -20,11 +19,11 @@ interface InspectionUtilitySyntax {
     return listOf(expect) + actuals
   }
 
-  fun IdeMetaPlugin.addLocalInspectionToolToIdeRegistry(): ExtensionPhase =
-    registerExtensionPoint(
-      EP_NAME,
-      LocalInspectionTool::class.java
-    )
+  fun InspectionUtilitySyntax.addLocalInspectionToolToIdeRegistry(): ExtensionPhase = TODO("untested")
+  /*registerExtensionPoint(
+    EP_NAME,
+    LocalInspectionTool::class.java
+  )*/
 }
 
 sealed class ExtendedReturnsCheck(val name: String, val type: KotlinBuiltIns.() -> KotlinType) : Check {

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/intention/IntentionExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/intention/IntentionExtensionProviderSyntax.kt
@@ -1,7 +1,7 @@
 package arrow.meta.ide.dsl.editor.intention
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.phases.editor.IntentionExtensionProvider
+import arrow.meta.ide.phases.editor.intention.IntentionExtensionProvider
 import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.intention.IntentionAction

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/intention/IntentionExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/intention/IntentionExtensionProviderSyntax.kt
@@ -1,7 +1,6 @@
 package arrow.meta.ide.dsl.editor.intention
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.dsl.utils.ideRegistry
 import arrow.meta.ide.phases.editor.IntentionExtensionProvider
 import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
@@ -15,15 +14,11 @@ import org.jetbrains.kotlin.idea.quickfix.KotlinSingleIntentionActionFactory
 import org.jetbrains.kotlin.idea.quickfix.QuickFixContributor
 import org.jetbrains.kotlin.psi.KtElement
 
-interface IntentionExtensionProviderSyntax : IntentionExtensionProvider {
-  fun IdeMetaPlugin.addIntention(
+interface IntentionExtensionProviderSyntax : IntentionExtensionProviderUtilitySyntax {
+  fun IdeMetaPlugin.addIntentionWithMetaData(
     intention: IntentionAction
   ): ExtensionPhase =
-    ideRegistry {
-      register(intention)?.run {
-        println("ADDED Intention")
-      }
-    }
+    IntentionExtensionProvider.RegisterIntentionWithMetaData(intention)
 
   /**
    * TODO: This Bails if there is no html and intentionDescription. Try to add them in the Function and not with the resource Folder. But this is fine for now
@@ -32,35 +27,26 @@ interface IntentionExtensionProviderSyntax : IntentionExtensionProvider {
     category: String,
     intention: IntentionAction
   ): ExtensionPhase =
-    ideRegistry {
-      register(intention, category)?.run {
-        println("ADDED Intention with MetaData")
-      }
-    }
+    IntentionExtensionProvider.RegisterIntention(intention, category)
 
   fun IdeMetaPlugin.unregisterIntention(
     intention: IntentionAction
   ): ExtensionPhase =
-    ideRegistry {
-      unregister(intention)?.run {
-        println("Unregistered Intention")
-      }
-    }
+    IntentionExtensionProvider.UnregisterIntention(intention)
 
   @Suppress("UNCHECKED_CAST")
   fun <K : KtElement> IdeMetaPlugin.addIntention(
+    category: String,
     text: String = "",
     kClass: Class<K> = KtElement::class.java as Class<K>,
     isApplicableTo: (element: K, caretOffset: Int) -> Boolean = Noop.boolean2False,
     applyTo: (element: K, editor: Editor?) -> Unit = Noop.effect2,
     priority: PriorityAction.Priority = PriorityAction.Priority.LOW
   ): ExtensionPhase =
-    addIntention(ktIntention(text, kClass, isApplicableTo, applyTo, priority))
+    addIntention(category, ktIntention(text, kClass, isApplicableTo, applyTo, priority))
 
-  fun IdeMetaPlugin.setIntentionAsEnabled(enabled: Boolean, intention: IntentionAction): ExtensionPhase =
-    ideRegistry {
-      intention.setEnabled(enabled)
-    }
+  fun IdeMetaPlugin.setIntentionAsEnabled(intention: IntentionAction, enabled: Boolean): ExtensionPhase =
+    IntentionExtensionProvider.SetAvailability(intention, enabled)
 
   /**
    * You can use this in [addQuickFixContributor] for @param intentions

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/intention/IntentionExtensionProviderUtilitySyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/intention/IntentionExtensionProviderUtilitySyntax.kt
@@ -1,0 +1,17 @@
+package arrow.meta.ide.dsl.editor.intention
+
+import com.intellij.codeInsight.intention.IntentionAction
+import com.intellij.codeInsight.intention.IntentionManager
+import com.intellij.codeInsight.intention.impl.config.IntentionActionMetaData
+import com.intellij.codeInsight.intention.impl.config.IntentionManagerSettings
+
+interface IntentionExtensionProviderUtilitySyntax {
+  fun IntentionExtensionProviderUtilitySyntax.availableIntentions(): List<IntentionAction> =
+    IntentionManager.getInstance()?.availableIntentionActions?.toList() ?: emptyList()
+
+  fun IntentionAction.isEnabled(): Boolean =
+    IntentionManagerSettings.getInstance().isEnabled(this)
+
+  fun IntentionActionMetaData.isEnabled(): Boolean =
+    IntentionManagerSettings.getInstance().isEnabled(this)
+}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/syntaxHighlighter/SyntaxHighlighterExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/syntaxHighlighter/SyntaxHighlighterExtensionProviderSyntax.kt
@@ -1,7 +1,7 @@
 package arrow.meta.ide.dsl.editor.syntaxHighlighter
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.dsl.utils.ideRegistry
+import arrow.meta.ide.phases.editor.syntaxHighlighter.SyntaxHighlighterExtensionProvider
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.lexer.Lexer
 import com.intellij.openapi.editor.colors.TextAttributesKey
@@ -10,7 +10,6 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighter
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
 import com.intellij.psi.tree.IElementType
-import org.jetbrains.kotlin.idea.KotlinLanguage
 import org.jetbrains.kotlin.lexer.KotlinLexer
 
 interface SyntaxHighlighterExtensionProviderSyntax {
@@ -19,12 +18,11 @@ interface SyntaxHighlighterExtensionProviderSyntax {
     highlightingLexer: Lexer = KotlinLexer(),
     tokenHighlights: (tokenType: IElementType?) -> Array<TextAttributesKey>
   ): ExtensionPhase =
-    ideRegistry {
-      SyntaxHighlighterFactory.LANGUAGE_FACTORY
-        .addExplicitExtension(KotlinLanguage.INSTANCE, syntaxHighlighterFactory(
-          this@SyntaxHighlighterExtensionProviderSyntax.syntaxHighlighter(highlightingLexer, tokenHighlights)
-        ))
-    }
+    SyntaxHighlighterExtensionProvider.RegisterSyntaxHighlighter(
+      syntaxHighlighterFactory(
+        this@SyntaxHighlighterExtensionProviderSyntax.syntaxHighlighter(highlightingLexer, tokenHighlights)
+      )
+    )
 
   fun SyntaxHighlighterExtensionProviderSyntax.syntaxHighlighter(
     highlightingLexer: Lexer = KotlinLexer(),

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -1,12 +1,7 @@
 package arrow.meta.ide.dsl.extensions
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.phases.editor.AddClassExtension
-import arrow.meta.ide.phases.editor.AddExtension
-import arrow.meta.ide.phases.editor.AddFileTypeExtension
-import arrow.meta.ide.phases.editor.AddLanguageExtension
-import arrow.meta.ide.phases.editor.RegisterBaseExtension
-import arrow.meta.ide.phases.editor.RegisterExtension
+import arrow.meta.ide.phases.editor.ExtensionProvider
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.ContainerProvider
 import com.intellij.lang.LanguageExtension
@@ -27,38 +22,38 @@ interface ExtensionProviderSyntax {
     impl: E,
     loadingOrder: LoadingOrder = LoadingOrder.ANY
   ): ExtensionPhase =
-    AddExtension(EP_NAME, impl, loadingOrder)
+    ExtensionProvider.AddExtension(EP_NAME, impl, loadingOrder)
 
   fun <E> IdeMetaPlugin.extensionProvider(
     LE: LanguageExtension<E>,
     impl: E
   ): ExtensionPhase =
-    AddLanguageExtension(LE, impl)
+    ExtensionProvider.AddLanguageExtension(LE, impl)
 
   fun <E> IdeMetaPlugin.extensionProvider(
     FE: FileTypeExtension<E>,
     impl: E
   ): ExtensionPhase =
-    AddFileTypeExtension(FE, impl)
+    ExtensionProvider.AddFileTypeExtension(FE, impl)
 
   fun <E> IdeMetaPlugin.extensionProvider(
     CE: ClassExtension<E>,
     forClass: Class<*>,
     impl: E
   ): ExtensionPhase =
-    AddClassExtension(CE, forClass, impl)
+    ExtensionProvider.AddClassExtension(CE, forClass, impl)
 
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: BaseExtensionPointName,
     aClass: Class<E>
   ): ExtensionPhase =
-    RegisterBaseExtension(EP_NAME, aClass)
+    ExtensionProvider.RegisterBaseExtension(EP_NAME, aClass)
 
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: ExtensionPointName<E>,
     aClass: Class<E>
   ): ExtensionPhase =
-    RegisterExtension(EP_NAME, aClass)
+    ExtensionProvider.RegisterExtension(EP_NAME, aClass)
 
   fun IdeMetaPlugin.addContainerProvider(f: (PsiElement) -> PsiElement?): ExtensionPhase =
     extensionProvider(

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -13,6 +13,7 @@ import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor
 
+
 interface ExtensionProviderSyntax : ExtensionProvider {
   // Todo: Check LoadingOrder
   fun <E> IdeMetaPlugin.extensionProvider(

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -1,57 +1,64 @@
 package arrow.meta.ide.dsl.extensions
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.dsl.utils.ideRegistry
-import arrow.meta.ide.phases.editor.ExtensionProvider
+import arrow.meta.ide.phases.editor.AddClassExtension
+import arrow.meta.ide.phases.editor.AddExtension
+import arrow.meta.ide.phases.editor.AddFileTypeExtension
+import arrow.meta.ide.phases.editor.AddLanguageExtension
+import arrow.meta.ide.phases.editor.RegisterBaseExtension
+import arrow.meta.ide.phases.editor.RegisterExtension
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.ContainerProvider
 import com.intellij.lang.LanguageExtension
 import com.intellij.openapi.extensions.BaseExtensionPointName
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.LoadingOrder
+import com.intellij.openapi.fileTypes.FileTypeExtension
+import com.intellij.openapi.util.ClassExtension
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor
 
 
-interface ExtensionProviderSyntax : ExtensionProvider {
+interface ExtensionProviderSyntax {
   // Todo: Check LoadingOrder
   fun <E> IdeMetaPlugin.extensionProvider(
     EP_NAME: ExtensionPointName<E>,
     impl: E,
     loadingOrder: LoadingOrder = LoadingOrder.ANY
   ): ExtensionPhase =
-    ideRegistry {
-      addExtension(EP_NAME, impl, loadingOrder)
-      println("ADDED another Extension: FOR ${EP_NAME.name}")
-    }
+    AddExtension(EP_NAME, impl, loadingOrder)
 
   fun <E> IdeMetaPlugin.extensionProvider(
     LE: LanguageExtension<E>,
     impl: E
   ): ExtensionPhase =
-    ideRegistry {
-      addLanguageExtension(LE, impl)
-      println("Adds LanguageExtension for ${LE.name}")
-    }
+    AddLanguageExtension(LE, impl)
+
+  fun <E> IdeMetaPlugin.extensionProvider(
+    FE: FileTypeExtension<E>,
+    impl: E
+  ): ExtensionPhase =
+    AddFileTypeExtension(FE, impl)
+
+  fun <E> IdeMetaPlugin.extensionProvider(
+    CE: ClassExtension<E>,
+    forClass: Class<*>,
+    impl: E
+  ): ExtensionPhase =
+    AddClassExtension(CE, forClass, impl)
 
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: BaseExtensionPointName,
     aClass: Class<E>
   ): ExtensionPhase =
-    ideRegistry {
-      registerExtension(EP_NAME, aClass)
-      println("registered: ${EP_NAME.name}")
-    }
+    RegisterBaseExtension(EP_NAME, aClass)
 
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: ExtensionPointName<E>,
     aClass: Class<E>
   ): ExtensionPhase =
-    ideRegistry {
-      registerExtension(EP_NAME, aClass)
-      println("registered: ${EP_NAME.name}")
-    }
+    RegisterExtension(EP_NAME, aClass)
 
   fun IdeMetaPlugin.addContainerProvider(f: (PsiElement) -> PsiElement?): ExtensionPhase =
     extensionProvider(

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -1,7 +1,7 @@
 package arrow.meta.ide.dsl.extensions
 
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.phases.editor.ExtensionProvider
+import arrow.meta.ide.phases.editor.extension.ExtensionProvider
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.ContainerProvider
 import com.intellij.lang.LanguageExtension

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
@@ -1,7 +1,5 @@
 package arrow.meta.ide.dsl.utils
 
-import arrow.meta.dsl.platform.ide
-import arrow.meta.phases.ExtensionPhase
 import org.celtric.kotlin.html.BlockElement
 import org.celtric.kotlin.html.InlineElement
 import org.celtric.kotlin.html.code
@@ -10,9 +8,6 @@ import org.celtric.kotlin.html.text
 object IdeUtils {
   fun <A> isNotNull(a: A?): Boolean = a?.let { true } ?: false
 }
-
-fun <A> ideRegistry(f: () -> A): ExtensionPhase =
-  ide { f().run { ExtensionPhase.Empty } } ?: ExtensionPhase.Empty
 
 fun <A> List<A?>.toNotNullable(): List<A> = fold(emptyList()) { acc: List<A>, r: A? -> if (r != null) acc + r else acc }
 

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
@@ -1,9 +1,12 @@
 package arrow.meta.ide.internal.registry
 
 import arrow.meta.dsl.platform.ide
-import arrow.meta.internal.registry.InternalRegistry
-import arrow.meta.phases.ExtensionPhase
 import arrow.meta.ide.phases.analysis.MetaIdeAnalyzer
+import arrow.meta.ide.phases.editor.ExtensionProvider2
+import arrow.meta.internal.registry.InternalRegistry
+import arrow.meta.phases.CompilerContext
+import arrow.meta.phases.ExtensionPhase
+import com.intellij.openapi.extensions.Extensions
 import org.jetbrains.kotlin.container.useImpl
 
 internal interface IdeInternalRegistry : InternalRegistry {
@@ -21,4 +24,12 @@ internal interface IdeInternalRegistry : InternalRegistry {
       )
     } ?: ExtensionPhase.Empty
 
+  override fun CompilerContext.registerIdeExclusivePhase(currentPhase: ExtensionPhase) =
+    when (currentPhase) {
+      is ExtensionProvider2 -> registerExtensionProvider2
+    }
+
+
+  fun registerExtensionProvider2(phase: ExtensionProvider2): Unit =
+    Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(phase.addExtension()
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
@@ -2,12 +2,38 @@ package arrow.meta.ide.internal.registry
 
 import arrow.meta.dsl.platform.ide
 import arrow.meta.ide.phases.analysis.MetaIdeAnalyzer
-import arrow.meta.ide.phases.editor.ExtensionProvider2
+import arrow.meta.ide.phases.editor.AddClassExtension
+import arrow.meta.ide.phases.editor.AddExtension
+import arrow.meta.ide.phases.editor.AddFileTypeExtension
+import arrow.meta.ide.phases.editor.AddLanguageExtension
+import arrow.meta.ide.phases.editor.ExtensionProvider
+import arrow.meta.ide.phases.editor.RegisterBaseExtension
+import arrow.meta.ide.phases.editor.RegisterExtension
+import arrow.meta.ide.phases.resolve.LOG
 import arrow.meta.internal.registry.InternalRegistry
 import arrow.meta.phases.CompilerContext
+import arrow.meta.phases.Composite
 import arrow.meta.phases.ExtensionPhase
+import arrow.meta.phases.analysis.AnalysisHandler
+import arrow.meta.phases.analysis.CollectAdditionalSources
+import arrow.meta.phases.analysis.ExtraImports
+import arrow.meta.phases.analysis.PreprocessedVirtualFileFactory
+import arrow.meta.phases.codegen.asm.ClassBuilder
+import arrow.meta.phases.codegen.asm.Codegen
+import arrow.meta.phases.codegen.ir.IRGeneration
+import arrow.meta.phases.config.Config
+import arrow.meta.phases.config.StorageComponentContainer
+import arrow.meta.phases.resolve.DeclarationAttributeAlterer
+import arrow.meta.phases.resolve.PackageProvider
+import arrow.meta.phases.resolve.synthetics.SyntheticResolver
+import arrow.meta.phases.resolve.synthetics.SyntheticScopeProvider
+import com.intellij.core.CoreApplicationEnvironment
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.extensions.Extensions
+import com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.container.useImpl
+import org.jetbrains.kotlin.idea.KotlinFileType
+import org.jetbrains.kotlin.idea.KotlinLanguage
 
 internal interface IdeInternalRegistry : InternalRegistry {
 
@@ -26,10 +52,29 @@ internal interface IdeInternalRegistry : InternalRegistry {
 
   override fun CompilerContext.registerIdeExclusivePhase(currentPhase: ExtensionPhase) =
     when (currentPhase) {
-      is ExtensionProvider2 -> registerExtensionProvider2
+      is ExtensionPhase.Empty, is CollectAdditionalSources, is Composite, is Config, is ExtraImports,
+      is PreprocessedVirtualFileFactory, is StorageComponentContainer, is AnalysisHandler, is ClassBuilder,
+      is Codegen, is DeclarationAttributeAlterer, is PackageProvider, is SyntheticResolver,
+      is IRGeneration, is SyntheticScopeProvider -> Unit // filter out ExtensionPhases which happen in the compiler
+      is ExtensionProvider<*> -> registerExtensionProvider(currentPhase)
+
+      else -> LOG.error("Unsupported ide extension phase: $currentPhase")
     }
 
 
-  fun registerExtensionProvider2(phase: ExtensionProvider2): Unit =
-    Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(phase.addExtension()
+  fun <E> registerExtensionProvider(phase: ExtensionProvider<E>, dispose: Disposable = Disposer.newDisposable()): Unit =
+    when (phase) {
+      is AddExtension -> phase.run {
+        println("ADDED ${phase.EP_NAME.name}")
+        Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(impl, loadingOrder, dispose)
+      }
+      is AddLanguageExtension -> phase.run {
+        println("ADDED LanguageExtension: ${LE.name}")
+        LE.addExplicitExtension(KotlinLanguage.INSTANCE, impl)
+      }
+      is AddFileTypeExtension -> phase.run { FE.addExplicitExtension(KotlinFileType.INSTANCE, impl) }
+      is AddClassExtension -> phase.run { CE.addExplicitExtension(forClass, impl) }
+      is RegisterBaseExtension -> phase.run { CoreApplicationEnvironment.registerExtensionPoint(Extensions.getRootArea(), EP_NAME, aClass) }
+      is RegisterExtension -> phase.run { CoreApplicationEnvironment.registerExtensionPoint(Extensions.getRootArea(), EP_NAME, aClass) }
+    }
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/AnActionExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/AnActionExtensionProvider.kt
@@ -12,5 +12,4 @@ sealed class AnActionExtensionProvider : ExtensionPhase {
   data class AddTransparentTimerListener(val delay: Int, val listener: TimerListener) : AnActionExtensionProvider()
   data class RemoveTimerListener(val listener: TimerListener) : AnActionExtensionProvider()
   data class RemoveTransparentTimerListener(val listener: TimerListener) : AnActionExtensionProvider()
-  data class CollectActionIds(val prefix: String) : AnActionExtensionProvider()
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/AnActionExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/AnActionExtensionProvider.kt
@@ -1,31 +1,16 @@
 package arrow.meta.ide.phases.editor
 
-import com.intellij.openapi.actionSystem.ActionManager
+import arrow.meta.phases.ExtensionPhase
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.TimerListener
 
-interface AnActionExtensionProvider {
-  fun register(actionId: String, action: AnAction): Unit? =
-    ActionManager.getInstance()?.registerAction(actionId, action)
-
-  fun unregister(actionId: String): Unit? =
-    ActionManager.getInstance()?.unregisterAction(actionId)
-
-  fun replace(actionId: String, newAction: AnAction): Unit? =
-    ActionManager.getInstance()?.replaceAction(actionId, newAction)
-
-  fun addTimerListener(delay: Int, listener: TimerListener): Unit? =
-    ActionManager.getInstance()?.addTimerListener(delay, listener)
-
-  fun addTransparentTimerListener(delay: Int, listener: TimerListener): Unit? =
-    ActionManager.getInstance()?.addTransparentTimerListener(delay, listener)
-
-  fun removeTL(listener: TimerListener): Unit? =
-    ActionManager.getInstance()?.removeTimerListener(listener)
-
-  fun removeTransparentTL(listener: TimerListener): Unit? =
-    ActionManager.getInstance()?.removeTransparentTimerListener(listener)
-
-  fun allActionIds(prefix: String): List<String> =
-    ActionManager.getInstance().getActionIds(prefix).toList()
+sealed class AnActionExtensionProvider : ExtensionPhase {
+  data class RegisterAction(val actionId: String, val action: AnAction) : AnActionExtensionProvider()
+  data class UnregisterAction(val actionId: String) : AnActionExtensionProvider()
+  data class ReplaceAction(val actionId: String, val newAction: AnAction) : AnActionExtensionProvider()
+  data class AddTimerListener(val delay: Int, val listener: TimerListener) : AnActionExtensionProvider()
+  data class AddTransparentTimerListener(val delay: Int, val listener: TimerListener) : AnActionExtensionProvider()
+  data class RemoveTimerListener(val listener: TimerListener) : AnActionExtensionProvider()
+  data class RemoveTransparentTimerListener(val listener: TimerListener) : AnActionExtensionProvider()
+  data class CollectActionIds(val prefix: String) : AnActionExtensionProvider()
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/ExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/ExtensionProvider.kt
@@ -1,98 +1,35 @@
 package arrow.meta.ide.phases.editor
 
-import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
-import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.core.JavaCoreApplicationEnvironment
 import com.intellij.lang.LanguageExtension
-import com.intellij.openapi.Disposable
 import com.intellij.openapi.extensions.BaseExtensionPointName
 import com.intellij.openapi.extensions.ExtensionPointName
-import com.intellij.openapi.extensions.Extensions
 import com.intellij.openapi.extensions.LoadingOrder
 import com.intellij.openapi.fileTypes.FileTypeExtension
 import com.intellij.openapi.util.ClassExtension
-import com.intellij.openapi.util.Disposer
-import org.jetbrains.kotlin.idea.KotlinFileType
-import org.jetbrains.kotlin.idea.KotlinLanguage
 
 /**
- *
- * 3 ExtensionPhases ->
+ * We're lifting the arguments of the interpreter to data types in an ADT and as we extend our Algebra of manipulating the
+ * Editor environment, so does the ADT. Additionally, we're promoting users to compute only one value at a time and not a list of manipulations, which we cant control
+ * as we do in the InternalRegistry in the compiler. The ADT gives as more granularity, because we're essentially asking for a SumType of a specific shape.
+ * Now we're also getting the RunTimeExceptions, due to MemoryLeaks we discuss in ...
  */
+sealed class ExtensionProvider<E> : ExtensionPhase
 
+data class AddExtension<E>(val EP_NAME: ExtensionPointName<E>, val impl: E, val loadingOrder: LoadingOrder) : ExtensionProvider<E>()
+data class AddLanguageExtension<E>(val LE: LanguageExtension<E>, val impl: E) : ExtensionProvider<E>()
 
-interface ExtensionProvider2 : ExtensionPhase {
-  fun <E> addExtension(EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder): Unit
-  fun <E> addLanguageExtension(LE: LanguageExtension<E>, impl: E): Unit
-  fun <E> addFileTypeExtension(FE: FileTypeExtension<E>, impl: E): Unit
-  fun <E> addClassExtension(CE: ClassExtension<E>, forClass: Class<*>, impl: E): Unit
-  fun <E> registerExtension(EP_NAME: BaseExtensionPointName, aClass: Class<E>): Unit
-  fun <E> registerExtension(EP_NAME: ExtensionPointName<E>, aClass: Class<E>): Unit
-}
+/**
+ * Examples are here: [JavaCoreApplicationEnvironment] line 57, 58
+ */
+data class AddFileTypeExtension<E>(val FE: FileTypeExtension<E>, val impl: E) : ExtensionProvider<E>()
 
+/**
+ * Examples are here: [JavaCoreApplicationEnvironment] line 72 - 77
+ * kotlinx.metadata.jvm.impl.JvmClassExtension is internal
+ */
+data class AddClassExtension<E>(val CE: ClassExtension<E>, val forClass: Class<*>, val impl: E) : ExtensionProvider<E>()
 
-fun <E> extensionProvider2( // in ExtensionProviderSyntax
-  addExtension: (EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder) -> Unit = Noop.effect3,
-  addLanguageExtension: (LE: LanguageExtension<E>, impl: E) -> Unit = Noop.effect2,
-  addFileTypeExtension: (FE: FileTypeExtension<E>, impl: E) -> Unit = Noop.effect2,
-  addClassExtension: (CE: ClassExtension<E>, forClass: Class<*>, impl: E) -> Unit = Noop.effect3,
-  registerBaseExtension: (EP_NAME: BaseExtensionPointName, aClass: Class<E>) -> Unit = Noop.effect2,
-  registerExtension: (EP_NAME: ExtensionPointName<E>, aClass: Class<E>) -> Unit = Noop.effect2
-): ExtensionPhase =
-  object : ExtensionProvider2 {
-    override fun <E> addExtension(EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder) {
-      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun <E> addLanguageExtension(LE: LanguageExtension<E>, impl: E) {
-      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun <E> addFileTypeExtension(FE: FileTypeExtension<E>, impl: E) {
-      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun <E> addClassExtension(CE: ClassExtension<E>, forClass: Class<*>, impl: E) {
-      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun <E> registerExtension(EP_NAME: BaseExtensionPointName, aClass: Class<E>) {
-      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-
-    override fun <E> registerExtension(EP_NAME: ExtensionPointName<E>, aClass: Class<E>) {
-      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
-    }
-  }
-
-interface ExtensionProvider {
-  val dispose: Disposable
-    get() = Disposer.newDisposable()
-
-  fun <E> addExtension(EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder): Unit =
-    Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(impl, loadingOrder, dispose)
-  // lift this function as an interpreter
-
-  fun <E> addLanguageExtension(LE: LanguageExtension<E>, impl: E): Unit =
-    LE.addExplicitExtension(KotlinLanguage.INSTANCE, impl)
-
-  /**
-   * Examples are here: [JavaCoreApplicationEnvironment] line 57, 58
-   */
-  fun <E> addFileTypeExtension(FE: FileTypeExtension<E>, impl: E): Unit =
-    FE.addExplicitExtension(KotlinFileType.INSTANCE, impl)
-
-  /**
-   * Examples are here: [JavaCoreApplicationEnvironment] line 72 - 77
-   * kotlinx.metadata.jvm.impl.JvmClassExtension is internal
-   */
-  fun <E> addClassExtension(CE: ClassExtension<E>, forClass: Class<*>, impl: E): Unit =
-    CE.addExplicitExtension(forClass, impl)
-
-  fun <E> registerExtension(EP_NAME: BaseExtensionPointName, aClass: Class<E>): Unit =
-    CoreApplicationEnvironment.registerExtensionPoint(Extensions.getRootArea(), EP_NAME, aClass)
-
-  fun <E> registerExtension(EP_NAME: ExtensionPointName<E>, aClass: Class<E>): Unit =
-    CoreApplicationEnvironment.registerExtensionPoint(Extensions.getRootArea(), EP_NAME, aClass)
-}
+data class RegisterBaseExtension<E>(val EP_NAME: BaseExtensionPointName, val aClass: Class<E>) : ExtensionProvider<E>()
+data class RegisterExtension<E>(val EP_NAME: ExtensionPointName<E>, val aClass: Class<E>) : ExtensionProvider<E>()

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/ExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/ExtensionProvider.kt
@@ -9,27 +9,21 @@ import com.intellij.openapi.extensions.LoadingOrder
 import com.intellij.openapi.fileTypes.FileTypeExtension
 import com.intellij.openapi.util.ClassExtension
 
-/**
- * We're lifting the arguments of the interpreter to data types in an ADT and as we extend our Algebra of manipulating the
- * Editor environment, so does the ADT. Additionally, we're promoting users to compute only one value at a time and not a list of manipulations, which we cant control
- * as we do in the InternalRegistry in the compiler. The ADT gives as more granularity, because we're essentially asking for a SumType of a specific shape.
- * Now we're also getting the RunTimeExceptions, due to MemoryLeaks we discuss in ...
- */
-sealed class ExtensionProvider<E> : ExtensionPhase
+sealed class ExtensionProvider<E> : ExtensionPhase {
+  data class AddExtension<E>(val EP_NAME: ExtensionPointName<E>, val impl: E, val loadingOrder: LoadingOrder) : ExtensionProvider<E>()
+  data class AddLanguageExtension<E>(val LE: LanguageExtension<E>, val impl: E) : ExtensionProvider<E>()
 
-data class AddExtension<E>(val EP_NAME: ExtensionPointName<E>, val impl: E, val loadingOrder: LoadingOrder) : ExtensionProvider<E>()
-data class AddLanguageExtension<E>(val LE: LanguageExtension<E>, val impl: E) : ExtensionProvider<E>()
+  /**
+   * Examples are here: [JavaCoreApplicationEnvironment] line 57, 58
+   */
+  data class AddFileTypeExtension<E>(val FE: FileTypeExtension<E>, val impl: E) : ExtensionProvider<E>()
 
-/**
- * Examples are here: [JavaCoreApplicationEnvironment] line 57, 58
- */
-data class AddFileTypeExtension<E>(val FE: FileTypeExtension<E>, val impl: E) : ExtensionProvider<E>()
+  /**
+   * Examples are here: [JavaCoreApplicationEnvironment] line 72 - 77
+   * kotlinx.metadata.jvm.impl.JvmClassExtension is internal
+   */
+  data class AddClassExtension<E>(val CE: ClassExtension<E>, val forClass: Class<*>, val impl: E) : ExtensionProvider<E>()
 
-/**
- * Examples are here: [JavaCoreApplicationEnvironment] line 72 - 77
- * kotlinx.metadata.jvm.impl.JvmClassExtension is internal
- */
-data class AddClassExtension<E>(val CE: ClassExtension<E>, val forClass: Class<*>, val impl: E) : ExtensionProvider<E>()
-
-data class RegisterBaseExtension<E>(val EP_NAME: BaseExtensionPointName, val aClass: Class<E>) : ExtensionProvider<E>()
-data class RegisterExtension<E>(val EP_NAME: ExtensionPointName<E>, val aClass: Class<E>) : ExtensionProvider<E>()
+  data class RegisterBaseExtension<E>(val EP_NAME: BaseExtensionPointName, val aClass: Class<E>) : ExtensionProvider<E>()
+  data class RegisterExtension<E>(val EP_NAME: ExtensionPointName<E>, val aClass: Class<E>) : ExtensionProvider<E>()
+}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/ExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/ExtensionProvider.kt
@@ -1,5 +1,7 @@
 package arrow.meta.ide.phases.editor
 
+import arrow.meta.internal.Noop
+import arrow.meta.phases.ExtensionPhase
 import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.core.JavaCoreApplicationEnvironment
 import com.intellij.lang.LanguageExtension
@@ -14,12 +16,63 @@ import com.intellij.openapi.util.Disposer
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.idea.KotlinLanguage
 
+/**
+ *
+ * 3 ExtensionPhases ->
+ */
+
+
+interface ExtensionProvider2 : ExtensionPhase {
+  fun <E> addExtension(EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder): Unit
+  fun <E> addLanguageExtension(LE: LanguageExtension<E>, impl: E): Unit
+  fun <E> addFileTypeExtension(FE: FileTypeExtension<E>, impl: E): Unit
+  fun <E> addClassExtension(CE: ClassExtension<E>, forClass: Class<*>, impl: E): Unit
+  fun <E> registerExtension(EP_NAME: BaseExtensionPointName, aClass: Class<E>): Unit
+  fun <E> registerExtension(EP_NAME: ExtensionPointName<E>, aClass: Class<E>): Unit
+}
+
+
+fun <E> extensionProvider2( // in ExtensionProviderSyntax
+  addExtension: (EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder) -> Unit = Noop.effect3,
+  addLanguageExtension: (LE: LanguageExtension<E>, impl: E) -> Unit = Noop.effect2,
+  addFileTypeExtension: (FE: FileTypeExtension<E>, impl: E) -> Unit = Noop.effect2,
+  addClassExtension: (CE: ClassExtension<E>, forClass: Class<*>, impl: E) -> Unit = Noop.effect3,
+  registerBaseExtension: (EP_NAME: BaseExtensionPointName, aClass: Class<E>) -> Unit = Noop.effect2,
+  registerExtension: (EP_NAME: ExtensionPointName<E>, aClass: Class<E>) -> Unit = Noop.effect2
+): ExtensionPhase =
+  object : ExtensionProvider2 {
+    override fun <E> addExtension(EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder) {
+      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <E> addLanguageExtension(LE: LanguageExtension<E>, impl: E) {
+      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <E> addFileTypeExtension(FE: FileTypeExtension<E>, impl: E) {
+      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <E> addClassExtension(CE: ClassExtension<E>, forClass: Class<*>, impl: E) {
+      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <E> registerExtension(EP_NAME: BaseExtensionPointName, aClass: Class<E>) {
+      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+
+    override fun <E> registerExtension(EP_NAME: ExtensionPointName<E>, aClass: Class<E>) {
+      TODO("not implemented") //To change body of created functions use File | Settings | File Templates.
+    }
+  }
+
 interface ExtensionProvider {
   val dispose: Disposable
     get() = Disposer.newDisposable()
 
   fun <E> addExtension(EP_NAME: ExtensionPointName<E>, impl: E, loadingOrder: LoadingOrder): Unit =
     Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(impl, loadingOrder, dispose)
+  // lift this function as an interpreter
 
   fun <E> addLanguageExtension(LE: LanguageExtension<E>, impl: E): Unit =
     LE.addExplicitExtension(KotlinLanguage.INSTANCE, impl)

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/IdeContext.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/IdeContext.kt
@@ -1,0 +1,8 @@
+package arrow.meta.ide.phases.editor
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.util.Disposer
+
+object IdeContext {
+  val dispose: Disposable = Disposer.newDisposable()
+}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/IntentionExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/IntentionExtensionProvider.kt
@@ -1,26 +1,13 @@
 package arrow.meta.ide.phases.editor
 
+import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.intention.IntentionAction
-import com.intellij.codeInsight.intention.IntentionManager
-import com.intellij.codeInsight.intention.impl.config.IntentionManagerSettings
+import com.intellij.codeInsight.intention.impl.config.IntentionActionMetaData
 
-interface IntentionExtensionProvider {
-  fun register(intention: IntentionAction, category: String): Unit? =
-    IntentionManager.getInstance()?.registerIntentionAndMetaData(intention, category)
-
-  fun register(intention: IntentionAction): Unit? =
-    IntentionManager.getInstance()?.addAction(intention)
-
-  fun unregister(intention: IntentionAction): Unit? =
-    IntentionManager.getInstance()?.unregisterIntention(intention)
-
-  fun availableIntentions(): List<IntentionAction> =
-    IntentionManager.getInstance()?.availableIntentionActions?.toList() ?: emptyList()
-
-  fun IntentionAction.isEnabled(): Boolean =
-    IntentionManagerSettings.getInstance().isEnabled(this)
-
-  fun IntentionAction.setEnabled(enabled: Boolean): Unit =
-    IntentionManagerSettings.getInstance().setEnabled(this, enabled)
+sealed class IntentionExtensionProvider : ExtensionPhase {
+  data class RegisterIntention(val intention: IntentionAction, val category: String) : IntentionExtensionProvider()
+  data class RegisterIntentionWithMetaData(val intention: IntentionAction) : IntentionExtensionProvider()
+  data class UnregisterIntention(val intention: IntentionAction) : IntentionExtensionProvider()
+  data class SetAvailability(val intention: IntentionAction, val enabled: Boolean) : IntentionExtensionProvider()
+  data class SetAvailabilityOnActionMetaData(val intention: IntentionActionMetaData, val enabled: Boolean) : IntentionExtensionProvider()
 }
-

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/action/AnActionExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/action/AnActionExtensionProvider.kt
@@ -1,4 +1,4 @@
-package arrow.meta.ide.phases.editor
+package arrow.meta.ide.phases.editor.action
 
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.openapi.actionSystem.AnAction

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/extension/ExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/extension/ExtensionProvider.kt
@@ -1,4 +1,4 @@
-package arrow.meta.ide.phases.editor
+package arrow.meta.ide.phases.editor.extension
 
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.core.JavaCoreApplicationEnvironment

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/intention/IntentionExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/intention/IntentionExtensionProvider.kt
@@ -1,4 +1,4 @@
-package arrow.meta.ide.phases.editor
+package arrow.meta.ide.phases.editor.intention
 
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.intention.IntentionAction

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/syntaxHighlighter/SyntaxHighlighterExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/syntaxHighlighter/SyntaxHighlighterExtensionProvider.kt
@@ -1,0 +1,8 @@
+package arrow.meta.ide.phases.editor.syntaxHighlighter
+
+import arrow.meta.phases.ExtensionPhase
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+
+sealed class SyntaxHighlighterExtensionProvider : ExtensionPhase {
+  data class RegisterSyntaxHighlighter(val factory: SyntaxHighlighterFactory) : SyntaxHighlighterExtensionProvider()
+}


### PR DESCRIPTION
We've been executing environmental changes to the editor without control prior to this. 
This PR tries to align the ide DSL to the behavior of ExtensionPhase and composes the necessary  SumTypes, which are then interpreted by the InternalRegistry. Removing the hack with `ideRegistry`

ExtensionProvider is an ADT for 2 reasons because we want users to manipulate the environment once at a time and we can control the execution more granular. The interpreter in the ide solely asks for a SumType of a specific shape and as we grow in our algebra of manipulating the editor environment. So does our ADT. 

These 3 groups of ExtensionPhases need to be addressed:
- [X] ExtensionProvider
- [x] AnActionExtensionProvider
- [X] IntentionExtensionProvider
- [X] SyntaxHighlighterExtensionProvider

I am open for suggestions :) 