### PR TITLE
Fixes sidebar deploy when clicking over the icon

### DIFF
--- a/docs/_sass/components/_sidebar-menu.scss
+++ b/docs/_sass/components/_sidebar-menu.scss
@@ -52,6 +52,7 @@
             font-size: 18px;
             transition: all .3s;
             -moz-osx-font-smoothing: unset;
+            pointer-events: none;
       }
     }
 


### PR DESCRIPTION
Adding the `pointer-events: none` property, fixes the sidebar collapse behavior when clicking over the icon.