### PR TITLE
Ide Union Types & missing dep in gradle plugin 

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/union/UnionsPlugin.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/union/UnionsPlugin.kt
@@ -17,15 +17,12 @@ import org.jetbrains.kotlin.ir.expressions.IrReturn
 import org.jetbrains.kotlin.ir.expressions.IrTypeOperatorCall
 import org.jetbrains.kotlin.ir.expressions.impl.IrGetObjectValueImpl
 import org.jetbrains.kotlin.ir.expressions.impl.IrReturnImpl
-import org.jetbrains.kotlin.ir.symbols.impl.IrClassSymbolImpl
 import org.jetbrains.kotlin.ir.types.IrType
 import org.jetbrains.kotlin.ir.types.impl.originalKotlinType
-import org.jetbrains.kotlin.ir.util.dump
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi2ir.findSingleFunction
 import org.jetbrains.kotlin.types.KotlinType
-import org.jetbrains.kotlin.types.typeUtil.asTypeProjection
 
 /**
  *
@@ -203,7 +200,7 @@ private fun IrUtils.nullableConversionCall(typeArgument: IrType?, argument: IrEx
  * val willBeInt: Int? = proof() //ok
  * ```
  */
-private fun Diagnostic.suppressTypeMismatchOnNullableReceivers(): Boolean =
+fun Diagnostic.suppressTypeMismatchOnNullableReceivers(): Boolean =
   if (factory == Errors.TYPE_MISMATCH)
     Errors.TYPE_MISMATCH.cast(this).run {
       b.nullableUnionTargets(subType = a)

--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
@@ -1,11 +1,11 @@
 package arrow.meta.plugin.gradle
 
+import io.github.classgraph.ClassGraph
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
-import io.github.classgraph.ClassGraph
-import java.util.Properties
+import java.util.*
 
 /**
  * The project-level Gradle plugin behavior that is used specifying the plugin's configuration through the
@@ -25,6 +25,9 @@ class ArrowGradlePlugin : Plugin<Project> {
     val properties = Properties()
     properties.load(this.javaClass.getResourceAsStream("plugin.properties"))
     val compilerPluginVersion = properties.getProperty("COMPILER_PLUGIN_VERSION")
+    project.buildscript.repositories.maven { m ->
+      m.setUrl("https://oss.jfrog.org/artifactory/oss-snapshot-local/")
+    }
 
     project.extensions.create("arrow", ArrowExtension::class.java)
     project.afterEvaluate { p ->

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/IdeMetaPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/IdeMetaPlugin.kt
@@ -10,6 +10,7 @@ import arrow.meta.ide.plugins.initial.initialIdeSetUp
 import arrow.meta.ide.plugins.nothing.nothingIdePlugin
 import arrow.meta.ide.plugins.optics.opticsIdePlugin
 import arrow.meta.ide.plugins.typeclasses.typeclassesIdePlugin
+import arrow.meta.ide.plugins.union.uniontypes
 import arrow.meta.phases.CompilerContext
 import kotlin.contracts.ExperimentalContracts
 
@@ -18,6 +19,7 @@ open class IdeMetaPlugin : MetaPlugin(), IdeInternalRegistry, IdeSyntax {
   override fun intercept(ctx: CompilerContext): List<Plugin> =
     super.intercept(ctx) +
       initialIdeSetUp +
+      uniontypes +
       higherKindsIdePlugin +
       typeclassesIdePlugin +
       comprehensionsIdePlugin +

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/union/UnionIdePlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/union/UnionIdePlugin.kt
@@ -1,0 +1,14 @@
+package arrow.meta.ide.plugins.union
+
+import arrow.meta.Plugin
+import arrow.meta.ide.IdeMetaPlugin
+import arrow.meta.invoke
+import arrow.meta.plugins.union.suppressTypeMismatchOnNullableReceivers
+import org.jetbrains.kotlin.diagnostics.Diagnostic
+
+val IdeMetaPlugin.uniontypes: Plugin
+  get() = "Union Types"{
+    meta(
+      addDiagnosticSuppressor(Diagnostic::suppressTypeMismatchOnNullableReceivers)
+    )
+  }


### PR DESCRIPTION
This adds the DiagnosticSuppressor in `UnionTypes` for the Ide.
Furthermore, we're missing the repository dependencies in the gradle-plugin to pull the compiler-plugin. 
Otherwise this error occurs: 
```
A problem occurred configuring project ':arrow-core-data'.
> Could not resolve all artifacts for configuration ':arrow-core-data:classpath'.
   > Could not find io.arrow-kt:arrow-meta-compiler-plugin:0.10.3-SNAPSHOT.
     Searched in the following locations:
       - https://plugins.gradle.org/m2/io/arrow-kt/arrow-meta-compiler-plugin/0.10.3-SNAPSHOT/maven-metadata.xml
       - https://plugins.gradle.org/m2/io/arrow-kt/arrow-meta-compiler-plugin/0.10.3-SNAPSHOT/arrow-meta-compiler-plugin-0.10.3-SNAPSHOT.pom
     Required by:
         project :arrow-core-data > io.arrow-kt.arrow:io.arrow-kt.arrow.gradle.plugin:0.10.3-rc-2 > io.arrow-kt:gradle-plugin:0.10.3-rc-2
```
Currently, users can add a buildScript block at the top of their `build.gradle` to resolve that problem.