### PR TITLE
BreakExpression quote-and-template scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -4,6 +4,7 @@ import arrow.meta.quotes.Scope
 import arrow.meta.quotes.classorobject.ClassDeclaration
 import arrow.meta.quotes.classorobject.ObjectDeclaration
 import arrow.meta.quotes.declaration.DestructuringDeclaration
+import arrow.meta.quotes.declaration.PropertyAccessor
 import arrow.meta.quotes.element.CatchClause
 import arrow.meta.quotes.element.FinallySection
 import arrow.meta.quotes.element.ImportDirective
@@ -21,7 +22,7 @@ import arrow.meta.quotes.expression.LambdaExpression
 import arrow.meta.quotes.expression.ThrowExpression
 import arrow.meta.quotes.expression.TryExpression
 import arrow.meta.quotes.expression.WhenExpression
-import arrow.meta.quotes.expression.expressionwithlabel.PropertyAccessor
+import arrow.meta.quotes.expression.expressionwithlabel.BreakExpression
 import arrow.meta.quotes.expression.expressionwithlabel.ReturnExpression
 import arrow.meta.quotes.expression.loopexpression.ForExpression
 import arrow.meta.quotes.expression.loopexpression.WhileExpression
@@ -44,6 +45,7 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtAnonymousInitializer
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockCodeFragment
+import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
@@ -417,6 +419,9 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`return`: ReturnExpression
     get() = ReturnExpression(expression.value as KtReturnExpression)
+
+  override val String.`break`: BreakExpression
+    get() = BreakExpression(expression.value as KtBreakExpression)
 
   override fun String.expressionIn(context: PsiElement): Scope<KtExpressionCodeFragment> =
     Scope(delegate.createExpressionCodeFragment(trimMargin(), context))

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -4,6 +4,7 @@ import arrow.meta.quotes.Scope
 import arrow.meta.quotes.classorobject.ClassDeclaration
 import arrow.meta.quotes.classorobject.ObjectDeclaration
 import arrow.meta.quotes.declaration.DestructuringDeclaration
+import arrow.meta.quotes.declaration.PropertyAccessor
 import arrow.meta.quotes.element.CatchClause
 import arrow.meta.quotes.element.FinallySection
 import arrow.meta.quotes.element.ImportDirective
@@ -21,7 +22,7 @@ import arrow.meta.quotes.expression.LambdaExpression
 import arrow.meta.quotes.expression.ThrowExpression
 import arrow.meta.quotes.expression.TryExpression
 import arrow.meta.quotes.expression.WhenExpression
-import arrow.meta.quotes.expression.expressionwithlabel.PropertyAccessor
+import arrow.meta.quotes.expression.expressionwithlabel.BreakExpression
 import arrow.meta.quotes.expression.expressionwithlabel.ReturnExpression
 import arrow.meta.quotes.expression.loopexpression.ForExpression
 import arrow.meta.quotes.expression.loopexpression.WhileExpression
@@ -320,6 +321,8 @@ interface ElementScope {
   val String.`if`: IfExpression
 
   val String.`return`: ReturnExpression
+
+  val String.`break`: BreakExpression
 
   val String.annotatedExpression: AnnotatedExpression
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
@@ -18,6 +18,7 @@ import arrow.meta.quotes.expression.IsExpression
 import arrow.meta.quotes.expression.LambdaExpression
 import arrow.meta.quotes.expression.ThrowExpression
 import arrow.meta.quotes.expression.TryExpression
+import arrow.meta.quotes.expression.expressionwithlabel.BreakExpression
 import arrow.meta.quotes.expression.expressionwithlabel.ReturnExpression
 import arrow.meta.quotes.expression.loopexpression.ForExpression
 import arrow.meta.quotes.expression.loopexpression.WhileExpression
@@ -29,6 +30,7 @@ import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.NamedFunct
 import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.Property
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
+import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
@@ -70,6 +72,15 @@ fun Meta.blockExpression(
   map: BlockExpression.(KtBlockExpression) -> Transform<KtBlockExpression>
 ): ExtensionPhase =
   quote(match, map) { BlockExpression(it) }
+
+/**
+ * @see [BreakExpression]
+ */
+fun Meta.breakExpression(
+  match: KtBreakExpression.() -> Boolean,
+  map: BreakExpression.(KtBreakExpression) -> Transform<KtBreakExpression>
+) : ExtensionPhase =
+  quote(match, map) { BreakExpression(it) }
 
 /**
  * @see [CatchClause]

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/declaration/PropertyAccessor.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/declaration/PropertyAccessor.kt
@@ -1,4 +1,4 @@
-package arrow.meta.quotes.expression.expressionwithlabel
+package arrow.meta.quotes.declaration
 
 import arrow.meta.quotes.Scope
 import arrow.meta.quotes.ScopedList

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/BreakExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/BreakExpression.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 
 /**
- * <code>"""$labelName@$targetLabel""".`break`</code>
+ * <code>"""break$targetLabel""".`break`</code>
  *
  * A template destructuring [Scope] for a [KtReturnExpression].
  *
@@ -15,7 +15,7 @@ import org.jetbrains.kotlin.psi.KtSimpleNameExpression
  * import arrow.meta.Plugin
  * import arrow.meta.invoke
  * import arrow.meta.quotes.Transform
- * import arrow.meta.quotes.returnExpression
+ * import arrow.meta.quotes.breakExpression
  *
  * val Meta.reformatBreak: Plugin
  *  get() =
@@ -24,7 +24,7 @@ import org.jetbrains.kotlin.psi.KtSimpleNameExpression
  *     breakExpression({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """$labelName@$targetLabel""".`break`
+ *       newDeclaration = """break$targetLabel""".`break`
  *      )
  *      }
  *     )

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/BreakExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/BreakExpression.kt
@@ -1,0 +1,38 @@
+package arrow.meta.quotes.expression.expressionwithlabel
+
+import arrow.meta.quotes.Scope
+import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtReturnExpression
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+
+/**
+ * <code>"""$labelName@$targetLabel""".`break`</code>
+ *
+ * A template destructuring [Scope] for a [KtReturnExpression].
+ *
+ *  ```
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.returnExpression
+ *
+ * val Meta.reformatBreak: Plugin
+ *  get() =
+ *   "ReformatBreak" {
+ *    meta(
+ *     breakExpression({ true }) { e ->
+ *      Transform.replace(
+ *       replacing = e,
+ *       newDeclaration = """$labelName@$targetLabel""".`break`
+ *      )
+ *      }
+ *     )
+ *    }
+ * ```
+ */
+class BreakExpression(
+  override val value: KtBreakExpression,
+  override val targetLabel: Scope<KtSimpleNameExpression> = Scope(value.getTargetLabel()),
+  override val labelName: String? = value.getLabelName() ?: "break"
+  ) : ExpressionWithLabel<KtBreakExpression>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ExpressionWithLabel.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ExpressionWithLabel.kt
@@ -1,0 +1,14 @@
+package arrow.meta.quotes.expression.expressionwithlabel
+
+import arrow.meta.quotes.Scope
+import org.jetbrains.kotlin.psi.KtExpressionWithLabel
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+
+/**
+ * A template destructuring [Scope] for a [KtExpressionWithLabel]
+ */
+open class ExpressionWithLabel<out T: KtExpressionWithLabel>(
+  override val value: T,
+  open val targetLabel: Scope<KtSimpleNameExpression> = Scope(value.getTargetLabel()),
+  open val labelName: String? = value.getLabelName()
+) : Scope<T>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ReturnExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ReturnExpression.kt
@@ -23,7 +23,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  *     returnExpression({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """return $`return`""".`return`
+ *       newDeclaration = """$labelName $`return`""".`return`
  *      )
  *      }
  *     )
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
  * ```
  */
 class ReturnExpression(
-  override val value: KtReturnExpression?,
-  val `return`: Scope<KtExpression> = Scope(value?.returnedExpression)
-) : Scope<KtReturnExpression>(value)
+  override val value: KtReturnExpression,
+  override val labelName: String? = value.getLabelName() ?: "return",
+  val `return`: Scope<KtExpression> = Scope(value.returnedExpression)
+) : ExpressionWithLabel<KtReturnExpression>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/Property.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/Property.kt
@@ -2,7 +2,7 @@ package arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner
 
 import arrow.meta.quotes.Scope
 import arrow.meta.quotes.ScopedList
-import arrow.meta.quotes.expression.expressionwithlabel.PropertyAccessor
+import arrow.meta.quotes.declaration.PropertyAccessor
 import arrow.meta.quotes.modifierlist.TypeReference
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtExpression

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/BreakExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/BreakExpressionTest.kt
@@ -25,7 +25,7 @@ class BreakExpressionTest {
     assertThis(CompilerTest(
       config = { listOf(addMetaPlugins(BreakExpressionPlugin())) },
       code = { breakExpression },
-      assert = { compiles }//quoteOutputMatches(breakExpression) }
+      assert = { quoteOutputMatches(breakExpression) }
     ))
   }
 }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/BreakExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/BreakExpressionTest.kt
@@ -1,0 +1,31 @@
+package arrow.meta.quotes.scope
+
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.CompilerTest.Companion.source
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.BreakExpressionPlugin
+import org.junit.Test
+
+class BreakExpressionTest {
+
+  private val breakExpression = """
+                         | //metadebug
+                         | 
+                         | fun loop() {
+                         |  loop@ for (i in 1..100) {
+                         |    for (j in 1..100) {
+                         |      if (j > 30) break@loop
+                         |    }
+                         |  }
+                         |}
+                         | """.trimMargin().source
+
+  @Test
+  fun `Validate break expression scope properties`() {
+    assertThis(CompilerTest(
+      config = { listOf(addMetaPlugins(BreakExpressionPlugin())) },
+      code = { breakExpression },
+      assert = { compiles }//quoteOutputMatches(breakExpression) }
+    ))
+  }
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/BreakExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/BreakExpressionPlugin.kt
@@ -5,23 +5,24 @@ import arrow.meta.Plugin
 import arrow.meta.invoke
 import arrow.meta.phases.CompilerContext
 import arrow.meta.quotes.Transform
-import arrow.meta.quotes.returnExpression
+import arrow.meta.quotes.breakExpression
 
-open class ReturnExpressionPlugin : Meta {
+open class BreakExpressionPlugin : Meta {
   override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
-    returnExpressionPlugin
+    breakExpressionPlugin
   )
 }
 
-val Meta.returnExpressionPlugin
+val Meta.breakExpressionPlugin
   get() =
     "Return Expression Scope Plugin" {
       meta(
-        returnExpression({ true }) { expression ->
+        breakExpression({ true }) { expression ->
           Transform.replace(
             replacing = expression,
-            newDeclaration = """$labelName $`return`""".`return`
+            newDeclaration = """break$targetLabel""".`break`
           )
         }
       )
     }
+


### PR DESCRIPTION
Break expression quote and template plus testing as well as the parent ExpressionWithLabel added!

### Checklist for KtBreakExpression
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element