### PR TITLE
Set baseurl param when building the site 

### DIFF
--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -49,6 +49,7 @@ jobs:
         bundle install --gemfile docs/Gemfile --path vendor/bundle
         MAYOR_MINOR_VERSION=$(grep -e "^VERSION_NAME=.*$" gradle.properties | cut -d= -f2 | cut -d. -f1-2)
         echo $MAYOR_MINOR_VERSION
+        # bundle exec jekyll build --baseurl /$MAYOR_MINOR_VERSION -s docs -d docs/build/_site
         bundle exec jekyll build -s docs -d docs/build/_site
         echo "Publish in S3..."
         # Waiting for AWS configuration to active this part:


### PR DESCRIPTION
I'm leaving it as a comment for now, but when we start publishing versioned sites of the docs we need to set a specific parameter `baseurl` when building the site.

This value will be the same as the directory where the site will be hosted/published, in our case the name/version of the release: `$MAYOR_MINOR_VERSION`

This will correctly set the paths on the menu entries, assets, and such.