### PR TITLE
Small fixes to fragment provider refresh

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/resolve/MetaSyntheticPackageFragmentProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/resolve/MetaSyntheticPackageFragmentProvider.kt
@@ -3,6 +3,7 @@ package arrow.meta.ide.phases.resolve
 import arrow.meta.ide.phases.config.buildFolders
 import arrow.meta.quotes.get
 import arrow.meta.quotes.ktClassOrObject
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbService
@@ -67,6 +68,7 @@ import org.jetbrains.kotlin.resolve.lazy.LazyEntity
 import org.jetbrains.kotlin.resolve.lazy.declarations.ClassMemberDeclarationProvider
 import org.jetbrains.kotlin.resolve.lazy.declarations.DeclarationProvider
 import org.jetbrains.kotlin.resolve.lazy.declarations.PackageMemberDeclarationProvider
+import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyAnnotationDescriptor
 import org.jetbrains.kotlin.resolve.lazy.descriptors.LazyClassDescriptor
 import org.jetbrains.kotlin.resolve.scopes.DescriptorKindFilter
 import org.jetbrains.kotlin.resolve.scopes.MemberScope
@@ -174,6 +176,9 @@ class MetaSyntheticPackageFragmentProvider(val project: Project) :
     ApplicationManager.getApplication().executeOnPooledThread {
       DumbService.getInstance(project).runReadActionInSmartMode {
         computeCache()
+
+        // refresh the highlighting of the current editor, using the new cache
+        DaemonCodeAnalyzer.getInstance(project).restart()
       }
     }
   }


### PR DESCRIPTION
Changes:
- Performance optimization by doing much less cache refreshes. The cache only needs to be refreshed after changes to .class files. We were refresh always, which is too often.
- refresh highlighting and warnings in all open editors after cache refresh. This should remove the warnings in almost all cases.

I made these changes while debugging the fragment provider for #96 