### PR TITLE
Fix: IfExpression testing and added validation

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -350,9 +350,6 @@ class DefaultElementScope(project: Project) : ElementScope {
   override fun String.blockCodeFragment(context: PsiElement?): Scope<KtBlockCodeFragment> =
     Scope(delegate.createBlockCodeFragment(trimMargin(), context))
 
-  override fun `if`(condition: KtExpression, thenExpr: KtExpression, elseExpr: KtExpression?): IfExpression =
-    IfExpression(delegate.createIf(condition, thenExpr, elseExpr))
-
   override fun argument(expression: KtExpression?, name: Name?, isSpread: Boolean, reformat: Boolean): ValueArgument =
     ValueArgument(delegate.createArgument(expression, name, isSpread, reformat))
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -271,12 +271,6 @@ interface ElementScope {
   
   fun String.blockCodeFragment(context: PsiElement?): Scope<KtBlockCodeFragment>
   
-  fun `if`(
-    condition: KtExpression,
-    thenExpr: KtExpression,
-    elseExpr: KtExpression? = null
-  ): IfExpression
-  
   fun argument(
     expression: KtExpression?,
     name: Name? = null,

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/IfExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/IfExpression.kt
@@ -6,7 +6,7 @@ import org.jetbrains.kotlin.psi.KtExpression
 import org.jetbrains.kotlin.psi.KtIfExpression
 
 /**
- * <code>"""if ($condition) $`else`""".`if`</code>
+ * <code>"""if ($condition) $then else $`else`""".`if`</code>
  *
  * A template destructuring [Scope] for a [KtIfExpression].
  *
@@ -18,17 +18,20 @@ import org.jetbrains.kotlin.psi.KtIfExpression
  * import arrow.meta.quotes.ifExpression
  *
  * val Meta.reformatIf: Plugin
- *  get() =
- *  "ReformatIf" {
- *   meta(
- *    ifExpression({ true }) { e ->
- *     Transform.replace(
- *      replacing = e,
- *      newDeclaration = """if ($condition) $`else`""".`if`
- *     )
- *    }
- *   )
- *  }
+ *    get() =
+ *      "Reformat If Expression" {
+ *        meta(
+ *          ifExpression({ true }) { expression ->
+ *            Transform.replace(
+ *              replacing = expression,
+ *              newDeclaration = when {
+ *                `else`.value == null -> """if ($condition) $then""".`if`
+ *                else -> """if ($condition) $then else $`else`""".`if`
+ *              }
+ *            )
+ *          }
+ *        )
+ *      }
  *```
  */
 class IfExpression(

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/IfExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/IfExpression.kt
@@ -37,7 +37,7 @@ import org.jetbrains.kotlin.psi.KtIfExpression
 class IfExpression(
   override val value: KtIfExpression?,
   val condition: Scope<KtExpression> = Scope(value?.condition),
-  val then: Scope<KtExpression> = Scope(value),
+  val then: Scope<KtExpression> = Scope(value?.then),
   val `else`: Scope<KtExpression> = Scope(value?.`else`)
 ) : Scope<KtIfExpression>(value) {
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/IfExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/IfExpression.kt
@@ -40,6 +40,10 @@ class IfExpression(
   val then: Scope<KtExpression> = Scope(value),
   val `else`: Scope<KtExpression> = Scope(value?.`else`)
 ) : Scope<KtIfExpression>(value) {
-  override fun ElementScope.identity(): IfExpression =
-    """if ($condition) $`else`""".`if`  // {"""$then""".`if`} also works
+
+  override fun ElementScope.identity(): IfExpression = when {
+    `else`.value == null -> """if ($condition) $then""".`if`
+    else -> """if ($condition) $then else $`else`""".`if`
+  }
+
 }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/IfExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/IfExpressionTest.kt
@@ -54,11 +54,3 @@ class IfExpressionTest  {
       | """.source
   }
 }
-
-class Wrapper {
-  fun whatever() {
-    if (2 == 3) {
-      println("FAKE NEWS")
-    }
-  }
-}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/IfExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/IfExpressionTest.kt
@@ -22,7 +22,11 @@ class IfExpressionTest  {
 
   @Test
   fun `Do not validate if expression without else scope properties`() {
-    // TODO
+    validate(
+      """
+      | if (2 == 3) {
+      |   println("FAKE NEWS")
+      | }""".ifExpression())
   }
 
   @Test
@@ -34,7 +38,7 @@ class IfExpressionTest  {
     assertThis(CompilerTest(
       config = { listOf(addMetaPlugins(IfExpressionPlugin())) },
       code = { source },
-      assert = { compiles }// quoteOutputMatches(source) }
+      assert = { quoteOutputMatches(source) }
     ))
   }
 
@@ -48,5 +52,13 @@ class IfExpressionTest  {
       |   }
       |  }
       | """.source
+  }
+}
+
+class Wrapper {
+  fun whatever() {
+    if (2 == 3) {
+      println("FAKE NEWS")
+    }
   }
 }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/IfExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/IfExpressionPlugin.kt
@@ -25,4 +25,3 @@ val Meta.ifExpressionPlugin
         }
       )
     }
-


### PR DESCRIPTION
### Checklist for `KtIfExpression`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element, including an example using all properties
 - [x] Testing added for validation to ensure all properties can be used as a commutative identity

#89 + #202 