### PR TITLE
Throw expression quote and scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -317,4 +317,7 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.finally: FinallySectionScope
     get() = FinallySectionScope(expression.value as KtFinallySection)
+
+  override val String.`throw`: ThrowExpressionScope
+    get() = ThrowExpressionScope(expression.value as KtThrowExpression)
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -9,6 +9,7 @@ import arrow.meta.quotes.IfExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
 import arrow.meta.quotes.ParameterScope
 import arrow.meta.quotes.Scope
+import arrow.meta.quotes.ThrowExpressionScope
 import arrow.meta.quotes.TryExpressionScope
 import arrow.meta.quotes.WhenConditionScope
 import arrow.meta.quotes.WhenEntryScope
@@ -299,7 +300,9 @@ interface ElementScope {
   val String.catch: CatchClauseScope
 
   val String.finally: FinallySectionScope
-  
+
+  val String.`throw`: ThrowExpressionScope
+
   fun singleStatementBlock(
     statement: KtExpression,
     prevComment: String? = null,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ThrowExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ThrowExpression.kt
@@ -1,0 +1,47 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtThrowExpression
+
+/**
+ * A [KtThrowExpression] [Quote] with a custom template destructuring [ThrowExpressionScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.throwExpression
+ *
+ * val Meta.reformatThrow: Plugin
+ *  get() =
+ *   "ReformatThrow" {
+ *    meta(
+ *     throwExpression({ true }) { e ->
+ *      Transform.replace(
+ *       replacing = e,
+ *       newDeclaration = """ $`throw` """.`throw`
+ *      )
+ *      }
+ *     )
+ *    }
+ * ```
+ *
+ * @param match designed to to feed in any kind of [KtThrowExpression] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.throwExpression(
+  match: KtThrowExpression.() -> Boolean,
+  map: ThrowExpressionScope.(KtThrowExpression) -> Transform<KtThrowExpression>
+): ExtensionPhase =
+  quote(match, map) { ThrowExpressionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtThrowExpression]
+ */
+class ThrowExpressionScope(
+  override val value: KtThrowExpression?,
+  val `throw`: Scope<KtExpression> = Scope(value?.thrownExpression)
+) : Scope<KtThrowExpression>(value)


### PR DESCRIPTION
This PR introduces `KtThrowExpression` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtThrowExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element