### PR TITLE
Modifier list quote and scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -165,14 +165,14 @@ class DefaultElementScope(project: Project) : ElementScope {
   override val String.secondaryConstructor: Scope<KtSecondaryConstructor>
     get() = Scope(delegate.createSecondaryConstructor(trimMargin()))
 
-  override fun modifierList(modifier: KtModifierKeywordToken): Scope<KtModifierList> =
-    Scope(delegate.createModifierList(modifier))
+  override fun modifierList(modifier: KtModifierKeywordToken): ModifierListScope =
+    ModifierListScope(delegate.createModifierList(modifier))
 
-  override val String.modifierList: Scope<KtModifierList>
-    get() = Scope(delegate.createModifierList(trimMargin()))
+  override val String.modifierList: ModifierListScope
+    get() = ModifierListScope(delegate.createModifierList(trimMargin()))
 
-  override val emptyModifierList: Scope<KtModifierList>
-    get() = Scope(delegate.createEmptyModifierList())
+  override val emptyModifierList: ModifierListScope
+    get() = ModifierListScope(delegate.createEmptyModifierList())
 
   override fun modifier(modifier: KtModifierKeywordToken): PsiElement =
     delegate.createModifier(modifier)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -8,6 +8,7 @@ import arrow.meta.quotes.FinallySectionScope
 import arrow.meta.quotes.ForExpressionScope
 import arrow.meta.quotes.IfExpressionScope
 import arrow.meta.quotes.IsExpressionScope
+import arrow.meta.quotes.ModifierListScope
 import arrow.meta.quotes.NamedFunctionScope
 import arrow.meta.quotes.ParameterScope
 import arrow.meta.quotes.ReturnExpressionScope
@@ -42,7 +43,6 @@ import org.jetbrains.kotlin.psi.KtInitializerList
 import org.jetbrains.kotlin.psi.KtLabeledExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
-import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtParameterList
@@ -195,11 +195,11 @@ interface ElementScope {
   
   val String.secondaryConstructor: Scope<KtSecondaryConstructor>
   
-  fun modifierList(modifier: KtModifierKeywordToken): Scope<KtModifierList>
+  fun modifierList(modifier: KtModifierKeywordToken): ModifierListScope
   
-  val String.modifierList: Scope<KtModifierList>
+  val String.modifierList: ModifierListScope
   
-  val emptyModifierList: Scope<KtModifierList>
+  val emptyModifierList: ModifierListScope
   
   fun modifier(modifier: KtModifierKeywordToken): PsiElement
   

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ModifierList.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ModifierList.kt
@@ -31,7 +31,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifier
  *  }
  *```
  *
- * * @param match designed to to feed in any kind of [KtModifierList] predicate returning a [Boolean]
+ * @param match designed to to feed in any kind of [KtModifierList] predicate returning a [Boolean]
  * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
  */
 fun Meta.modifierList(

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ModifierList.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ModifierList.kt
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifier
  *    modifierList({ true }) { l ->
  *     Transform.replace(
  *      replacing = l,
- *      newDeclaration = """ $`@annotations` $modifier value """.`if`
+ *      newDeclaration = """ $`@annotations` $modifier value """.`modifierList`
  *     )
  *    }
  *   )

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ModifierList.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ModifierList.kt
@@ -1,0 +1,50 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtAnnotationEntry
+import org.jetbrains.kotlin.psi.KtModifierList
+import org.jetbrains.kotlin.psi.psiUtil.visibilityModifier
+
+/**
+ * A [KtModifierList] [Quote] with a custom template destructuring [ModifierListScope].  See below:
+ *
+ *```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.modifierList
+ *
+ * val Meta.reformatModifier: Plugin
+ *  get() =
+ *  "ReformatModifier" {
+ *   meta(
+ *    modifierList({ true }) { l ->
+ *     Transform.replace(
+ *      replacing = l,
+ *      newDeclaration = """ $`@annotations` $modifier value """.`if`
+ *     )
+ *    }
+ *   )
+ *  }
+ *```
+ *
+ * * @param match designed to to feed in any kind of [KtModifierList] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.modifierList(
+  match: KtModifierList.() -> Boolean,
+  map: ModifierListScope.(KtModifierList) -> Transform<KtModifierList>
+): ExtensionPhase =
+  quote(match, map) { ModifierListScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtModifierList]
+ */
+class ModifierListScope(
+  override val value: KtModifierList?,
+  val `@annotations`: ScopedList<KtAnnotationEntry> = ScopedList(value?.annotationEntries ?: listOf()),
+  val modifier: PsiElement? = value?.visibilityModifier()
+) : Scope<KtModifierList>(value)


### PR DESCRIPTION
This PR introduces `KtModifierList` quote and its scope mapping. This PR is related to #89 

### Checklist for `KtModifierList`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element