### PR TITLE
Catch quote and scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -302,4 +302,7 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`while`: WhileExpressionScope
     get() = WhileExpressionScope(expression.value as KtWhileExpression)
+
+  override val String.catch: CatchClauseScope
+    get() = CatchClauseScope(expression.value as KtCatchClause)
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -1,5 +1,6 @@
 package arrow.meta.phases.analysis
 
+import arrow.meta.quotes.CatchClauseScope
 import arrow.meta.quotes.ClassScope
 import arrow.meta.quotes.ForExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
@@ -285,6 +286,8 @@ interface ElementScope {
   val String.`for`: ForExpressionScope
 
   val String.`while`: WhileExpressionScope
+
+  val String.catch: CatchClauseScope
   
   fun singleStatementBlock(
     statement: KtExpression,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/CatchClause.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/CatchClause.kt
@@ -1,0 +1,50 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtCatchClause
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtParameterList
+
+/**
+ * A [KtCatchClause] [Quote] with a custom template destructuring [CatchClauseScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.CatchClause
+ *
+ * val Meta.reformatCatchClause: Plugin
+ *  get() =
+ *   "ReformatCatchClause" {
+ *    meta(
+ *     catchClause({ true }) { c ->
+ *      Transform.replace(
+ *       replacing = c,
+ *       newDeclaration = """ catch $`(parameter)` $`{ body }` """.catch
+ *      )
+ *     }
+ *    )
+ *   }
+ *```
+ *
+ * @param match designed to to feed in any kind of [KtCatchClause] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.catchClause(
+  match: KtCatchClause.() -> Boolean,
+  map: CatchClauseScope.(KtCatchClause) -> Transform<KtCatchClause>
+): ExtensionPhase =
+  quote(match, map) { CatchClauseScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtCatchClause]
+ */
+class CatchClauseScope(
+  override val value: KtCatchClause?,
+  val `(parameter)`: ParameterScope = ParameterScope(value?.catchParameter),
+  val `{ body }`: Scope<KtExpression> = Scope(value?.catchBody),
+  val parameterList: Scope<KtParameterList> = Scope(value?.parameterList)
+) : Scope<KtCatchClause>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/CatchClause.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/CatchClause.kt
@@ -14,7 +14,7 @@ import org.jetbrains.kotlin.psi.KtParameterList
  * import arrow.meta.Plugin
  * import arrow.meta.invoke
  * import arrow.meta.quotes.Transform
- * import arrow.meta.quotes.CatchClause
+ * import arrow.meta.quotes.catchClause
  *
  * val Meta.reformatCatchClause: Plugin
  *  get() =


### PR DESCRIPTION
This PR introduces `KtCatchClause` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for KtCatchClause
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element