### PR TITLE
ThisExpression quote and template

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/instanceexpressionwithlabel/ThisExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/expressionwithlabel/instanceexpressionwithlabel/ThisExpression.kt
@@ -1,0 +1,39 @@
+package arrow.meta.quotes.expression.expressionwithlabel.instanceexpressionwithlabel
+
+import arrow.meta.quotes.Scope
+import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtThisExpression
+
+/**
+ * <code>"""$instanceReference$targetLabel""".`this`</code>
+ *
+ * A template destructuring [Scope] for a [KtBreakExpression].
+ *
+ *  ```
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.thisExpression
+ *
+ * val Meta.reformatThis: Plugin
+ *  get() =
+ *   "ReformatThis" {
+ *     meta(
+ *       thisExpression({ true }) { e ->
+ *         Transform.replace(
+ *           replacing = e,
+ *           newDeclaration = when {
+ *             targetLabel.value != null -> """$instanceReference$targetLabel""".`this`
+ *             else -> """$instanceReference""".`this`
+ *           }
+ *         )
+ *       }
+ *     )
+ *   }
+ * ```
+ */
+class ThisExpression(
+  override val value: KtThisExpression,
+  override val labelName: String? = value.getLabelName()
+) : InstanceExpressionWithLabel<KtThisExpression>(value)


### PR DESCRIPTION
### Checklist for `KtThisExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element
 - [x] Testing added for validation to ensure all properties can be used as a commutative identity