### PR TITLE
Create annotated expression quote and its scope mapping

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -326,4 +326,7 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`return`: ReturnExpressionScope
     get() = ReturnExpressionScope(expression.value as KtReturnExpression)
+
+  override val String.annotatedExpression: AnnotatedExpressionScope
+    get() = AnnotatedExpressionScope(expression.value as KtAnnotatedExpression)
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -1,5 +1,6 @@
 package arrow.meta.phases.analysis
 
+import arrow.meta.quotes.AnnotatedExpressionScope
 import arrow.meta.quotes.BlockExpressionScope
 import arrow.meta.quotes.CatchClauseScope
 import arrow.meta.quotes.ClassScope
@@ -308,6 +309,8 @@ interface ElementScope {
   val String.`is`: IsExpressionScope
 
   val String.`return`: ReturnExpressionScope
+
+  val String.annotatedExpression: AnnotatedExpressionScope
 
   fun singleStatementBlock(
     statement: KtExpression,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/AnnotatedExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/AnnotatedExpression.kt
@@ -1,0 +1,49 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtAnnotatedExpression
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtExpression
+
+/**
+ * A [KtAnnotatedExpression] [Quote] with a custom template destructuring [AnnotatedExpressionScope]. See below:
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.annotatedExpression
+ *
+ * val Meta.reformatAnnotated: Plugin
+ *  get() =
+ *   "ReformatAnnotated" {
+ *    meta(
+ *     annotatedExpression({ true }) { e ->
+ *      Transform.replace(
+ *       replacing = e,
+ *       newDeclaration = """ $`@annotations` $expression """.annotatedExpression
+ *      )
+ *      }
+ *     )
+ *    }
+ * ```
+ *
+ * @param match designed to to feed in any kind of [KtAnnotatedExpression] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.annotatedExpression(
+  match: KtAnnotatedExpression.() -> Boolean,
+  map: AnnotatedExpressionScope.(KtAnnotatedExpression) -> Transform<KtAnnotatedExpression>
+): ExtensionPhase =
+  quote(match, map) { AnnotatedExpressionScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtAnnotatedExpression]
+ */
+class AnnotatedExpressionScope(
+  override val value: KtAnnotatedExpression?,
+  val `@annotations`: ScopedList<KtAnnotationEntry> = ScopedList(value?.annotationEntries ?: listOf()),
+  val expression: Scope<KtExpression> = Scope(value?.baseExpression)
+) : Scope<KtAnnotatedExpression>(value)


### PR DESCRIPTION
This PR introduces `KtAnnotatedExpression` quote and its scope mapping. This PR is related to https://github.com/arrow-kt/arrow-meta/issues/89

### Checklist for `KtAnnotatedExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element