### PR TITLE
Create test to object declaration scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -93,12 +93,12 @@ class DefaultElementScope(project: Project) : ElementScope {
     get() = delegate.createNewLine()
   override val String.`class`: ClassDeclaration
     get() = ClassDeclaration(delegate.createClass(trimMargin()))
-  override val String.`object`: Scope<KtObjectDeclaration>
-    get() = Scope(delegate.createObject(trimMargin()))
-  override val companionObject: Scope<KtObjectDeclaration>
-    get() = Scope(delegate.createCompanionObject())
-  override val String.companionObject: Scope<KtObjectDeclaration>
-    get() = Scope(delegate.createCompanionObject(trimMargin()))
+  override val String.`object`: ObjectDeclaration
+    get() = ObjectDeclaration(delegate.createObject(trimMargin()))
+  override val companionObject: ObjectDeclaration
+    get() = ObjectDeclaration(delegate.createCompanionObject())
+  override val String.companionObject: ObjectDeclaration
+    get() = ObjectDeclaration(delegate.createCompanionObject(trimMargin()))
 
   override val <A : KtDeclaration> Scope<A>.synthetic: Scope<A>
     get() {

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -11,6 +11,7 @@ import arrow.meta.quotes.ImportDirective
 import arrow.meta.quotes.IsExpression
 import arrow.meta.quotes.ModifierList
 import arrow.meta.quotes.NamedFunction
+import arrow.meta.quotes.ObjectDeclaration
 import arrow.meta.quotes.ParameterList
 import arrow.meta.quotes.Parameter
 import arrow.meta.quotes.ReturnExpression
@@ -45,7 +46,6 @@ import org.jetbrains.kotlin.psi.KtInitializerList
 import org.jetbrains.kotlin.psi.KtLabeledExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
-import org.jetbrains.kotlin.psi.KtObjectDeclaration
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtProperty
@@ -136,11 +136,11 @@ interface ElementScope {
   
   val String.`class`: ClassDeclaration
   
-  val String.`object`: Scope<KtObjectDeclaration>
+  val String.`object`: ObjectDeclaration
   
-  val companionObject: Scope<KtObjectDeclaration>
+  val companionObject: ObjectDeclaration
   
-  val String.companionObject: Scope<KtObjectDeclaration>
+  val String.companionObject: ObjectDeclaration
 
   val <A: KtDeclaration> Scope<A>.synthetic: Scope<A>
   

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ObjectDeclaration.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ObjectDeclaration.kt
@@ -21,6 +21,5 @@ fun Meta.objectDeclaration(
  * A template destructuring [Scope] for a [KtObjectDeclaration]
  */
 class ObjectDeclaration(
-  override val value: KtObjectDeclaration,
-  val textOffset: Int = value.textOffset
+  override val value: KtObjectDeclaration
 ): ClassOrObjectScope<KtObjectDeclaration>(value)

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/ObjectDeclarationTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/ObjectDeclarationTest.kt
@@ -1,0 +1,26 @@
+package arrow.meta.quotes.scope
+
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.CompilerTest.Companion.source
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.ScopeMetaPlugin
+import org.junit.Test
+
+class ObjectDeclarationTest {
+  
+  private val `object` = """
+                         | //metadebug
+                         | @Deprecated("Test") object Test {
+                         |   fun test() { println("Test") }
+                         |   fun test2() { println("Test2") }
+                         | }""".source
+  
+  @Test
+  fun `validate object declaration scope properties`() {
+    assertThis(CompilerTest(
+      config = { metaDependencies + addMetaPlugins(ScopeMetaPlugin()) },
+      code = { `object` },
+      assert = { quoteOutputMatches(`object`) }
+    ))
+  }
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ObjectDeclarationPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ObjectDeclarationPlugin.kt
@@ -1,0 +1,22 @@
+package arrow.meta.quotes.scope.plugins
+
+import arrow.meta.Meta
+import arrow.meta.invoke
+import arrow.meta.quotes.Transform
+import arrow.meta.quotes.objectDeclaration
+
+val Meta.objectDeclarationPlugin
+  get() = "Object Declaration Scope Plugin" {
+    meta(
+      objectDeclaration({ name == "Test" }) { declaration ->
+        Transform.replace(
+          replacing = declaration,
+          newDeclaration =
+          """
+          | $`@annotations` object $name ${superTypeList?.let { ": ${it.text}" } ?: ""} {
+          |   $body
+          | }
+          | """.`object`)
+      }
+    )
+  }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ScopeMetaPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ScopeMetaPlugin.kt
@@ -1,0 +1,13 @@
+package arrow.meta.quotes.scope.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.phases.CompilerContext
+import arrow.meta.quotes.scope.plugins.objectDeclarationPlugin
+
+open class ScopeMetaPlugin : Meta {
+  
+  override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
+    objectDeclarationPlugin
+  )
+}


### PR DESCRIPTION
This PR proposes the creation of tests to scopes starting with `ObjectDeclaration`, these tests could help on documentation building since we can get all scope property informations that we need.