### PR TITLE
Responsive gif image

### DIFF
--- a/docs/_sass/components/_doc-content.scss
+++ b/docs/_sass/components/_doc-content.scss
@@ -134,4 +134,10 @@
             opacity: 1;
         }
     }
+
+    .gif {
+      img {
+        width: 100%;
+      }
+    }
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,7 +20,7 @@ Writing compiler plugins, source transformations, IDEA plugins, linters, type se
 
 ## Λrrow Meta examples
 
+{:.gif}
 ![Hello World Compiler Plugin Demo]({{ 'img/demos/hello-world-compiler-plugin.gif' | relative_url }})
 
 Take a look at [`arrow-meta-examples`](https://github.com/arrow-kt/arrow-meta-examples) repository for more details.
-


### PR DESCRIPTION
This PR adds a css class to the gif image in the landing docs in order to make it responsive.
Fixes #329 