### PR TITLE
Tests reorganization (Marie Kondo’s style :D)

### DIFF
--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -8,6 +8,7 @@ dependencies {
     compileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     compileOnly "com.intellij:openapi:$OPENAPI_VERSION"
 
+    testCompileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$KOTLIN_TEST_VERSION"
     testImplementation project(":testing-plugin")
     testRuntimeOnly project(':compiler-plugin')

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformRemoveTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformRemoveTest.kt
@@ -1,6 +1,8 @@
-package arrow.meta.plugin.testing
+package arrow.meta.quotes.transform
 
-import arrow.meta.plugin.testing.plugins.MetaPlugin
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.transform.plugins.TransformMetaPlugin
 import org.junit.Test
 
 class TransformRemoveTest {
@@ -8,7 +10,7 @@ class TransformRemoveTest {
   @Test
   fun `check if transformRemove function is deleted from AST`() {
       assertThis(CompilerTest(
-        config = { metaDependencies + addMetaPlugins(MetaPlugin()) },
+        config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
         code = {
           """
           | //metadebug
@@ -24,7 +26,7 @@ class TransformRemoveTest {
   @Test
   fun `check if the element of transformRemoveSingleElement function is deleted from AST`() {
     assertThis(CompilerTest(
-      config = { metaDependencies + addMetaPlugins(MetaPlugin()) },
+      config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
       code = {
         """
         | //metadebug
@@ -42,7 +44,7 @@ class TransformRemoveTest {
   @Test
   fun `check if the elements of transformRemoveElements function are deleted from AST`() {
     assertThis(CompilerTest(
-      config = { metaDependencies + addMetaPlugins(MetaPlugin()) },
+      config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
       code = {
         """
         | //metadebug

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformReplaceTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformReplaceTest.kt
@@ -1,6 +1,8 @@
-package arrow.meta.plugin.testing
+package arrow.meta.quotes.transform
 
-import arrow.meta.plugin.testing.plugins.MetaPlugin
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.transform.plugins.TransformMetaPlugin
 import org.junit.Test
 
 class TransformReplaceTest {
@@ -8,7 +10,7 @@ class TransformReplaceTest {
   @Test
   fun `should replace function scope to print message`() {
     assertThis(CompilerTest(
-      config = { metaDependencies + addMetaPlugins(MetaPlugin()) },
+      config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
       code = {
         """
 	  | //metadebug
@@ -23,7 +25,7 @@ class TransformReplaceTest {
   @Test
   fun `check if extra function is generated`() {
     assertThis(CompilerTest(
-      config = { metaDependencies + addMetaPlugins(MetaPlugin()) },
+      config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
 	code = {
 	  """
 	    | //metadebug

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformMetaPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformMetaPlugin.kt
@@ -1,0 +1,14 @@
+package arrow.meta.quotes.transform.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.phases.CompilerContext
+import kotlin.contracts.ExperimentalContracts
+
+open class TransformMetaPlugin : Meta {
+  @ExperimentalContracts
+  override fun intercept(ctx: CompilerContext): List<Plugin> = (
+    transformRemove
+      + transformReplace
+    )
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformRemovePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformRemovePlugin.kt
@@ -1,4 +1,4 @@
-package arrow.meta.plugin.testing.plugins.transform
+package arrow.meta.quotes.transform.plugins
 
 import arrow.meta.Meta
 import arrow.meta.Plugin

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformReplacePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformReplacePlugin.kt
@@ -1,4 +1,4 @@
-package arrow.meta.plugin.testing.plugins.transform
+package arrow.meta.quotes.transform.plugins
 
 import arrow.meta.Meta
 import arrow.meta.Plugin

--- a/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/plugins/MetaPlugin.kt
+++ b/testing-plugin/src/test/kotlin/arrow/meta/plugin/testing/plugins/MetaPlugin.kt
@@ -3,15 +3,12 @@ package arrow.meta.plugin.testing.plugins
 import arrow.meta.Meta
 import arrow.meta.Plugin
 import arrow.meta.phases.CompilerContext
-import arrow.meta.plugin.testing.plugins.transform.transformRemove
-import arrow.meta.plugin.testing.plugins.transform.transformReplace
 import kotlin.contracts.ExperimentalContracts
 
 open class MetaPlugin : Meta {
-    @ExperimentalContracts
-    override fun intercept(ctx: CompilerContext): List<Plugin> = (
-        transformRemove
-        + transformReplace
-        + helloWorld
+  @ExperimentalContracts
+  override fun intercept(ctx: CompilerContext): List<Plugin> =
+    listOf(
+      helloWorld
     )
 }


### PR DESCRIPTION
## Reason

Keep `testing-plugin` just with examples about how to write tests.

## Changes
- Move tests about `Transform` quote from `testing-plugin` to `compiler-plugin`
- Add a new `TransformMetaPlugin` for it.
- Add a missing dependency in `compiler-plugin` to compile the new tests.

## Structure

```
compiler-plugin/src/test/kotlin/arrow/meta/
├── plugins
│   ├── comprehensions
│   │   └── ComprehensionsTest.kt
│   ├── higherkind
│   │   └── HigherkindTest.kt
│   ├── lens
│   │   └── LensTest.kt
│   ├── typeclasses
│   │   └── TypeClassesTest.kt
│   └── union
│       └── UnionTest.kt
└── quotes
    └── transform
        ├── plugins
        │   ├── TransformMetaPlugin.kt
        │   ├── TransformRemovePlugin.kt
        │   └── TransformReplacePlugin.kt
        ├── TransformRemoveTest.kt
        └── TransformReplaceTest.kt
```

## Acknowledgments

Thanks @bloderxd again for these new tests!!