### PR TITLE
Fix repositories for Kotlin EAP versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
   repositories {
     mavenCentral()
     maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
-    maven { url "https://dl.bintray.com/kotlin/kotlin-dev/" }
+    maven { url "https://dl.bintray.com/kotlin/kotlin-eap/" }
   }
   dependencies {
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:$DOKKA_VERSION"
@@ -43,7 +43,7 @@ allprojects {
     mavenCentral()
     jcenter()
     maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-dev/' }
+    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap/' }
   }
 }
 


### PR DESCRIPTION
This is not related to #236 but I found this inconsistency which can cause problems.