### PR TITLE
Finally quote and scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -302,4 +302,7 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`while`: WhileExpressionScope
     get() = WhileExpressionScope(expression.value as KtWhileExpression)
+
+  override val String.finally: FinallySectionScope
+    get() = FinallySectionScope(expression.value as KtFinallySection)
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -1,6 +1,7 @@
 package arrow.meta.phases.analysis
 
 import arrow.meta.quotes.ClassScope
+import arrow.meta.quotes.FinallySectionScope
 import arrow.meta.quotes.ForExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
 import arrow.meta.quotes.ParameterScope
@@ -285,6 +286,8 @@ interface ElementScope {
   val String.`for`: ForExpressionScope
 
   val String.`while`: WhileExpressionScope
+
+  val String.finally: FinallySectionScope
   
   fun singleStatementBlock(
     statement: KtExpression,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/FinallySection.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/FinallySection.kt
@@ -1,0 +1,47 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtFinallySection
+
+/**
+ * A [KtFinallySection] [Quote] with a custom template destructuring [FinallySectionScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.finallySection
+ *
+ * val Meta.reformatFinallySection: Plugin
+ *  get() =
+ *   "ReformatFinallySection" {
+ *    meta(
+ *     finallySection({ true }) { s ->
+ *      Transform.replace(
+ *       replacing = s,
+ *       newDeclaration = """ $finally """.finally
+ *      )
+ *     }
+ *    )
+ *   }
+ *```
+ *
+ * @param match designed to to feed in any kind of [KtFinallySection] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.finallySection(
+  match: KtFinallySection.() -> Boolean,
+  map: FinallySectionScope.(KtFinallySection) -> Transform<KtFinallySection>
+): ExtensionPhase =
+  quote(match, map) { FinallySectionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtFinallySection]
+ */
+class FinallySectionScope(
+  override val value: KtFinallySection?,
+  val finally: Scope<KtBlockExpression> = Scope(value?.finalExpression)
+) : Scope<KtFinallySection>(value)


### PR DESCRIPTION
This PR introduces `KtFinallySection` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtFinallySection`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element