### PR TITLE
Updating two links in the sidebar menu

### DIFF
--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -11,7 +11,7 @@ options:
         url: /docs/apidocs/compiler-plugin/arrow.meta.plugins.hello-world/hello-world.html
 
       - title: Hello World IntelliJ IDEA
-        url: /docs/apidocs/idea-plugin/arrow.meta.ide.plugins.nothing/nothing-ide-plugin.html
+        url: /docs/apidocs/idea-plugin/arrow.meta.ide.plugins.helloworld/hello-world.html
 
   - title: Quotes
 

--- a/docs/_includes/_sidebar.html
+++ b/docs/_includes/_sidebar.html
@@ -5,7 +5,7 @@
     </button>
   </div>
   <div class="sidebar-brand">
-    <a href="{{ site.arrow_url }}">
+    <a href="https://meta.arrow-kt.io">
       <img src="{{ '/img/arrow-meta-brand-sidebar.svg' | relative_url }}" alt="Arrow Meta">
     </a>
   </div>


### PR DESCRIPTION
It updates the link of the Arrow Meta logo to point out to `https://meta.arrow-kt.io`. Additionally, it changes the URL of the `Hello World` IntelliJ IDEA section.