### PR TITLE
Block expression and quote

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -180,8 +180,8 @@ class DefaultElementScope(project: Project) : ElementScope {
   override val String.annotationEntry: Scope<KtAnnotationEntry>
     get() = Scope(delegate.createAnnotationEntry(trimMargin()))
 
-  override val emptyBody: Scope<KtBlockExpression>
-    get() = Scope(delegate.createEmptyBody())
+  override val emptyBody: BlockExpressionScope
+    get() = BlockExpressionScope(delegate.createEmptyBody())
 
   override val anonymousInitializer: Scope<KtAnonymousInitializer>
     get() = Scope(delegate.createAnonymousInitializer())
@@ -288,11 +288,11 @@ class DefaultElementScope(project: Project) : ElementScope {
   override val String.delegatedSuperTypeEntry: Scope<KtConstructorDelegationCall>
     get() = Scope(delegate.creareDelegatedSuperTypeEntry(trimMargin()))
 
-  override val String.block: Scope<KtBlockExpression>
-    get() = Scope(delegate.createBlock(trimMargin()))
+  override val String.block: BlockExpressionScope
+    get() = BlockExpressionScope(delegate.createBlock(trimMargin()))
 
-  override fun singleStatementBlock(statement: KtExpression, prevComment: String?, nextComment: String?): Scope<KtBlockExpression> =
-    Scope(delegate.createSingleStatementBlock(statement, prevComment, nextComment))
+  override fun singleStatementBlock(statement: KtExpression, prevComment: String?, nextComment: String?): BlockExpressionScope =
+    BlockExpressionScope(delegate.createSingleStatementBlock(statement, prevComment, nextComment))
 
   override val String.comment: PsiComment
     get() = delegate.createComment(trimMargin())

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -1,5 +1,6 @@
 package arrow.meta.phases.analysis
 
+import arrow.meta.quotes.BlockExpressionScope
 import arrow.meta.quotes.ClassScope
 import arrow.meta.quotes.ForExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
@@ -16,7 +17,6 @@ import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtAnonymousInitializer
 import org.jetbrains.kotlin.psi.KtBlockCodeFragment
-import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
@@ -196,7 +196,7 @@ interface ElementScope {
   
   val String.annotationEntry: Scope<KtAnnotationEntry>
   
-  val emptyBody: Scope<KtBlockExpression>
+  val emptyBody: BlockExpressionScope
   
   val anonymousInitializer: Scope<KtAnonymousInitializer>
   
@@ -280,7 +280,7 @@ interface ElementScope {
   
   val String.delegatedSuperTypeEntry: Scope<KtConstructorDelegationCall>
   
-  val String.block: Scope<KtBlockExpression>
+  val String.block: BlockExpressionScope
 
   val String.`for`: ForExpressionScope
 
@@ -290,7 +290,7 @@ interface ElementScope {
     statement: KtExpression,
     prevComment: String? = null,
     nextComment: String? = null
-  ): Scope<KtBlockExpression>
+  ): BlockExpressionScope
   
   val String.comment: PsiComment
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/BlockExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/BlockExpression.kt
@@ -1,0 +1,48 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtExpression
+
+/**
+ * A [KtBlockExpression] [Quote] with a custom template destructuring [BlockExpressionScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.blockExpression
+ *
+ * val Meta.reformatBlock: Plugin
+ *  get() =
+ *   "BlockExpression" {
+ *    meta(
+ *     blockExpression({ true }) { e ->
+ *      Transform.replace(
+ *       replacing = e,
+ *       newDeclaration = """ { $statements } """.block
+ *      )
+ *     }
+ *    )
+ *   }
+ *```
+ *
+ * @param match designed to to feed in any kind of [KtBlockExpression] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.blockExpression(
+  match: KtBlockExpression.() -> Boolean,
+  map: BlockExpressionScope.(KtBlockExpression) -> Transform<KtBlockExpression>
+): ExtensionPhase =
+  quote(match, map) { BlockExpressionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtBlockExpression]
+ */
+class BlockExpressionScope(
+  override val value: KtBlockExpression?,
+  val statements: ScopedList<KtExpression> = ScopedList(value?.statements ?: listOf()),
+  val firstStatement: Scope<KtExpression> = Scope(value?.firstStatement)
+) : Scope<KtBlockExpression>(value)


### PR DESCRIPTION
This PR introduces `KtBlockExpression` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtBlockExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element