### PR TITLE
Inspection cleanUp

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionSyntax.kt
@@ -4,6 +4,7 @@ import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeHighlighting.HighlightDisplayLevel
+import com.intellij.codeInspection.GlobalInspectionTool
 import com.intellij.codeInspection.InspectionEP
 import com.intellij.codeInspection.InspectionProfileEntry
 import com.intellij.codeInspection.InspectionSuppressor
@@ -12,7 +13,6 @@ import com.intellij.codeInspection.LocalInspectionEP
 import com.intellij.codeInspection.LocalInspectionTool
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.SuppressQuickFix
-import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.extensions.LoadingOrder
 import com.intellij.openapi.project.Project
@@ -50,7 +50,7 @@ interface InspectionSyntax : InspectionUtilitySyntax {
     )
 
   fun IdeMetaPlugin.addGlobalInspection(
-    inspectionTool: InspectionProfileEntry,
+    inspectionTool: GlobalInspectionTool,
     level: HighlightDisplayLevel,
     shortName: String,
     displayName: String,
@@ -64,7 +64,7 @@ interface InspectionSyntax : InspectionUtilitySyntax {
     )
 
   fun IdeMetaPlugin.addLocalInspection(
-    inspectionTool: InspectionProfileEntry,
+    inspectionTool: LocalInspectionTool,
     level: HighlightDisplayLevel,
     shortName: String,
     displayName: String,
@@ -134,7 +134,7 @@ interface InspectionSyntax : InspectionUtilitySyntax {
     }
 
   fun InspectionSyntax.inspection(
-    inspectionTool: InspectionProfileEntry,
+    inspectionTool: GlobalInspectionTool,
     level: HighlightDisplayLevel,
     shortName: String,
     displayName: String,
@@ -151,7 +151,7 @@ interface InspectionSyntax : InspectionUtilitySyntax {
     }
 
   fun InspectionSyntax.localInspection(
-    inspectionTool: InspectionProfileEntry,
+    inspectionTool: LocalInspectionTool,
     level: HighlightDisplayLevel,
     shortName: String,
     displayName: String,

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionSyntax.kt
@@ -87,6 +87,7 @@ interface InspectionSyntax : InspectionUtilitySyntax {
 
         override fun getGroupPath(): Array<String>? = groupPath
 
+        override fun getGroupDisplayName(): String = defaultFixText
       },
       LoadingOrder.FIRST
     )

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/nothing/NothingIdePlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/nothing/NothingIdePlugin.kt
@@ -12,7 +12,8 @@ val IdeMetaPlugin.nothingIdePlugin: Plugin
     meta(
       addLineMarkerProvider(
         icon = ArrowIcons.NOTHING,
-        transform = { it.safeAs<KtUserType>()?.takeIf { type -> type.referencedName == "Nothing" } },
+        transform = { it.safeAs<KtUserType>()?.takeIf { type -> type.referencedName == "Nothing" }
+          ?.referenceExpression?.getReferencedNameElement()},
         message = { "Bottom Type" }
       )
     )

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/purity/PurityPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/purity/PurityPlugin.kt
@@ -6,10 +6,12 @@ import arrow.meta.ide.dsl.editor.inspection.ExtendedReturnsCheck
 import arrow.meta.invoke
 import com.intellij.codeHighlighting.HighlightDisplayLevel
 import com.intellij.codeInspection.ProblemHighlightType
+import org.jetbrains.kotlin.codegen.coroutines.isSuspendLambdaOrLocalFunction
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.idea.util.nameIdentifierTextRangeInThis
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.resolve.calls.tower.isSynthesized
 import org.jetbrains.kotlin.util.ReturnsCheck
 
 val IdeMetaPlugin.purity: Plugin
@@ -27,7 +29,7 @@ val IdeMetaPlugin.purity: Plugin
         isApplicable = { f: KtNamedFunction ->
           f.nameIdentifier != null && !f.hasModifier(KtTokens.SUSPEND_KEYWORD) &&
             f.resolveToDescriptorIfAny()?.run {
-              !isSuspend && (ReturnsCheck.ReturnsUnit.check(this) || ExtendedReturnsCheck.ReturnsNothing.check(this)
+              !isSuspend && !isSynthesized && !isSuspendLambdaOrLocalFunction() && (ReturnsCheck.ReturnsUnit.check(this) || ExtendedReturnsCheck.ReturnsNothing.check(this)
                 || ExtendedReturnsCheck.ReturnsNullableNothing.check(this))
             } == true
         },

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
@@ -6,6 +6,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.SyntaxTraverser
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.util.containers.TreeTraversal
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
@@ -13,9 +14,17 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 object LightTestSyntax {
   /**
    * Deconstructs the KtFile into a List, which we can traverse freely as all references persist
+   * This stores solely the first layer of nodes from the ktFile
    */
   fun Source.ktFileToList(myFixture: CodeInsightTestFixture): List<PsiElement> =
     toKtFile(myFixture)?.let { SyntaxTraverser.psiTraverser().children(it).toList() } ?: emptyList()
+
+  /**
+   * traverses the Source code based on [traversal], which has several forms, such as
+   * [TreeTraversal.POST_ORDER_DFS], [TreeTraversal.PRE_ORDER_DFS], [TreeTraversal.TRACING_BFS], ...
+   */
+  fun Source.ktFileToList(traversal: TreeTraversal = TreeTraversal.PLAIN_BFS, myFixture: CodeInsightTestFixture): List<PsiElement> =
+    toKtFile(myFixture)?.let { SyntaxTraverser.psiTraverser(it).traverse(traversal).toList() } ?: emptyList()
 
   fun Source.toKtFile(myFixture: CodeInsightTestFixture): KtFile? =
     myFixture.configureByText(KotlinFileType.INSTANCE, this).safeAs()


### PR DESCRIPTION
A general cleanUp for the editor fixes unnecessary NPE with `Inspections`, boosts performance for LineMarker Resolution and cleansUp `InspectionSyntax`.