### PR TITLE
Temporary change: disable Gradle plugin publication

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -55,4 +55,4 @@ jobs:
         echo "Checking if version ends with SNAPSHOT to add a commit hash ..."
         echo $ACTUAL_VERSION | grep SNAPSHOT; if [[ $? -eq 0 ]]; then sed -i "s/^version = .*$/version = '$VERSION_NUMBER-$NEXT_COUNT-$LAST_COMMIT_HASH'/g" gradle-plugin/build.gradle; fi
         echo "Publish artifact ..."
-        ./gradlew -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET publishPlugins
+        #./gradlew -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET publishPlugins


### PR DESCRIPTION
Versions with more than one week cannot be deleted from Gradle Plugin Portal and our request to delete them hasn't been done.

This pull request disables the publication until old versions are deleted (we have a wrong latest version now and the new versions don't follow the right latest version).