### PR TITLE
CI: update Arrow version to 0.10.4-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Package definitions
 GROUP=io.arrow-kt
 VERSION_NAME=1.3.70-SNAPSHOT
-ARROW_VERSION=0.10.3-SNAPSHOT
+ARROW_VERSION=0.10.4-SNAPSHOT
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true


### PR DESCRIPTION
*Arrow* 0.10.3 has been released and the last version of *Arrow* is `0.10.4-SNAPSHOT`