### PR TITLE
FunctionLiteral Quote and Template Scope Testing Validation

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -58,12 +58,12 @@ import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtExpressionCodeFragment
 import org.jetbrains.kotlin.psi.KtForExpression
-import org.jetbrains.kotlin.psi.KtFunctionLiteral
 import org.jetbrains.kotlin.psi.KtFunctionTypeReceiver
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtInitializerList
 import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtLabeledExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
@@ -434,9 +434,10 @@ class DefaultElementScope(project: Project) : ElementScope {
     get() = AnnotatedExpression(expression.value as KtAnnotatedExpression)
 
   override val String.functionLiteral: FunctionLiteral
-    get() = FunctionLiteral(expression.value as KtFunctionLiteral)
+    get() = FunctionLiteral((expression.value as KtLambdaExpression).functionLiteral)
   
   override val String.classBody: ClassBody
     get() = ClassBody(delegate.createClass("class _ClassBodyScopeArrowMeta ${trimMargin()}").body)
+
 }
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/FunctionLiteral.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/FunctionLiteral.kt
@@ -49,4 +49,4 @@ class FunctionLiteral(
   override val value: KtFunctionLiteral,
   val name: Name? = value.nameAsName,
   val blockExpression: BlockExpression = BlockExpression(value.bodyBlockExpression)
-) : Scope<KtFunctionLiteral>(value)
+) : FunctionNotStubbed<KtFunctionLiteral>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/FunctionLiteral.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/FunctionLiteral.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
 // TODO: [KtTypeParameterListOwnerNotStubbed] is deprecated - rename package to JetTypeParameterListOwner when fully deprecated
 
 /**
- * <code>""" val $name = { $blockExpression }""".functionLiteral</code>
+ * <code>"""val $name = {$blockExpression}"""</code>
  *
  * A template destructuring [Scope] for a [KtFunctionLiteral].
  *
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
  *     functionLiteral({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """ val $name = { $blockExpression }""".functionLiteral
+ *       newDeclaration = """val $name = {$blockExpression}""".functionLiteral
  *      )
  *      }
  *     )

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/FunctionLiteral.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/FunctionLiteral.kt
@@ -8,7 +8,7 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
 // TODO: [KtTypeParameterListOwnerNotStubbed] is deprecated - rename package to JetTypeParameterListOwner when fully deprecated
 
 /**
- * <code>"""val $name = {$blockExpression}"""</code>
+ * <code>"""{$`(params)`$blockExpression}""".functionLiteral</code>
  *
  * A template destructuring [Scope] for a [KtFunctionLiteral].
  *
@@ -26,7 +26,7 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
  *     functionLiteral({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """val $name = {$blockExpression}""".functionLiteral
+ *       newDeclaration = """{$`(params)`$blockExpression}""".functionLiteral
  *      )
  *      }
  *     )
@@ -40,7 +40,7 @@ import org.jetbrains.kotlin.psi.KtFunctionLiteral
  * val increment: (Int) -> Unit = { x -> x + 1 }
  * ```
  *  #### Anonymous function
- *  An anonynous function is just another way to define a function:
+ *  An anonymous function is just another way to define a function:
  * ```kotlin:ank:silent
  * val increment: (Int) -> Unit = fun(x) { x + 1 }
  * ```

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/KtFunctionNotStubbed.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/KtFunctionNotStubbed.kt
@@ -1,0 +1,18 @@
+package arrow.meta.quotes.nameddeclaration.notstubbed
+
+import arrow.meta.quotes.Scope
+import arrow.meta.quotes.ScopedList
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtFunctionNotStubbed
+import org.jetbrains.kotlin.psi.KtParameter
+import org.jetbrains.kotlin.psi.KtTypeReference
+
+/**
+ * A template destructuring [Scope] for a [KtFunctionNotStubbed]
+ */
+open class FunctionNotStubbed<out T: KtFunctionNotStubbed>(
+  override val value: T,
+  val `(params)`: ScopedList<KtParameter> = ScopedList(value = value.valueParameters, postfix = " -> "),
+  val bodyExpression: Scope<KtExpression> = Scope(value.bodyExpression),
+  val returnType: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.typeReference), prefix = " : ")
+  ) : Scope<T>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/KtFunctionNotStubbed.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/notstubbed/KtFunctionNotStubbed.kt
@@ -5,7 +5,6 @@ import arrow.meta.quotes.ScopedList
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtFunctionNotStubbed
 import org.jetbrains.kotlin.psi.KtParameter
-import org.jetbrains.kotlin.psi.KtTypeReference
 
 /**
  * A template destructuring [Scope] for a [KtFunctionNotStubbed]
@@ -13,6 +12,5 @@ import org.jetbrains.kotlin.psi.KtTypeReference
 open class FunctionNotStubbed<out T: KtFunctionNotStubbed>(
   override val value: T,
   val `(params)`: ScopedList<KtParameter> = ScopedList(value = value.valueParameters, postfix = " -> "),
-  val bodyExpression: Scope<KtExpression> = Scope(value.bodyExpression),
-  val returnType: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.typeReference), prefix = " : ")
+  val bodyExpression: Scope<KtExpression> = Scope(value.bodyExpression)
   ) : Scope<T>(value)

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
@@ -19,7 +19,7 @@ class FunctionLiteralTest : AnnotationSpec() {
 
   @Test
   fun `Validate function literal as an anonymous function`() {
-    // TODO
+    validate("""val increment: (Int) -> Unit = fun(x) { x + 1 }""".functionLiteral())
   }
 
   @Test
@@ -31,7 +31,7 @@ class FunctionLiteralTest : AnnotationSpec() {
     assertThis(CompilerTest(
       config = { listOf(addMetaPlugins(FunctionLiteralPlugin())) },
       code = { source },
-      assert = { compiles } //quoteOutputMatches(source) }
+      assert = { quoteOutputMatches(source) }
     ))
   }
 

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
@@ -1,0 +1,55 @@
+package arrow.meta.quotes.scope
+
+import arrow.meta.plugin.testing.Code
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.CompilerTest.Companion.source
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.FunctionLiteralPlugin
+import org.junit.Test
+
+/**
+ * Function Literals are a little unclear - see more here: https://kotlinlang.org/docs/reference/lambdas.html
+ */
+class FunctionLiteralTest {
+
+  @Test
+  fun `Validate function literal scope properties`() {
+    validate("""val a = { i: Int -> i + 1 }""".functionLiteral())
+  }
+
+  @Test
+  fun `Validate function literal as an anonymous function`() {
+    // TODO
+  }
+
+  @Test
+  fun `Validate function literal as a lambda expression`() {
+    validate("""val sum: (Int, Int) -> Int = { x: Int, y: Int -> x + y }""".functionLiteral())
+  }
+
+  private fun validate(source: Code.Source) {
+    assertThis(CompilerTest(
+      config = { listOf(addMetaPlugins(FunctionLiteralPlugin())) },
+      code = { source },
+      assert = { compiles } //quoteOutputMatches(source) }
+    ))
+  }
+
+  private fun String.functionLiteral(): Code.Source {
+    return """
+      | //metadebug
+      | 
+      | class Wrapper {
+      |   fun whatever() {
+      |    $this
+      |   }
+      |  }
+      | """.trimMargin().trim().source
+  }
+}
+
+class Wrapper {
+  fun whatever() {
+    val a = { i: Int -> i + 1 }
+  }
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
@@ -7,9 +7,6 @@ import arrow.meta.plugin.testing.assertThis
 import arrow.meta.quotes.scope.plugins.FunctionLiteralPlugin
 import io.kotlintest.specs.AnnotationSpec
 
-/**
- * Function Literals are a little unclear - see more here: https://kotlinlang.org/docs/reference/lambdas.html
- */
 class FunctionLiteralTest : AnnotationSpec() {
 
   @Test
@@ -45,11 +42,5 @@ class FunctionLiteralTest : AnnotationSpec() {
       |   }
       |  }
       | """.trimMargin().trim().source
-  }
-}
-
-class Wrapper {
-  fun whatever() {
-    val a = { i: Int -> i + 1 }
   }
 }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/FunctionLiteralTest.kt
@@ -5,12 +5,12 @@ import arrow.meta.plugin.testing.CompilerTest
 import arrow.meta.plugin.testing.CompilerTest.Companion.source
 import arrow.meta.plugin.testing.assertThis
 import arrow.meta.quotes.scope.plugins.FunctionLiteralPlugin
-import org.junit.Test
+import io.kotlintest.specs.AnnotationSpec
 
 /**
  * Function Literals are a little unclear - see more here: https://kotlinlang.org/docs/reference/lambdas.html
  */
-class FunctionLiteralTest {
+class FunctionLiteralTest : AnnotationSpec() {
 
   @Test
   fun `Validate function literal scope properties`() {

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/IfExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/IfExpressionTest.kt
@@ -24,7 +24,7 @@ class IfExpressionTest : AnnotationSpec() {
   fun `Do not validate if expression without else scope properties`() {
     // TODO
   }
-  
+
   @Test
   fun `Validate if expression single line scope properties`() {
     validate("""if (2 == 3) println("FAKE NEWS") else println("success")""".ifExpression())

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/FunctionLiteralPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/FunctionLiteralPlugin.kt
@@ -1,0 +1,27 @@
+package arrow.meta.quotes.scope.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.invoke
+import arrow.meta.phases.CompilerContext
+import arrow.meta.quotes.Transform
+import arrow.meta.quotes.functionLiteral
+
+open class FunctionLiteralPlugin : Meta {
+  override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
+    functionLiteralPlugin
+  )
+}
+
+val Meta.functionLiteralPlugin
+  get() =
+    "If Expression Scope Plugin" {
+      meta(
+        functionLiteral({ true }) { expression ->
+          Transform.replace(
+            replacing = expression,
+            newDeclaration = """val $name = {$blockExpression}""".functionLiteral
+          )
+        }
+      )
+    }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/FunctionLiteralPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/FunctionLiteralPlugin.kt
@@ -20,7 +20,7 @@ val Meta.functionLiteralPlugin
         functionLiteral({ true }) { expression ->
           Transform.replace(
             replacing = expression,
-            newDeclaration = """val $name: $returnType = {$`(params)`$blockExpression}""".functionLiteral
+            newDeclaration = """{$`(params)`$blockExpression}""".functionLiteral
           )
         }
       )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/FunctionLiteralPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/FunctionLiteralPlugin.kt
@@ -15,12 +15,12 @@ open class FunctionLiteralPlugin : Meta {
 
 val Meta.functionLiteralPlugin
   get() =
-    "If Expression Scope Plugin" {
+    "Function Literal Scope Plugin" {
       meta(
         functionLiteral({ true }) { expression ->
           Transform.replace(
             replacing = expression,
-            newDeclaration = """val $name = {$blockExpression}""".functionLiteral
+            newDeclaration = """val $name: $returnType = {$`(params)`$blockExpression}""".functionLiteral
           )
         }
       )


### PR DESCRIPTION
### Checklist for `KtFunctionLiteral`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element
 - [x] Testing added for validation to ensure all properties can be used as a commutative identity