### PR TITLE
Adding media wrapper for videos

### DIFF
--- a/docs/_includes/_media-wrapper.html
+++ b/docs/_includes/_media-wrapper.html
@@ -1,0 +1,16 @@
+<a class="button-video">
+    <i class="fa fa-youtube-play"></i> Watch video
+</a>
+
+<div id="video-panel" class="video-panel">
+    <h2><i class="fa fa-video-camera"></i> Video</h2>
+    <div class="bg-video">
+        <div class="wrapper-video">
+            <div class="video-container">
+                <iframe width="560" height="315"
+                        src="https://www.youtube-nocookie.com/embed/{{ include.id }}?rel=0&amp;showinfo=1"
+                        frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
+            </div>
+        </div>
+    </div>
+</div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,7 @@
 layout: docs
 title: Quick Start
 permalink: /
+video: WKR384ZeBgk
 ---
 
 [![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Farrow-meta-compiler-plugin%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-compiler-plugin/)
@@ -16,8 +17,6 @@ permalink: /
 Λrrow Meta is a meta-programming library that cooperates with the Kotlin compiler in all it's phases bringing its full power to the community.
 
 Writing compiler plugins, source transformations, IDEA plugins, linters, type search engines, automatic code refactoring,... are just a few of the use cases of the things that can be accomplished with Meta.
-
-<iframe title="Lambda World 2019 - Arrow Meta - Enabling Functional Programming in the Kotlin Compiler" style="width:560px; height:315px !important" src="https://www.youtube.com/embed/WKR384ZeBgk" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 ## Λrrow Meta examples
 


### PR DESCRIPTION
This pull request adds a media wrapper to the main page of Arrow meta site to be able of show/hide the video of the Lambda World talk.