### PR TITLE
When condition scope and quote

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -222,8 +222,8 @@ class DefaultElementScope(project: Project) : ElementScope {
   override val String.whenEntry: WhenEntryScope
     get() = WhenEntryScope(delegate.createWhenEntry(trimMargin()))
 
-  override val String.whenCondition: Scope<KtWhenCondition>
-    get() = Scope(delegate.createWhenCondition(trimMargin()))
+  override val String.whenCondition: WhenConditionScope
+    get() = WhenConditionScope(delegate.createWhenCondition(trimMargin()))
 
   override fun blockStringTemplateEntry(expression: KtExpression): Scope<KtStringTemplateEntryWithExpression> =
     Scope(delegate.createBlockStringTemplateEntry(expression))

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -1,6 +1,13 @@
 package arrow.meta.phases.analysis
 
-import arrow.meta.quotes.*
+import arrow.meta.quotes.ClassScope
+import arrow.meta.quotes.ForExpressionScope
+import arrow.meta.quotes.NamedFunctionScope
+import arrow.meta.quotes.ParameterScope
+import arrow.meta.quotes.Scope
+import arrow.meta.quotes.WhenConditionScope
+import arrow.meta.quotes.WhenEntryScope
+import arrow.meta.quotes.WhileExpressionScope
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
 import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
@@ -52,8 +59,6 @@ import org.jetbrains.kotlin.psi.KtTypeProjection
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtValueArgumentList
-import org.jetbrains.kotlin.psi.KtWhenCondition
-import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.resolve.ImportPath
 
 interface ElementScope {

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -222,7 +222,7 @@ interface ElementScope {
   
   val String.whenEntry: WhenEntryScope
   
-  val String.whenCondition: Scope<KtWhenCondition>
+  val String.whenCondition: WhenConditionScope
   
   fun blockStringTemplateEntry(expression: KtExpression): Scope<KtStringTemplateEntryWithExpression>
   

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/WhenCondition.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/WhenCondition.kt
@@ -1,0 +1,46 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtWhenCondition
+
+/**
+ * A [KtWhenCondition] [Quote] with a custom template destructuring [WhenConditionScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.whenCondition
+ *
+ * val Meta.reformatWhenCondition: Plugin
+ *  get() =
+ *   "ReformatWhenCondition" {
+ *    meta(
+ *     whenCondition({ true }) { c ->
+ *      Transform.replace(
+ *       replacing = c,
+ *       newDeclaration = """ $condition """.whenCondition
+ *      )
+ *     }
+ *    )
+ *   }
+ *```
+ *
+ * @param match designed to to feed in any kind of [KtWhenCondition] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.whenCondition(
+  match: KtWhenCondition.() -> Boolean,
+  map: WhenConditionScope.(KtWhenCondition) -> Transform<KtWhenCondition>
+): ExtensionPhase =
+  quote(match, map) { WhenConditionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtWhenCondition]
+ */
+class WhenConditionScope(
+  override val value: KtWhenCondition?,
+  val condition: String = value?.text ?: ""
+) : Scope<KtWhenCondition>(value)


### PR DESCRIPTION
This PR introduces `KtWhenCondition` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtWhenCondition`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element