### PR TITLE
Ide support for KotlinIndicesHelperExtension

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/IdeSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/IdeSyntax.kt
@@ -7,6 +7,7 @@ import arrow.meta.ide.dsl.editor.hints.HintingSyntax
 import arrow.meta.ide.dsl.editor.icon.IconProviderSyntax
 import arrow.meta.ide.dsl.editor.inspection.InspectionSyntax
 import arrow.meta.ide.dsl.editor.intention.IntentionSyntax
+import arrow.meta.ide.dsl.editor.kotlinextension.KotlinIndicesSyntax
 import arrow.meta.ide.dsl.editor.language.LanguageSyntax
 import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
 import arrow.meta.ide.dsl.editor.liveTemplate.LiveTemplateSyntax
@@ -20,4 +21,4 @@ import arrow.meta.ide.dsl.extensions.ExtensionProviderSyntax
 interface IdeSyntax : IntentionSyntax, IconProviderSyntax,
   SyntaxHighlighterSyntax, InspectionSyntax, AnActionSyntax, ColorSettingsSyntax, HintingSyntax,
   LanguageSyntax, LineMarkerSyntax, LiveTemplateSyntax, NavigationSyntax, SearchSyntax, StructureViewSyntax,
-  UsageSyntax, ExtensionProviderSyntax, DocumentationProviderSyntax
+  UsageSyntax, ExtensionProviderSyntax, DocumentationProviderSyntax, KotlinIndicesSyntax

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/kotlinextension/KotlinIndicesSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/kotlinextension/KotlinIndicesSyntax.kt
@@ -1,0 +1,42 @@
+package arrow.meta.ide.dsl.editor.kotlinextension
+
+import arrow.meta.ide.IdeMetaPlugin
+import arrow.meta.internal.Noop
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.idea.core.extension.KotlinIndicesHelperExtension
+import org.jetbrains.kotlin.incremental.components.LookupLocation
+import org.jetbrains.kotlin.types.KotlinType
+
+interface KotlinIndicesSyntax {
+  fun IdeMetaPlugin.addKotlinIndicesHelper(
+    appendExtensionCallables: (consumer: MutableList<in CallableDescriptor>,
+                               moduleDescriptor: ModuleDescriptor,
+                               receiverTypes: Collection<KotlinType>,
+                               nameFilter: (String) -> Boolean,
+                               lookupLocation: LookupLocation) -> Unit = Noop.effect5
+  ): ExtensionPhase =
+    extensionProvider(
+      KotlinIndicesHelperExtension.extensionPointName,
+      ktIndicesHelperExtension(appendExtensionCallables)
+    )
+
+  fun KotlinIndicesSyntax.ktIndicesHelperExtension(
+    appendExtensionCallables: (consumer: MutableList<in CallableDescriptor>,
+                               moduleDescriptor: ModuleDescriptor,
+                               receiverTypes: Collection<KotlinType>,
+                               nameFilter: (String) -> Boolean,
+                               lookupLocation: LookupLocation) -> Unit = Noop.effect5
+  ): KotlinIndicesHelperExtension =
+    object : KotlinIndicesHelperExtension {
+      /**
+       * This method is deprecated, even though it is required to be implemented, and won't be called at RunTime
+       */
+      override fun appendExtensionCallables(consumer: MutableList<in CallableDescriptor>, moduleDescriptor: ModuleDescriptor, receiverTypes: Collection<KotlinType>, nameFilter: (String) -> Boolean): Unit =
+        Unit
+
+      override fun appendExtensionCallables(consumer: MutableList<in CallableDescriptor>, moduleDescriptor: ModuleDescriptor, receiverTypes: Collection<KotlinType>, nameFilter: (String) -> Boolean, lookupLocation: LookupLocation): Unit =
+        appendExtensionCallables(consumer, moduleDescriptor, receiverTypes, nameFilter, lookupLocation)
+    }
+}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -1,11 +1,18 @@
 package arrow.meta.ide.dsl.extensions
 
+import arrow.meta.dsl.analysis.AnalysisSyntax
 import arrow.meta.ide.IdeMetaPlugin
+import arrow.meta.ide.dsl.editor.icon.IconProviderSyntax
+import arrow.meta.ide.dsl.editor.inspection.InspectionSyntax
+import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
+import arrow.meta.ide.dsl.editor.search.SearchSyntax
 import arrow.meta.ide.phases.editor.extension.ExtensionProvider
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.ContainerProvider
+import com.intellij.ide.IconProvider
 import com.intellij.lang.LanguageExtension
 import com.intellij.openapi.extensions.BaseExtensionPointName
+import com.intellij.openapi.extensions.ExtensionPoint
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.LoadingOrder
 import com.intellij.openapi.fileTypes.FileTypeExtension
@@ -13,12 +20,6 @@ import com.intellij.openapi.util.ClassExtension
 import com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.resolve.diagnostics.DiagnosticSuppressor
-import arrow.meta.ide.dsl.editor.icon.IconProviderSyntax
-import arrow.meta.dsl.analysis.AnalysisSyntax
-import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
-import arrow.meta.ide.dsl.editor.search.SearchSyntax
-import arrow.meta.ide.dsl.editor.inspection.InspectionSyntax
-import com.intellij.ide.IconProvider
 
 /**
  * The [ExtensionProvider] phase sits at the core of the main API in IntelliJ's Platform for ExtensionPoints.
@@ -114,9 +115,10 @@ interface ExtensionProviderSyntax {
    */
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: BaseExtensionPointName<E>,
-    aClass: Class<E>
+    aClass: Class<E>,
+    kind: ExtensionPoint.Kind
   ): ExtensionPhase =
-    ExtensionProvider.RegisterBaseExtension(EP_NAME, aClass)
+    ExtensionProvider.RegisterBaseExtension(EP_NAME, aClass, kind)
 
   /**
    * Interestingly enough, [ExtensionProvider] registers new workflows to the ide.
@@ -142,6 +144,7 @@ interface ExtensionProviderSyntax {
    * import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
    * import arrow.meta.invoke
    * import com.intellij.openapi.extensions.ExtensionPointName
+   * import com.intellij.openapi.extensions.ExtensionPoint
    * import javax.swing.Icon
    *
    * interface MetaProvider {
@@ -155,7 +158,7 @@ interface ExtensionProviderSyntax {
    * val IdeMetaPlugin.registeringIdeExtensions: Plugin
    *   get() = "Register ExtensionPoints" {
    *     meta(
-   *        registerExtensionPoint(MetaProvider.EP_NAME, MetaProvider::class.java)
+   *        registerExtensionPoint(MetaProvider.EP_NAME, MetaProvider::class.java, ExtensionPoint.Kind.INTERFACE)
    *     )
    *   }
    * //sampleEnd
@@ -163,9 +166,10 @@ interface ExtensionProviderSyntax {
    */
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: ExtensionPointName<E>,
-    aClass: Class<E>
+    aClass: Class<E>,
+    kind: ExtensionPoint.Kind
   ): ExtensionPhase =
-    ExtensionProvider.RegisterExtension(EP_NAME, aClass)
+    ExtensionProvider.RegisterExtension(EP_NAME, aClass, kind)
 
   /**
    * registers a [ContainerProvider].

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -163,6 +163,7 @@ interface ExtensionProviderSyntax {
    *   }
    * //sampleEnd
    * ```
+   * @param kind There are more [resources] on the ExtensionPointKinds [here](http://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_extension_points.html)
    */
   fun <E> IdeMetaPlugin.registerExtensionPoint(
     EP_NAME: ExtensionPointName<E>,

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
@@ -27,7 +27,6 @@ import arrow.meta.phases.resolve.synthetics.SyntheticResolver
 import arrow.meta.phases.resolve.synthetics.SyntheticScopeProvider
 import com.intellij.codeInsight.intention.IntentionManager
 import com.intellij.codeInsight.intention.impl.config.IntentionManagerSettings
-import com.intellij.core.CoreApplicationEnvironment
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.extensions.Extensions
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
@@ -130,7 +129,7 @@ internal interface IdeInternalRegistry : InternalRegistry {
       is ExtensionProvider.AddLanguageExtension -> phase.run { LE.addExplicitExtension(KotlinLanguage.INSTANCE, impl) }
       is ExtensionProvider.AddFileTypeExtension -> phase.run { FE.addExplicitExtension(KotlinFileType.INSTANCE, impl) }
       is ExtensionProvider.AddClassExtension -> phase.run { CE.addExplicitExtension(forClass, impl) }
-      is ExtensionProvider.RegisterBaseExtension -> phase.run { CoreApplicationEnvironment.registerExtensionPoint(Extensions.getRootArea(), EP_NAME, aClass) }
-      is ExtensionProvider.RegisterExtension -> phase.run { CoreApplicationEnvironment.registerExtensionPoint(Extensions.getRootArea(), EP_NAME, aClass) }
+      is ExtensionProvider.RegisterBaseExtension -> phase.run { Extensions.getRootArea().registerExtensionPoint(EP_NAME.name, aClass.name, kind) }
+      is ExtensionProvider.RegisterExtension -> phase.run { Extensions.getRootArea().registerExtensionPoint(EP_NAME.name, aClass.name, kind) }
     }
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/extension/ExtensionProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/editor/extension/ExtensionProvider.kt
@@ -1,14 +1,15 @@
 package arrow.meta.ide.phases.editor.extension
 
+import arrow.meta.ide.dsl.extensions.ExtensionProviderSyntax
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.core.JavaCoreApplicationEnvironment
 import com.intellij.lang.LanguageExtension
 import com.intellij.openapi.extensions.BaseExtensionPointName
+import com.intellij.openapi.extensions.ExtensionPoint
 import com.intellij.openapi.extensions.ExtensionPointName
 import com.intellij.openapi.extensions.LoadingOrder
 import com.intellij.openapi.fileTypes.FileTypeExtension
 import com.intellij.openapi.util.ClassExtension
-import arrow.meta.ide.dsl.extensions.ExtensionProviderSyntax
 
 /**
  * @see [ExtensionProviderSyntax]
@@ -40,10 +41,10 @@ sealed class ExtensionProvider<E> : ExtensionPhase {
   /**
    * @see [ExtensionProviderSyntax.registerExtensionPoint]
    */
-  data class RegisterBaseExtension<E>(val EP_NAME: BaseExtensionPointName<E>, val aClass: Class<E>) : ExtensionProvider<E>()
+  data class RegisterBaseExtension<E>(val EP_NAME: BaseExtensionPointName<E>, val aClass: Class<E>, val kind: ExtensionPoint.Kind) : ExtensionProvider<E>()
 
   /**
    * @see [ExtensionProviderSyntax.registerExtensionPoint]
    */
-  data class RegisterExtension<E>(val EP_NAME: ExtensionPointName<E>, val aClass: Class<E>) : ExtensionProvider<E>()
+  data class RegisterExtension<E>(val EP_NAME: ExtensionPointName<E>, val aClass: Class<E>, val kind: ExtensionPoint.Kind) : ExtensionProvider<E>()
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/initial/InitialIdePlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/initial/InitialIdePlugin.kt
@@ -7,11 +7,13 @@ import arrow.meta.invoke
 import arrow.meta.plugins.higherkind.kindsTypeMismatch
 import arrow.meta.plugins.typeclasses.suppressUnusedParameter
 import arrow.meta.plugins.union.suppressTypeMismatchOnNullableReceivers
+import com.intellij.openapi.extensions.ExtensionPoint
 import org.jetbrains.kotlin.cfg.ClassMissingCase
 import org.jetbrains.kotlin.cfg.WhenMissingCase
 import org.jetbrains.kotlin.diagnostics.Diagnostic
 import org.jetbrains.kotlin.diagnostics.DiagnosticWithParameters1
 import org.jetbrains.kotlin.diagnostics.Errors
+import org.jetbrains.kotlin.idea.core.extension.KotlinIndicesHelperExtension
 import org.jetbrains.kotlin.psi.KtWhenExpression
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
@@ -23,7 +25,9 @@ val IdeMetaPlugin.initialIdeSetUp: Plugin
         val result = diagnostic.suppressMetaDiagnostics()
         diagnostic.logSuppression(result)
         result
-      }
+      },
+      registerExtensionPoint(KotlinIndicesHelperExtension.Companion.extensionPointName,
+        KotlinIndicesHelperExtension::class.java, ExtensionPoint.Kind.INTERFACE)
     )
   }
 


### PR DESCRIPTION
resolves #246 KotlinIndicesHelperExtension is not registered as an ide Extension - check `KotlinCoreEnvironment# registerPluginExtensionPoints`.
Thus we have to manually add it. 

Furthermore, I discovered redundancies in Meta's Interpreter and flatten the registration process.
Turns out prior to this we could only register extensions, which were known to the `CoreApplicationEnvironment`. That method is only sufficient in Testing Environment. The technique proposed here is abstracting that process to any environment.  

To SumUp, `KotlinIndicesHelperExtension` has an unclear position to me in the ide. I am in contact with Alex from Jetbrains, who may give us more intel on that.