### PR TITLE
Fix: use of shadowJar for compiler plugin

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -18,4 +18,17 @@ jobs:
       env:
         JAVA_OPTS: -Xms512m -Xmx1024m
       run: |
-        ./gradlew clean build
+        # Generate compiler-plugin artifact
+        ./gradlew :compile-plugin:shadowJar
+        #
+        # Generate testing-plugin artifact when running compiler-plugin tests
+        ./gradlew :compile-plugin:test
+        #
+        # Run tests from testing-plugin
+        ./gradlew :testing-plugin:test
+        #
+        # Generate idea-plugin artifact
+        ./gradlew :idea-plugin:build
+        #
+        # Check Gradle Plugin build
+        ./gradlew :gradle-plugin:build

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -21,7 +21,19 @@ jobs:
       env:
         JAVA_OPTS: -Xms512m -Xmx1024m
       run: |
-        ./gradlew clean build
+        # Generate compiler-plugin artifact
+        ./gradlew :compile-plugin:shadowJar
+        #
+        # Generate testing-plugin artifact when running compiler-plugin tests
+        ./gradlew :compile-plugin:test
+        #
+        # Run testing plugin tests 
+        ./gradlew :testing-plugin:test
+        #
+        # Generate idea-plugin artifact
+        ./gradlew :idea-plugin:build
+        #
+        # Note: Gradle Plugin and Documentation have their own workflows
     - name: Publish artifacts
       env:
         BINTRAY_USER: ${{ secrets.BINTRAY_USER }}

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -3,13 +3,14 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
-    compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    // WARNING: don't change the configuration name because it's used by shadowJar
+    compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     compileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlin_version"
     compileOnly "com.intellij:openapi:7.0.3"
 
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$kotlin_test_version"
     testImplementation project(":testing-plugin")
-    testRuntimeOnly project(":compiler-plugin")
+    testRuntimeOnly project(path: ':compiler-plugin', configuration: 'shadow')
 
     testRuntimeOnly "io.arrow-kt:arrow-annotations:$VERSION_NAME"
     testRuntimeOnly "io.arrow-kt:arrow-core-data:$VERSION_NAME"

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -32,5 +32,3 @@ ank {
 //}
 
 compileKotlin.kotlinOptions.freeCompilerArgs += ["-Xskip-runtime-version-check"]
-
-apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/docs/gradle.properties
+++ b/docs/gradle.properties
@@ -1,4 +1,0 @@
-# Maven publishing configuration
-POM_NAME=Arrow Meta Docs
-POM_ARTIFACT_ID=arrow-meta-docs
-POM_PACKAGING=jar

--- a/testing-plugin/build.gradle
+++ b/testing-plugin/build.gradle
@@ -14,17 +14,15 @@ dependencies {
 
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     compileOnly "io.github.classgraph:classgraph:$class_graph_version"
-    compileOnly project(":compiler-plugin")
-    implementation "org.assertj:assertj-core:$assertj_version"
+    compileOnly project(path: ':compiler-plugin', configuration: 'shadow')
 
+    implementation "org.assertj:assertj-core:$assertj_version"
     // TODO: temporary dependency until PR is approved and published
     // implementation "com.github.tschuchortdev:kotlin-compile-testing:$kotlin_compile_testing"
     implementation "com.github.arrow-kt:kotlin-compile-testing:$kotlin_compile_testing"
 
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$kotlin_test_version"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junit_vintage_version"
-    testRuntimeOnly project(":compiler-plugin")
-
     testRuntimeOnly "io.arrow-kt:arrow-annotations:$VERSION_NAME"
 }
 

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -44,8 +44,9 @@ interface ConfigSyntax {
 
   val metaDependencies: List<Config>
     get() {
-      val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
-      val arrowAnnotations = Dependency("arrow-annotations:${System.getProperty("CURRENT_VERSION")}")
+      val currentVersion = System.getProperty("CURRENT_VERSION")
+      val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin:$currentVersion:all")))
+      val arrowAnnotations = Dependency("arrow-annotations:$currentVersion")
       return CompilerTest.addCompilerPlugins(compilerPlugin) + CompilerTest.addDependencies(arrowAnnotations)
     }
 }

--- a/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/ExampleTest.kt
+++ b/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/ExampleTest.kt
@@ -81,47 +81,4 @@ class ExampleTest {
       }
     ))
   }
-
-  @Test
-  fun `checks the meta debug output given a configuration`() {
-    val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin")))
-    val arrowAnnotations = Dependency("arrow-annotations:${System.getProperty("CURRENT_VERSION")}")
-
-    assertThis(CompilerTest(
-      config = {
-        addCompilerPlugins(compilerPlugin) + addDependencies(arrowAnnotations)
-      },
-      code = {
-        """
-        | import arrow.higherkind
-        | 
-        | //metadebug
-        | 
-        | @higherkind
-        | class Id2<out A>(val value: A)
-        | 
-        | val x: Id2Of<Int> = Id2(1)
-        | 
-        """.source
-      },
-      assert = {
-        allOf(quoteOutputMatches(
-          """
-          | import arrow.higherkind
-          | 
-          | //meta: <date>
-          | 
-          | @arrow.synthetic class ForId2 private constructor() { companion object }
-          | @arrow.synthetic typealias Id2Of<A> = arrow.Kind<ForId2, A>
-          | @arrow.synthetic typealias Id2KindedJ<A> = arrow.HkJ<ForId2, A>
-          | @arrow.synthetic fun <A> Id2Of<A>.fix(): Id2<A> =
-          |   this as Id2<A>
-          | @arrow.synthetic @higherkind /* empty? */class Id2 <out A> public constructor (val value: A) : Id2Of<A> {}
-          | 
-          | val x: Id2Of<Int> = Id2(1)
-          | 
-          """.source))
-      }
-    ))
-  }
 }


### PR DESCRIPTION
## Changes

- Update checks for the use of shadowJar
- `configuration: 'shadow'` for `compiler-plugin` dependencies
- Recover `compile` for `"org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"` to be included in shadowJar
- Update `metaDependencies`
- Remove doc artifact from publication in artifact repository
- Remove duplicated test in testing-plugin.
