### PR TITLE
ContinueExpression quote and template scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -23,6 +23,7 @@ import arrow.meta.quotes.expression.ThrowExpression
 import arrow.meta.quotes.expression.TryExpression
 import arrow.meta.quotes.expression.WhenExpression
 import arrow.meta.quotes.expression.expressionwithlabel.BreakExpression
+import arrow.meta.quotes.expression.expressionwithlabel.ContinueExpression
 import arrow.meta.quotes.expression.expressionwithlabel.ReturnExpression
 import arrow.meta.quotes.expression.loopexpression.ForExpression
 import arrow.meta.quotes.expression.loopexpression.WhileExpression
@@ -49,6 +50,7 @@ import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
 import org.jetbrains.kotlin.psi.KtClassBody
 import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
+import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtEnumEntry
@@ -422,6 +424,9 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.`break`: BreakExpression
     get() = BreakExpression(expression.value as KtBreakExpression)
+
+  override val String.`continue`: ContinueExpression
+    get() = ContinueExpression(expression.value as KtContinueExpression)
 
   override fun String.expressionIn(context: PsiElement): Scope<KtExpressionCodeFragment> =
     Scope(delegate.createExpressionCodeFragment(trimMargin(), context))

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -23,6 +23,7 @@ import arrow.meta.quotes.expression.ThrowExpression
 import arrow.meta.quotes.expression.TryExpression
 import arrow.meta.quotes.expression.WhenExpression
 import arrow.meta.quotes.expression.expressionwithlabel.BreakExpression
+import arrow.meta.quotes.expression.expressionwithlabel.ContinueExpression
 import arrow.meta.quotes.expression.expressionwithlabel.ReturnExpression
 import arrow.meta.quotes.expression.loopexpression.ForExpression
 import arrow.meta.quotes.expression.loopexpression.WhileExpression
@@ -323,6 +324,8 @@ interface ElementScope {
   val String.`return`: ReturnExpression
 
   val String.`break`: BreakExpression
+
+  val String.`continue`: ContinueExpression
 
   val String.annotatedExpression: AnnotatedExpression
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
@@ -19,6 +19,7 @@ import arrow.meta.quotes.expression.LambdaExpression
 import arrow.meta.quotes.expression.ThrowExpression
 import arrow.meta.quotes.expression.TryExpression
 import arrow.meta.quotes.expression.expressionwithlabel.BreakExpression
+import arrow.meta.quotes.expression.expressionwithlabel.ContinueExpression
 import arrow.meta.quotes.expression.expressionwithlabel.ReturnExpression
 import arrow.meta.quotes.expression.loopexpression.ForExpression
 import arrow.meta.quotes.expression.loopexpression.WhileExpression
@@ -33,6 +34,7 @@ import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtDestructuringDeclaration
 import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 import org.jetbrains.kotlin.psi.KtFile
@@ -99,6 +101,15 @@ fun Meta.classDeclaration(
   map: ClassDeclaration.(KtClass) -> Transform<KtClass>
 ): ExtensionPhase =
   quote(match, map) { ClassDeclaration(it) }
+
+/**
+ * @see [ContinueExpression]
+ */
+fun Meta.continueExpression(
+  match: KtContinueExpression.() -> Boolean,
+  map: ContinueExpression.(KtContinueExpression) -> Transform<KtContinueExpression>
+): ExtensionPhase =
+  quote(match, map) { ContinueExpression(it) }
 
 /**
  * @see [DotQualifiedExpression]

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/BreakExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/BreakExpression.kt
@@ -2,13 +2,12 @@ package arrow.meta.quotes.expression.expressionwithlabel
 
 import arrow.meta.quotes.Scope
 import org.jetbrains.kotlin.psi.KtBreakExpression
-import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 
 /**
  * <code>"""break$targetLabel""".`break`</code>
  *
- * A template destructuring [Scope] for a [KtReturnExpression].
+ * A template destructuring [Scope] for a [KtBreakExpression].
  *
  *  ```
  * import arrow.meta.Meta

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ContinueExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ContinueExpression.kt
@@ -2,33 +2,35 @@ package arrow.meta.quotes.expression.expressionwithlabel
 
 import arrow.meta.quotes.Scope
 import org.jetbrains.kotlin.psi.KtContinueExpression
-import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 
 /**
- * <code>"""break$targetLabel""".`break`</code>
+ * <code>"""continue""".`continue`</code>
  *
- * A template destructuring [Scope] for a [KtReturnExpression].
+ * A template destructuring [Scope] for a [KtContinueExpression].
  *
  *  ```
  * import arrow.meta.Meta
  * import arrow.meta.Plugin
  * import arrow.meta.invoke
  * import arrow.meta.quotes.Transform
- * import arrow.meta.quotes.breakExpression
+ * import arrow.meta.quotes.continueExpression
  *
- * val Meta.reformatBreak: Plugin
+ * val Meta.reformatContinue: Plugin
  *  get() =
- *   "ReformatBreak" {
+ *   "ReformatContinue" {
  *    meta(
- *     breakExpression({ true }) { e ->
+ *     continueExpression({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """continue$targetLabel""".`break`
+ *       newDeclaration = when {
+ *          targetLabel.value != null -> """continue$targetLabel""".`continue`
+ *          else -> """continue""".`continue`
+ *        }
  *      )
- *      }
- *     )
- *    }
+ *     }
+ *   )
+ * }
  * ```
  */
 class ContinueExpression(

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ContinueExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ContinueExpression.kt
@@ -1,12 +1,12 @@
 package arrow.meta.quotes.expression.expressionwithlabel
 
 import arrow.meta.quotes.Scope
-import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 
 /**
- * <code>"""return $`return`""".`return`</code>
+ * <code>"""break$targetLabel""".`break`</code>
  *
  * A template destructuring [Scope] for a [KtReturnExpression].
  *
@@ -15,24 +15,24 @@ import org.jetbrains.kotlin.psi.KtSimpleNameExpression
  * import arrow.meta.Plugin
  * import arrow.meta.invoke
  * import arrow.meta.quotes.Transform
- * import arrow.meta.quotes.returnExpression
+ * import arrow.meta.quotes.breakExpression
  *
- * val Meta.reformatReturn: Plugin
+ * val Meta.reformatBreak: Plugin
  *  get() =
- *   "ReformatReturn" {
+ *   "ReformatBreak" {
  *    meta(
- *     returnExpression({ true }) { e ->
+ *     breakExpression({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """return$`return`""".`return`
+ *       newDeclaration = """continue$targetLabel""".`break`
  *      )
  *      }
  *     )
  *    }
  * ```
  */
-class ReturnExpression(
-  override val value: KtReturnExpression,
+class ContinueExpression(
+  override val value: KtContinueExpression,
   override val targetLabel: Scope<KtSimpleNameExpression> = Scope(value.getTargetLabel()),
-  val `return`: Scope<KtExpression> = Scope(value.returnedExpression)
-) : ExpressionWithLabel<KtReturnExpression>(value)
+  override val labelName: String? = value.getLabelName() ?: "continue"
+) : ExpressionWithLabel<KtContinueExpression>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ReturnExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/ReturnExpression.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 
 /**
- * <code>"""return $`return`""".`return`</code>
+ * <code>"""return""".`return`</code>
  *
  * A template destructuring [Scope] for a [KtReturnExpression].
  *
@@ -24,11 +24,15 @@ import org.jetbrains.kotlin.psi.KtSimpleNameExpression
  *     returnExpression({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """return$`return`""".`return`
- *      )
- *      }
- *     )
- *    }
+ *       newDeclaration = when {
+ *          `return`.value != null -> """return $`return`""".`return`
+ *          targetLabel.value != null -> """return$targetLabel""".`return`
+ *          else -> """return""".`return`
+ *         }
+ *       )
+ *     }
+ *   )
+ * }
  * ```
  */
 class ReturnExpression(

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/ContinueExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/ContinueExpressionTest.kt
@@ -1,0 +1,53 @@
+package arrow.meta.quotes.scope
+
+import arrow.meta.plugin.testing.Code
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.CompilerTest.Companion.source
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.ReturnExpressionPlugin
+import org.junit.Test
+
+class ContinueExpressionTest {
+
+  @Test
+  fun `Validate continue expression scope properties`() {
+    validate("""
+        | loop@ for (i in 1..100) {
+        |   for (j in 1..100) {
+        |     if (j > 30) continue@loop
+        |   }
+        | } 
+        | """.continueExpression())
+  }
+
+  @Test
+  fun `Validate continue expression no labeled target scope properties`() {
+    validate("""
+        | for(i in 0 until 100 step 3) {
+        |   if (i == 6) continue
+        |   if (i == 60) break
+        |   println(i)
+        | }
+        | """.continueExpression())
+  }
+
+  private fun validate(source: Code.Source) {
+    assertThis(CompilerTest(
+      config = { listOf(addMetaPlugins(ReturnExpressionPlugin())) },
+      code = { source },
+      assert = { quoteOutputMatches(source) }
+    ))
+  }
+
+  private fun String.continueExpression(): Code.Source {
+    return """
+      | //metadebug
+      | 
+      | class Wrapper {
+      |   fun whatever() {
+      |     $this
+      |   }
+      | }
+      | """.trimMargin().trim().source
+  }
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ContinueExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ContinueExpressionPlugin.kt
@@ -5,7 +5,7 @@ import arrow.meta.Plugin
 import arrow.meta.invoke
 import arrow.meta.phases.CompilerContext
 import arrow.meta.quotes.Transform
-import arrow.meta.quotes.breakExpression
+import arrow.meta.quotes.continueExpression
 
 open class ContinueExpressionPlugin : Meta {
   override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
@@ -17,10 +17,13 @@ val Meta.continueExpressionPlugin
   get() =
     "Continue Expression Scope Plugin" {
       meta(
-        breakExpression({ true }) { expression ->
+        continueExpression({ true }) { expression ->
           Transform.replace(
             replacing = expression,
-            newDeclaration = """break$targetLabel""".`break`
+            newDeclaration = when {
+                targetLabel.value != null -> """continue$targetLabel""".`continue`
+                else -> """continue""".`continue`
+              }
           )
         }
       )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ContinueExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ContinueExpressionPlugin.kt
@@ -7,15 +7,15 @@ import arrow.meta.phases.CompilerContext
 import arrow.meta.quotes.Transform
 import arrow.meta.quotes.breakExpression
 
-open class BreakExpressionPlugin : Meta {
+open class ContinueExpressionPlugin : Meta {
   override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
-    breakExpressionPlugin
+    continueExpressionPlugin
   )
 }
 
-val Meta.breakExpressionPlugin
+val Meta.continueExpressionPlugin
   get() =
-    "Break Expression Scope Plugin" {
+    "Continue Expression Scope Plugin" {
       meta(
         breakExpression({ true }) { expression ->
           Transform.replace(
@@ -25,4 +25,3 @@ val Meta.breakExpressionPlugin
         }
       )
     }
-

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ReturnExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ReturnExpressionPlugin.kt
@@ -20,7 +20,11 @@ val Meta.returnExpressionPlugin
         returnExpression({ true }) { expression ->
           Transform.replace(
             replacing = expression,
-            newDeclaration = """$labelName $`return`""".`return`
+            newDeclaration = when {
+              `return`.value != null -> """return $`return`""".`return`
+              targetLabel.value != null -> """return$targetLabel""".`return`
+              else -> """return""".`return`
+            }
           )
         }
       )


### PR DESCRIPTION
`ContinueExpression` quote and template scope plus adjusted `ReturnExpression` with testing validation

#89 

### Checklist for KtContinueExpression
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element