### PR TITLE
Is expression quote and its scope mapping

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -320,4 +320,7 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`throw`: ThrowExpressionScope
     get() = ThrowExpressionScope(expression.value as KtThrowExpression)
+
+  override val String.`is`: IsExpressionScope
+    get() = IsExpressionScope(expression.value as KtIsExpression)
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -1,11 +1,12 @@
 package arrow.meta.phases.analysis
 
-import arrow.meta.quotes.CatchClauseScope
 import arrow.meta.quotes.BlockExpressionScope
+import arrow.meta.quotes.CatchClauseScope
 import arrow.meta.quotes.ClassScope
 import arrow.meta.quotes.FinallySectionScope
 import arrow.meta.quotes.ForExpressionScope
 import arrow.meta.quotes.IfExpressionScope
+import arrow.meta.quotes.IsExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
 import arrow.meta.quotes.ParameterScope
 import arrow.meta.quotes.Scope
@@ -302,6 +303,8 @@ interface ElementScope {
   val String.finally: FinallySectionScope
 
   val String.`throw`: ThrowExpressionScope
+
+  val String.`is`: IsExpressionScope
 
   fun singleStatementBlock(
     statement: KtExpression,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/IsExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/IsExpression.kt
@@ -1,0 +1,51 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtIsExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+import org.jetbrains.kotlin.psi.KtTypeReference
+
+/**
+ * A [KtIsExpression] [Quote] with a custom template destructuring [IsExpressionScope]. See below:
+ *
+ *```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.isExpression
+ *
+ * val Meta.reformatIs: Plugin
+ *  get() =
+ *  "ReformatIs" {
+ *   meta(
+ *    isExpression({ true }) { e ->
+ *     Transform.replace(
+ *      replacing = e,
+ *      newDeclaration = """ $left $operation $type """.`is`
+ *     )
+ *    }
+ *   )
+ *  }
+ *```
+ *
+ * * @param match designed to to feed in any kind of [KtIsExpression] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.isExpression(
+  match: KtIsExpression.() -> Boolean,
+  map: IsExpressionScope.(KtIsExpression) -> Transform<KtIsExpression>
+): ExtensionPhase =
+  quote(match, map) { IsExpressionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtIsExpression]
+ */
+class IsExpressionScope(
+  override val value: KtIsExpression?,
+  val left: Scope<KtExpression> = Scope(value?.leftHandSide),
+  val operation: Scope<KtSimpleNameExpression> = Scope(value?.operationReference),
+  val type: Scope<KtTypeReference> = Scope(value?.typeReference)
+) : Scope<KtIsExpression>(value)


### PR DESCRIPTION
This PR introduces `KtIsExpression` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtIsExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element