### PR TITLE
Return quote and its scope mapping

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -323,4 +323,7 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`is`: IsExpressionScope
     get() = IsExpressionScope(expression.value as KtIsExpression)
+
+  override val String.`return`: ReturnExpressionScope
+    get() = ReturnExpressionScope(expression.value as KtReturnExpression)
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -9,6 +9,7 @@ import arrow.meta.quotes.IfExpressionScope
 import arrow.meta.quotes.IsExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
 import arrow.meta.quotes.ParameterScope
+import arrow.meta.quotes.ReturnExpressionScope
 import arrow.meta.quotes.Scope
 import arrow.meta.quotes.ThrowExpressionScope
 import arrow.meta.quotes.TryExpressionScope
@@ -305,6 +306,8 @@ interface ElementScope {
   val String.`throw`: ThrowExpressionScope
 
   val String.`is`: IsExpressionScope
+
+  val String.`return`: ReturnExpressionScope
 
   fun singleStatementBlock(
     statement: KtExpression,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ReturnExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ReturnExpression.kt
@@ -1,0 +1,47 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtReturnExpression
+
+/**
+ * A [KtReturnExpression] [Quote] with a custom template destructuring [ReturnExpressionScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.returnExpression
+ *
+ * val Meta.reformatReturn: Plugin
+ *  get() =
+ *   "ReformatReturn" {
+ *    meta(
+ *     returnExpression({ true }) { e ->
+ *      Transform.replace(
+ *       replacing = e,
+ *       newDeclaration = """ $`return` """.`return`
+ *      )
+ *      }
+ *     )
+ *    }
+ * ```
+ *
+ * @param match designed to to feed in any kind of [KtReturnExpression] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.returnExpression(
+  match: KtReturnExpression.() -> Boolean,
+  map: ReturnExpressionScope.(KtReturnExpression) -> Transform<KtReturnExpression>
+): ExtensionPhase =
+  quote(match, map) { ReturnExpressionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtReturnExpression]
+ */
+class ReturnExpressionScope(
+  override val value: KtReturnExpression?,
+  val `return`: Scope<KtExpression> = Scope(value?.returnedExpression)
+) : Scope<KtReturnExpression>(value)


### PR DESCRIPTION
This PR introduces `KtReturnExpression` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtReturnExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element