### PR TITLE
Initial purity plugin

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/IdeMetaPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/IdeMetaPlugin.kt
@@ -9,6 +9,7 @@ import arrow.meta.ide.plugins.higherkinds.higherKindsIdePlugin
 import arrow.meta.ide.plugins.initial.initialIdeSetUp
 import arrow.meta.ide.plugins.nothing.nothingIdePlugin
 import arrow.meta.ide.plugins.optics.opticsIdePlugin
+import arrow.meta.ide.plugins.purity.purity
 import arrow.meta.ide.plugins.typeclasses.typeclassesIdePlugin
 import arrow.meta.ide.plugins.union.uniontypes
 import arrow.meta.phases.CompilerContext
@@ -19,6 +20,7 @@ open class IdeMetaPlugin : MetaPlugin(), IdeInternalRegistry, IdeSyntax {
   override fun intercept(ctx: CompilerContext): List<Plugin> =
     super.intercept(ctx) +
       initialIdeSetUp +
+      purity +
       uniontypes +
       higherKindsIdePlugin +
       typeclassesIdePlugin +

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionUtilitySyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionUtilitySyntax.kt
@@ -1,8 +1,5 @@
 package arrow.meta.ide.dsl.editor.inspection
 
-import arrow.meta.phases.ExtensionPhase
-import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.openapi.extensions.ExtensionPointName
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.idea.util.actualsForExpected
@@ -19,11 +16,8 @@ interface InspectionUtilitySyntax {
     return listOf(expect) + actuals
   }
 
-  fun InspectionUtilitySyntax.addLocalInspectionToolToIdeRegistry(): ExtensionPhase = TODO("untested")
-  /*registerExtensionPoint(
-    EP_NAME,
-    LocalInspectionTool::class.java
-  )*/
+  val ArrowPath: Array<String>
+    get() = arrayOf("Kotlin", "Λrrow")
 }
 
 sealed class ExtendedReturnsCheck(val name: String, val type: KotlinBuiltIns.() -> KotlinType) : Check {
@@ -34,6 +28,3 @@ sealed class ExtendedReturnsCheck(val name: String, val type: KotlinBuiltIns.() 
   object ReturnsNothing : ExtendedReturnsCheck("Nothing", { nothingType })
   object ReturnsNullableNothing : ExtendedReturnsCheck("NullableNothing", { nullableNothingType })
 }
-
-val EP_NAME: ExtensionPointName<LocalInspectionTool>
-  get() = ExtensionPointName.create<LocalInspectionTool>("com.intellij.codeInspection.LocalInspectionTool")

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/dummy/DummyIdePlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/dummy/DummyIdePlugin.kt
@@ -1,37 +1,7 @@
 package arrow.meta.ide.plugins.dummy
 
 import arrow.meta.Plugin
-import arrow.meta.ide.dsl.editor.inspection.ExtendedReturnsCheck
-import arrow.meta.invoke
 import arrow.meta.ide.IdeMetaPlugin
-import com.intellij.codeInspection.ProblemHighlightType
-import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
-import org.jetbrains.kotlin.lexer.KtTokens
-import org.jetbrains.kotlin.psi.KtNamedFunction
-import org.jetbrains.kotlin.util.ReturnsCheck
 
-/**
- * Unrelated to [arrow.meta.plugins.helloWorld.helloWorld]
- */
 val IdeMetaPlugin.dummyIdePlugin: Plugin
-  get() = "DummyIdePlugin" {
-    meta(
-      addApplicableInspection(
-        defaultFixText = "Impure",
-        inspectionHighlightType = { ProblemHighlightType.ERROR },
-        kClass = KtNamedFunction::class.java,
-        highlightingRange = { f -> f.textRange },
-        inspectionText = { f -> "Function should be suspended" },
-        applyTo = { f, project, editor ->
-          f.addModifier(KtTokens.SUSPEND_KEYWORD)
-        },
-        isApplicable = { f: KtNamedFunction ->
-          f.nameIdentifier != null && !f.hasModifier(KtTokens.SUSPEND_KEYWORD) &&
-            f.resolveToDescriptorIfAny()?.run {
-              !isSuspend && (ReturnsCheck.ReturnsUnit.check(this) || ExtendedReturnsCheck.ReturnsNothing.check(this)
-                || ExtendedReturnsCheck.ReturnsNullableNothing.check(this))
-            } == true
-        }
-      )
-    )
-  }
+  get() = TODO()

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/purity/PurityPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/purity/PurityPlugin.kt
@@ -1,0 +1,38 @@
+package arrow.meta.ide.plugins.purity
+
+import arrow.meta.Plugin
+import arrow.meta.ide.IdeMetaPlugin
+import arrow.meta.ide.dsl.editor.inspection.ExtendedReturnsCheck
+import arrow.meta.invoke
+import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.ProblemHighlightType
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
+import org.jetbrains.kotlin.idea.util.nameIdentifierTextRangeInThis
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.util.ReturnsCheck
+
+val IdeMetaPlugin.purity: Plugin
+  get() = "PurityPlugin" {
+    meta(
+      addApplicableInspection(
+        defaultFixText = "Suspend",
+        inspectionHighlightType = { ProblemHighlightType.ERROR },
+        kClass = KtNamedFunction::class.java,
+        highlightingRange = { f -> f.nameIdentifierTextRangeInThis() },
+        inspectionText = { f -> "Function should be suspended" },
+        applyTo = { f, project, editor ->
+          f.addModifier(KtTokens.SUSPEND_KEYWORD)
+        },
+        isApplicable = { f: KtNamedFunction ->
+          f.nameIdentifier != null && !f.hasModifier(KtTokens.SUSPEND_KEYWORD) &&
+            f.resolveToDescriptorIfAny()?.run {
+              !isSuspend && (ReturnsCheck.ReturnsUnit.check(this) || ExtendedReturnsCheck.ReturnsNothing.check(this)
+                || ExtendedReturnsCheck.ReturnsNullableNothing.check(this))
+            } == true
+        },
+        level = HighlightDisplayLevel.ERROR,
+        groupPath = ArrowPath + "PurityPlugin"
+      )
+    )
+  }


### PR DESCRIPTION

<img width="772" alt="Screenshot 2019-11-09 at 21 56 30" src="https://user-images.githubusercontent.com/46971368/68535368-b739d680-0341-11ea-9d1e-a370bb6e4e65.png">
<img width="433" alt="Screenshot 2019-11-09 at 21 56 56" src="https://user-images.githubusercontent.com/46971368/68535371-c7ea4c80-0341-11ea-89bc-aa130e3b2304.png">

This aims to solve https://github.com/arrow-kt/arrow-meta/issues/28
The `InspectionSyntax` allows us to write costume Inspections based on Tooling, what Kotlin already uses in the editor. This allows plugin developers to not only indicate code elements, which need to be inspected but additionally to manipulate them programmatically. 
As here to add a `suspended` keyword to a function. 

`ApplicableInspections` can traverse any KtElement. Furthermore, we can extend the Scope of Inspection to the whole Project instead of individual files. This allows users to write fast fixes, which are universal for the whole project and deal with subsequent issues. 

I'll add checks for calls in the function body, which return Unit or Nothing.
We should also add Text for an explanation. 