### PR TITLE
[WIP] Add Functor API to ElementScope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -113,6 +113,21 @@ class DefaultElementScope(project: Project) : ElementScope {
       } else this
     }
 
+  override fun <A : KtElement, B : KtElement> Scope<A>.map(f: (A) -> B): Scope<B> =
+          value?.let { v ->
+            Scope(f(v))
+          }.orEmpty()
+
+  override fun <A : KtElement, B : KtElement> Scope<A>.`as`(b: B): Scope<B> =
+          map { b }
+
+  override fun <A : B, B : KtElement> Scope<A>.widen(): Scope<B> = this
+
+  override fun <A : KtElement, B : KtElement> Scope<A>.fold(b: B, f: (B, A) -> B): B =
+          value?.let { v ->
+            f(b, v)
+          } ?: b
+
   override fun property(modifiers: String?, name: String, type: String?, isVar: Boolean, initializer: String?): Scope<KtProperty> =
     Scope(delegate.createProperty(modifiers, name, type, isVar, initializer))
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -70,7 +70,7 @@ import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtValueArgumentList
 import org.jetbrains.kotlin.resolve.ImportPath
 
-interface ElementScope {
+interface ElementScope : ScopeSyntax {
   
   val valKeyword: PsiElement
   

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ScopeSyntax.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ScopeSyntax.kt
@@ -1,0 +1,27 @@
+package arrow.meta.phases.analysis
+
+import arrow.meta.quotes.Scope
+import org.jetbrains.kotlin.psi.KtElement
+
+interface ScopeSyntax {
+
+    /**
+     * Transform a scope of [A] into a scope of [B].
+     */
+    fun <A : KtElement, B : KtElement> Scope<A>.map(f: (A) -> B): Scope<B>
+
+    /**
+     * Replaces a value [A] of a scope with [B].
+     */
+    fun <A : KtElement, B : KtElement> Scope<A>.`as`(b: B): Scope<B>
+
+    /**
+     * Given [A] is a sub type of [B], re-type this value from Scope<A> to Scope<B>.
+     */
+    fun <A : B, B : KtElement> Scope<A>.widen(): Scope<B>
+
+    /**
+     * fold on Scope using the provided function f.
+     */
+    fun <A : KtElement, B : KtElement> Scope<A>.fold(b: B, f: (B, A) -> B): B
+}


### PR DESCRIPTION
#### WIP

re #161 

```
                    """println("Hello ΛRROW Meta!")"""
                                        .expression
                                        .map { exp ->
                                            """ fun ${this.name}(): Unit = ${exp.text}""".function.value
                                        }.synthetic
```

```
                    """private""".modifierList
                                        .fold(
                                                """ |fun helloWorld(): Unit =
                                                |  println("Hello ΛRROW Meta!")
                                                |""".function.value
                                        ) { acc, mod ->
                                            """ ${mod.text} fun ${acc.name}(): Unit =
                                                ${acc.bodyExpression?.text.orEmpty()}
                                            """.trimIndent().function.value
                                        }.scope()
                                        .synthetic
```