### PR TITLE
TypeAlias Quote and Template Testing Validation

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
@@ -931,14 +931,14 @@ open class Converter {
 internal val PsiElement.ast: Node get() = when(this) {
   is KtClassOrObject -> Converter.convertDecl(this)
   is KtNamedFunction -> Converter.convertFunc(this)
-  is KtExpression -> Converter.convertExpr(this)
+  is KtTypeAlias -> Converter.convertTypeAlias(this)
   is KtWhenCondition -> Converter.convertWhenCond(this)
   is KtWhenEntry -> Converter.convertWhenEntry(this)
   is KtCatchClause -> Converter.convertTryCatch(this)
   is KtImportDirective -> Converter.convertImport(this)
   is KtValueArgument -> Converter.convertValueArg(this)
-  is KtTypeAlias -> Converter.convertTypeAlias(this)
   is KtTypeReference -> Converter.convertTypeRef(this)
   is KtClassBody -> Converter.convertClassBody(this)
+  is KtExpression -> Converter.convertExpr(this)
   else -> TODO("Unsupported ${this}")
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
@@ -31,6 +31,7 @@ import arrow.meta.quotes.nameddeclaration.notstubbed.FunctionLiteral
 import arrow.meta.quotes.nameddeclaration.stub.Parameter
 import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.NamedFunction
 import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.Property
+import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.TypeAlias
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtBreakExpression
@@ -55,6 +56,7 @@ import org.jetbrains.kotlin.psi.KtReturnExpression
 import org.jetbrains.kotlin.psi.KtThisExpression
 import org.jetbrains.kotlin.psi.KtThrowExpression
 import org.jetbrains.kotlin.psi.KtTryExpression
+import org.jetbrains.kotlin.psi.KtTypeAlias
 import org.jetbrains.kotlin.psi.KtTypeReference
 import org.jetbrains.kotlin.psi.KtValueArgument
 import org.jetbrains.kotlin.psi.KtWhenCondition
@@ -303,6 +305,15 @@ fun Meta.tryExpression(
   map: TryExpression.(KtTryExpression) -> Transform<KtTryExpression>
 ): ExtensionPhase =
   quote(match, map) { TryExpression(it) }
+
+/**
+ * @see [TypeAlias]
+ */
+fun Meta.typeAlias(
+  match: KtTypeAlias.() -> Boolean,
+  map: TypeAlias.(KtTypeAlias) -> Transform<KtTypeAlias>
+): ExtensionPhase =
+  quote(match, map) { TypeAlias(it) }
 
 /**
  * """someObject.add(${argumentName = argumentExpression}.valueArgument)""""

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ScopedList.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/ScopedList.kt
@@ -23,9 +23,11 @@ data class ScopedList<K : KtElement>(
 
   fun toStringList(): List<String> {
     val list = arrayListOf<String>()
-    if (value.isEmpty())
+    if (value.isEmpty()) {
       if (forceRenderSurroundings) list.add(prefix + postfix)
-    else list.addAll(value.filterNot { it.text == "null" }.map {it.text})
+    } else {
+      list.addAll(value.mapNotNull {it.text})
+    }
     return list
   }
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/WhenExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/WhenExpression.kt
@@ -2,7 +2,6 @@ package arrow.meta.quotes.expression
 
 import arrow.meta.quotes.Scope
 import arrow.meta.quotes.ScopedList
-import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.Property
 import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtWhenEntry
 import org.jetbrains.kotlin.psi.KtWhenExpression
@@ -38,7 +37,6 @@ import org.jetbrains.kotlin.psi.KtWhenExpression
 class WhenExpression(
   override val value: KtWhenExpression?,
   val entries: ScopedList<KtWhenEntry> = ScopedList(value?.entries.orEmpty()),
-  val variable: Property = Property(value?.subjectVariable),
   val `(expression)`: Scope<KtExpression> = Scope(value?.subjectExpression),
   val `else`: Scope<KtExpression> = Scope(value?.elseExpression)
 ) : Scope<KtWhenExpression>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/NamedFunction.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/NamedFunction.kt
@@ -54,7 +54,7 @@ class NamedFunction(
   ),
   val returnType: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.typeReference), prefix = " : "),
   val body: FunctionBody? = value.body()?.let { FunctionBody(it) }
-) : Scope<KtNamedFunction>(value)
+) : TypeParameterListOwner<KtNamedFunction>(value)
 
 class FunctionBody(
   override val value: KtExpression

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/Property.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/Property.kt
@@ -127,28 +127,28 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifierType
  * ```
  */
 class Property(
-  override val value: KtProperty?,
-  val modality: Name? = value?.modalityModifierType()?.value?.let(Name::identifier),
-  val visibility: Name? = value?.visibilityModifierType()?.value?.let(Name::identifier),
-  val `(typeParameters)`: ScopedList<KtTypeParameter> = ScopedList(prefix = "<", value = value?.typeParameters
+  override val value: KtProperty,
+  val modality: Name? = value.modalityModifierType()?.value?.let(Name::identifier),
+  val visibility: Name? = value.visibilityModifierType()?.value?.let(Name::identifier),
+  val `(typeParameters)`: ScopedList<KtTypeParameter> = ScopedList(prefix = "<", value = value.typeParameters
     ?: listOf(), postfix = ">"),
-  val receiver: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value?.receiverTypeReference), postfix = "."),
-  val name: Name? = value?.nameAsName,
-  val typeReference: TypeReference? = TypeReference(value?.typeReference),
+  val receiver: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.receiverTypeReference), postfix = "."),
+  val name: Name? = value.nameAsName,
+  val typeReference: TypeReference? = TypeReference(value.typeReference),
   val `(params)`: ScopedList<KtParameter> = ScopedList(
     prefix = "(",
-    value = value?.valueParameters ?: listOf(),
+    value = value.valueParameters ?: listOf(),
     postfix = ")",
     forceRenderSurroundings = true
   ),
-  val delegate: Scope<KtPropertyDelegate> = Scope(value?.delegate), // TODO KtPropertyDelegate scope and quote template
-  val delegateExpressionOrInitializer: Scope<KtExpression> = Scope(value?.delegateExpressionOrInitializer), // TODO KtExpression scope and quote template
-  val returnType: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value?.typeReference), prefix = " : "),
+  val delegate: Scope<KtPropertyDelegate> = Scope(value.delegate), // TODO KtPropertyDelegate scope and quote template
+  val delegateExpressionOrInitializer: Scope<KtExpression> = Scope(value.delegateExpressionOrInitializer), // TODO KtExpression scope and quote template
+  val returnType: ScopedList<KtTypeReference> = ScopedList(listOfNotNull(value.typeReference), prefix = " : "),
   val valOrVar: Name = when {
-    value?.isVar == true -> "var"
+    value.isVar -> "var"
     else -> "val"
   }.let(Name::identifier),
-  val getter : PropertyAccessor = PropertyAccessor(value?.getter),
-  val setter : PropertyAccessor = PropertyAccessor(value?.setter)
-) : Scope<KtProperty>(value)
+  val getter : PropertyAccessor = PropertyAccessor(value.getter),
+  val setter : PropertyAccessor = PropertyAccessor(value.setter)
+) : TypeParameterListOwner<KtProperty>(value)
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/TypeAlias.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/TypeAlias.kt
@@ -37,4 +37,4 @@ class TypeAlias(
   val name: Name? = value.nameAsName,
   val `(typeParameters)`: ScopedList<KtTypeParameter> = ScopedList(prefix = "<", value = value.typeParameters, postfix = ">"),
   val type: Scope<KtTypeReference> = Scope(value.getTypeReference())
-  ) : Scope<KtTypeAlias>(value)
+) : TypeParameterListOwner<KtTypeAlias>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/TypeAlias.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/TypeAlias.kt
@@ -1,10 +1,8 @@
 package arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner
 
 import arrow.meta.quotes.Scope
-import arrow.meta.quotes.ScopedList
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.psi.KtTypeAlias
-import org.jetbrains.kotlin.psi.KtTypeParameter
 import org.jetbrains.kotlin.psi.KtTypeReference
 
 /**
@@ -35,6 +33,5 @@ import org.jetbrains.kotlin.psi.KtTypeReference
 class TypeAlias(
   override val value: KtTypeAlias,
   val name: Name? = value.nameAsName,
-  val `(typeParameters)`: ScopedList<KtTypeParameter> = ScopedList(prefix = "<", value = value.typeParameters, postfix = ">"),
   val type: Scope<KtTypeReference> = Scope(value.getTypeReference())
 ) : TypeParameterListOwner<KtTypeAlias>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/TypeParameterListOwner.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/nameddeclaration/stub/typeparameterlistowner/TypeParameterListOwner.kt
@@ -1,0 +1,17 @@
+package arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner
+
+import arrow.meta.quotes.Scope
+import arrow.meta.quotes.ScopedList
+import org.jetbrains.kotlin.psi.KtExpressionWithLabel
+import org.jetbrains.kotlin.psi.KtTypeConstraint
+import org.jetbrains.kotlin.psi.KtTypeParameter
+import org.jetbrains.kotlin.psi.KtTypeParameterListOwner
+
+/**
+ * A template destructuring [Scope] for a [KtExpressionWithLabel]
+ */
+open class TypeParameterListOwner<out T: KtTypeParameterListOwner>(
+  override val value: T,
+  open val `(typeConstraints)`: ScopedList<KtTypeConstraint> = ScopedList(value = value.typeConstraints),
+  open val `(typeParams)`: ScopedList<KtTypeParameter> = ScopedList(value = value.typeParameters)
+) : Scope<T>(value)

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/TypeAliasTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/TypeAliasTest.kt
@@ -1,27 +1,43 @@
 package arrow.meta.quotes.scope
 
+import arrow.meta.plugin.testing.Code
 import arrow.meta.plugin.testing.CompilerTest
 import arrow.meta.plugin.testing.CompilerTest.Companion.source
 import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.TypeAliasPlugin
+import io.kotlintest.specs.AbstractAnnotationSpec
 import io.kotlintest.specs.AnnotationSpec
-
-// TODO Ast to Expr Conversion needed
 
 class TypeAliasTest : AnnotationSpec() {
 
-  private val typeAlias = """
+  @Test
+  fun `Validate type alias properties`() {
+    val typeAlias = """
+                         | //metadebug
+                         | 
+                         | typealias IntegerPredicate = (Int) -> Boolean
+                         | """.source
+
+    validate(typeAlias)
+  }
+
+  @AbstractAnnotationSpec.Ignore // issues with type erasure when AST parsing the compiled code?
+  @AbstractAnnotationSpec.Test
+  fun `Validate type alias properties with generics`() {
+    val typeAlias = """
                          | //metadebug
                          | 
                          | typealias Predicate<T> = (T) -> Boolean
                          | """.source
 
-  @Ignore
-  @Test
-  fun `Validate type alias properties`() {
+    validate(typeAlias)
+  }
+
+  private fun validate(source: Code.Source) {
     assertThis(CompilerTest(
-      config = { listOf(addMetaPlugins()) }, // TODO create a scope plugin for finally section
-      code = { typeAlias },
-      assert = { quoteOutputMatches(typeAlias) }
+      config = { listOf(addMetaPlugins(TypeAliasPlugin())) },
+      code = { source },
+      assert = { quoteOutputMatches(source) }
     ))
   }
 }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/TypeAliasTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/TypeAliasTest.kt
@@ -5,7 +5,6 @@ import arrow.meta.plugin.testing.CompilerTest
 import arrow.meta.plugin.testing.CompilerTest.Companion.source
 import arrow.meta.plugin.testing.assertThis
 import arrow.meta.quotes.scope.plugins.TypeAliasPlugin
-import io.kotlintest.specs.AbstractAnnotationSpec
 import io.kotlintest.specs.AnnotationSpec
 
 class TypeAliasTest : AnnotationSpec() {
@@ -21,8 +20,19 @@ class TypeAliasTest : AnnotationSpec() {
     validate(typeAlias)
   }
 
-  @AbstractAnnotationSpec.Ignore // issues with type erasure when AST parsing the compiled code?
-  @AbstractAnnotationSpec.Test
+  @Test
+  fun `Validate type alias with constraints properties`() {
+     val typeAlias = """
+                         | //metadebug
+                         | 
+                         | typealias Predicate<Int> = (Int) -> Boolean
+                         | """.source
+
+    validate(typeAlias)
+  }
+
+  @Ignore // issues with type erasure when AST parsing the compiled code?
+  @Test
   fun `Validate type alias properties with generics`() {
     val typeAlias = """
                          | //metadebug

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/TypeAliasTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/TypeAliasTest.kt
@@ -30,8 +30,7 @@ class TypeAliasTest : AnnotationSpec() {
 
     validate(typeAlias)
   }
-
-  @Ignore // issues with type erasure when AST parsing the compiled code?
+  
   @Test
   fun `Validate type alias properties with generics`() {
     val typeAlias = """

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/TypeAliasPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/TypeAliasPlugin.kt
@@ -20,7 +20,7 @@ val Meta.typeAliasPlugin
         typeAlias({ true }) { element ->
           Transform.replace(
             replacing = element,
-            newDeclaration = typeAlias("""$name""", `(typeParameters)`.toStringList() , """$type""")
+            newDeclaration = typeAlias("""$name""", `(typeParams)`.toStringList() , """$type""")
           )
         }
       )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/TypeAliasPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/TypeAliasPlugin.kt
@@ -1,0 +1,27 @@
+package arrow.meta.quotes.scope.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.invoke
+import arrow.meta.phases.CompilerContext
+import arrow.meta.quotes.Transform
+import arrow.meta.quotes.typeAlias
+
+open class TypeAliasPlugin : Meta {
+  override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
+    typeAliasPlugin
+  )
+}
+
+val Meta.typeAliasPlugin
+  get() =
+    "Type Alias Expression Scope Plugin" {
+      meta(
+        typeAlias({ true }) { element ->
+          Transform.replace(
+            replacing = element,
+            newDeclaration = typeAlias("""$name""", `(typeParameters)`.toStringList() , """$type""")
+          )
+        }
+      )
+    }


### PR DESCRIPTION
### Checklist for `KtTypeAlias`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element
 - [x] Testing added for validation to ensure all properties can be used as a commutative identity