### PR TITLE
Parameter list quote and scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -195,8 +195,8 @@ class DefaultElementScope(project: Project) : ElementScope {
   override val String.loopParameter: ParameterScope
     get() = ParameterScope(delegate.createLoopParameter(trimMargin()))
 
-  override val String.parameterList: Scope<KtParameterList>
-    get() = Scope(delegate.createParameterList(trimMargin()))
+  override val String.parameterList: ParameterListScope
+    get() = ParameterListScope(delegate.createParameterList(trimMargin()))
 
   override val String.typeParameterList: Scope<KtTypeParameterList>
     get() = Scope(delegate.createTypeParameterList(trimMargin()))
@@ -204,11 +204,11 @@ class DefaultElementScope(project: Project) : ElementScope {
   override val String.typeParameter: Scope<KtTypeParameter>
     get() = Scope(delegate.createTypeParameter(trimMargin()))
 
-  override val String.lambdaParameterListIfAny: Scope<KtParameterList>
-    get() = Scope(delegate.createLambdaParameterList(trimMargin()))
+  override val String.lambdaParameterListIfAny: ParameterListScope
+    get() = ParameterListScope(delegate.createLambdaParameterList(trimMargin()))
 
-  override val String.lambdaParameterList: Scope<KtParameterList>
-    get() = Scope(delegate.createLambdaParameterList(trimMargin()))
+  override val String.lambdaParameterList: ParameterListScope
+    get() = ParameterListScope(delegate.createLambdaParameterList(trimMargin()))
 
   override fun lambdaExpression(parameters: String, body: String): Scope<KtLambdaExpression> =
     Scope(delegate.createLambdaExpression(parameters, body))

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -9,6 +9,7 @@ import arrow.meta.quotes.ForExpressionScope
 import arrow.meta.quotes.IfExpressionScope
 import arrow.meta.quotes.IsExpressionScope
 import arrow.meta.quotes.NamedFunctionScope
+import arrow.meta.quotes.ParameterListScope
 import arrow.meta.quotes.ParameterScope
 import arrow.meta.quotes.ReturnExpressionScope
 import arrow.meta.quotes.Scope
@@ -45,7 +46,6 @@ import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtModifierList
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtPackageDirective
-import org.jetbrains.kotlin.psi.KtParameterList
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtPropertyAccessor
@@ -215,15 +215,15 @@ interface ElementScope {
   
   val String.loopParameter: ParameterScope
   
-  val String.parameterList: Scope<KtParameterList>
+  val String.parameterList: ParameterListScope
   
   val String.typeParameterList: Scope<KtTypeParameterList>
   
   val String.typeParameter: Scope<KtTypeParameter>
   
-  val String.lambdaParameterListIfAny: Scope<KtParameterList>
+  val String.lambdaParameterListIfAny: ParameterListScope
   
-  val String.lambdaParameterList: Scope<KtParameterList>
+  val String.lambdaParameterList: ParameterListScope
   
   fun lambdaExpression(
     parameters: String,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ParameterList.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ParameterList.kt
@@ -1,0 +1,47 @@
+package arrow.meta.quotes
+
+import arrow.meta.Meta
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtParameterList
+
+/**
+ * A [KtParameterList] [Quote] with a custom template destructuring [ParameterListScope]. See below:
+ *
+ *```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.parameterList
+ *
+ * val Meta.reformatParameterList: Plugin
+ *  get() =
+ *  "ReformatParameterList" {
+ *   meta(
+ *    parameterList({ true }) { l ->
+ *     Transform.replace(
+ *      replacing = l,
+ *      newDeclaration = """ $`(params)` """.parameterList
+ *     )
+ *    }
+ *   )
+ *  }
+ *```
+ *
+ * * @param match designed to to feed in any kind of [KtParameterList] predicate returning a [Boolean]
+ * @param map map a function that maps over the resulting action from matching on the transformation at the PSI level.
+ */
+fun Meta.parameterList(
+  match: KtParameterList.() -> Boolean,
+  map: ParameterListScope.(KtParameterList) -> Transform<KtParameterList>
+): ExtensionPhase =
+  quote(match, map) { ParameterListScope(it) }
+
+/**
+ * A template destructuring [Scope] for a [KtParameterList]
+ */
+class ParameterListScope(
+  override val value: KtParameterList?,
+  val `(params)`: ScopedList<KtParameter> = ScopedList(value?.parameters ?: listOf())
+) : Scope<KtParameterList>(value)


### PR DESCRIPTION
This PR introduces `KtParameterList` quote and its scope mapping. This PR is related to #89 

### Checklist for `KtParameterList`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element