### PR TITLE
testing-plugin: allow to test Meta plugins

### DIFF
--- a/testing-plugin/build.gradle
+++ b/testing-plugin/build.gradle
@@ -5,7 +5,6 @@ dependencies {
 
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION"
     compileOnly "io.github.classgraph:classgraph:$CLASS_GRAPH_VERSION"
-    compileOnly project(':compiler-plugin')
 
     implementation "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     implementation "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable:$KOTLIN_VERSION"
@@ -16,6 +15,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib-jdk8"
     }
     implementation "org.assertj:assertj-core:$ASSERTJ_VERSION"
+    implementation project(':compiler-plugin')
 
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$KOTLIN_TEST_VERSION"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION"

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
@@ -14,6 +14,7 @@ internal fun compile(data: CompilationData): Result =
     sources = data.sources.map { SourceFile.kotlin(it.filename, it.text.trimMargin()) }
     classpaths = data.dependencies.map { classpathOf(it) }
     pluginClasspaths = data.compilerPlugins.map { classpathOf(it) }
+    compilerPlugins = data.metaPlugins
   }.compile()
 
 private fun classpathOf(dependency: String): File {

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilationAssertions.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilationAssertions.kt
@@ -53,9 +53,9 @@ private val interpreter: (CompilerTest) -> Unit = {
         when (config) {
           is Config.AddCompilerPlugins -> remaining.compilationData(acc.addCompilerPlugins(config))
           is Config.AddDependencies -> remaining.compilationData(acc.addDependencies(config))
+          is Config.AddMetaPlugins -> remaining.compilationData(acc.addMetaPlugins(config))
           is Config.Many -> (config.configs + remaining).compilationData(acc)
           Config.Empty -> remaining.compilationData(acc)
-          is Config.AddMetaPlugins -> TODO("How do we bootstrap the Meta Plugin Quote system?")
         }
       }
     }
@@ -92,6 +92,9 @@ private fun CompilationData.addDependencies(config: Config.AddDependencies) =
 
 private fun CompilationData.addCompilerPlugins(config: Config.AddCompilerPlugins) =
   copy(compilerPlugins = compilerPlugins + config.plugins.flatMap { it.dependencies.map { it.mavenCoordinates } })
+
+private fun CompilationData.addMetaPlugins(config: Config.AddMetaPlugins) =
+  copy(metaPlugins = metaPlugins + config.plugins)
 
 private fun assertEvalsTo(compilationResult: Result, source: Code.Source, output: Any?) {
   assertCompiles(compilationResult)

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilationData.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilationData.kt
@@ -1,11 +1,14 @@
 package arrow.meta.plugin.testing
 
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+
 /**
  * Compilation data is a Monoid that can accumulate in its element as it's
  * composed and merged with other CompilationData elements
  */
 internal data class CompilationData(
   val compilerPlugins: List<String> = emptyList(),
+  val metaPlugins: List<ComponentRegistrar> = emptyList(),
   val dependencies: List<String> = emptyList(),
   val sources: List<Code.Source> = emptyList()
 ) {

--- a/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/testing-plugin/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -1,5 +1,6 @@
 package arrow.meta.plugin.testing
 
+import arrow.meta.Meta
 import arrow.meta.Plugin
 
 /**
@@ -74,7 +75,7 @@ interface ConfigSyntax {
   /**
    * Adds the Meta Plugins to run the compilation.
    */
-  fun addMetaPlugins(vararg element: Plugin): Config =
+  fun addMetaPlugins(vararg element: Meta): Config =
     Config.Many(listOf(Config.AddMetaPlugins(element.toList())))
 
   /**
@@ -108,7 +109,7 @@ interface ConfigSyntax {
  */
 sealed class Config {
   internal data class AddCompilerPlugins(val plugins: List<CompilerPlugin>) : Config()
-  internal data class AddMetaPlugins(val plugins: List<Plugin>) : Config()
+  internal data class AddMetaPlugins(val plugins: List<Meta>) : Config()
   internal data class AddDependencies(val dependencies: List<Dependency>) : Config()
   internal data class Many(val configs: List<Config>) : Config()
   internal object Empty : Config()

--- a/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/ExampleTest.kt
+++ b/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/ExampleTest.kt
@@ -1,6 +1,7 @@
 package arrow.meta.plugin.testing
 
 import arrow.meta.plugin.testing.Code.Source
+import arrow.meta.plugin.testing.plugins.MetaPlugin
 import org.junit.Test
 
 class ExampleTest {
@@ -132,6 +133,24 @@ class ExampleTest {
       },
       assert = {
         allOf(compiles)
+      }
+    ))
+  }
+
+  @Test
+  fun `allows to test a Meta plugin`() {
+    assertThis(CompilerTest(
+      config = { metaDependencies + addMetaPlugins(MetaPlugin()) },
+      code = {
+          """
+          | //metadebug
+          | 
+          | fun helloWorld(): String = TODO()
+          | 
+          """.source
+      },
+      assert = {
+        allOf("helloWorld()".source.evalsTo("Hello ΛRROW Meta!"))
       }
     ))
   }

--- a/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/plugins/HelloWorldPlugin.kt
+++ b/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/plugins/HelloWorldPlugin.kt
@@ -1,0 +1,25 @@
+package arrow.meta.plugin.testing.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.invoke
+import arrow.meta.quotes.Transform
+import arrow.meta.quotes.namedFunction
+
+val Meta.helloWorld: Plugin
+  get() =
+    "Hello World" {
+      meta(
+        namedFunction({ name == "helloWorld" }) { c ->
+          Transform.replace(
+            replacing = c,
+            newDeclaration =
+            """| 
+               | fun helloWorld(): String = 
+               |   "Hello ΛRROW Meta!"
+               |   
+               |""".function.synthetic
+          )
+        }
+      )
+    }

--- a/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/plugins/MetaPlugin.kt
+++ b/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/plugins/MetaPlugin.kt
@@ -1,0 +1,14 @@
+package arrow.meta.plugin.testing.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.phases.CompilerContext
+import kotlin.contracts.ExperimentalContracts
+
+open class MetaPlugin : Meta {
+    @ExperimentalContracts
+    override fun intercept(ctx: CompilerContext): List<Plugin> =
+        listOf(
+            helloWorld
+        )
+}


### PR DESCRIPTION
**Note**: I didn't find a way to provide `Plugin` but `Meta` (the plugin is defined under `Meta` and I couldn't add a reference to the created plugin without being inside a class which extends `Meta`).