### PR TITLE
PackageDirective quote and scope

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
@@ -940,5 +940,6 @@ internal val PsiElement.ast: Node get() = when(this) {
   is KtTypeReference -> Converter.convertTypeRef(this)
   is KtClassBody -> Converter.convertClassBody(this)
   is KtExpression -> Converter.convertExpr(this)
+  is KtPackageDirective -> Converter.convertPackage(this)
   else -> TODO("Unsupported ${this}")
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -9,6 +9,7 @@ import arrow.meta.quotes.declaration.PropertyAccessor
 import arrow.meta.quotes.element.CatchClause
 import arrow.meta.quotes.element.FinallySection
 import arrow.meta.quotes.element.ImportDirective
+import arrow.meta.quotes.element.PackageDirective
 import arrow.meta.quotes.element.ParameterList
 import arrow.meta.quotes.element.ValueArgument
 import arrow.meta.quotes.element.WhenEntry
@@ -438,6 +439,8 @@ class DefaultElementScope(project: Project) : ElementScope {
   
   override val String.classBody: ClassBody
     get() = ClassBody(delegate.createClass("class _ClassBodyScopeArrowMeta ${trimMargin()}").body)
-
+  
+  override val String.`package`: PackageDirective
+    get() = PackageDirective(delegate.createFile(trimMargin()).packageDirective)
 }
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -66,7 +66,6 @@ import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtLabeledExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
-import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtPropertyDelegate
 import org.jetbrains.kotlin.psi.KtPsiFactory
@@ -321,11 +320,11 @@ class DefaultElementScope(project: Project) : ElementScope {
   override fun stringTemplate(content: String): Scope<KtStringTemplateExpression> =
     Scope(delegate.createStringTemplate(content))
 
-  override val String.packageDirective: Scope<KtPackageDirective>
-    get() = Scope(delegate.createPackageDirective(FqName(trimMargin())))
+  override val String.`package`: PackageDirective
+    get() = PackageDirective(delegate.createPackageDirective(FqName(trimMargin())))
 
-  override val String.packageDirectiveOrNull: Scope<KtPackageDirective>
-    get() = Scope(delegate.createPackageDirectiveIfNeeded(FqName(trimMargin())))
+  override val String.packageDirectiveOrNull: PackageDirective
+    get() = PackageDirective(delegate.createPackageDirectiveIfNeeded(FqName(trimMargin())))
 
   override fun importDirective(importPath: ImportPath): ImportDirective =
     ImportDirective(delegate.createImportDirective(importPath))
@@ -439,8 +438,5 @@ class DefaultElementScope(project: Project) : ElementScope {
   
   override val String.classBody: ClassBody
     get() = ClassBody(delegate.createClass("class _ClassBodyScopeArrowMeta ${trimMargin()}").body)
-  
-  override val String.`package`: PackageDirective
-    get() = PackageDirective(delegate.createFile(trimMargin()).packageDirective)
 }
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -56,7 +56,6 @@ import org.jetbrains.kotlin.psi.KtFunctionTypeReceiver
 import org.jetbrains.kotlin.psi.KtInitializerList
 import org.jetbrains.kotlin.psi.KtLabeledExpression
 import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
-import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtPrimaryConstructor
 import org.jetbrains.kotlin.psi.KtPropertyDelegate
 import org.jetbrains.kotlin.psi.KtSecondaryConstructor
@@ -255,9 +254,9 @@ interface ElementScope {
   
   fun stringTemplate(content: String): Scope<KtStringTemplateExpression>
   
-  val String.packageDirective: Scope<KtPackageDirective>
+  val String.`package`: PackageDirective
 
-  val String.packageDirectiveOrNull: Scope<KtPackageDirective>
+  val String.packageDirectiveOrNull: PackageDirective
   
   fun importDirective(importPath: ImportPath): ImportDirective
   
@@ -331,8 +330,6 @@ interface ElementScope {
   val String.functionLiteral: FunctionLiteral
   
   val String.classBody: ClassBody
-
-  val String.`package`: PackageDirective
   /**
    * Creates an expression that has reference to its context
    *

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -9,6 +9,7 @@ import arrow.meta.quotes.declaration.PropertyAccessor
 import arrow.meta.quotes.element.CatchClause
 import arrow.meta.quotes.element.FinallySection
 import arrow.meta.quotes.element.ImportDirective
+import arrow.meta.quotes.element.PackageDirective
 import arrow.meta.quotes.element.ParameterList
 import arrow.meta.quotes.element.ValueArgument
 import arrow.meta.quotes.element.WhenEntry
@@ -331,6 +332,7 @@ interface ElementScope {
   
   val String.classBody: ClassBody
 
+  val String.`package`: PackageDirective
   /**
    * Creates an expression that has reference to its context
    *

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
@@ -8,6 +8,7 @@ import arrow.meta.quotes.classorobject.ObjectDeclaration
 import arrow.meta.quotes.declaration.DestructuringDeclaration
 import arrow.meta.quotes.element.CatchClause
 import arrow.meta.quotes.element.ImportDirective
+import arrow.meta.quotes.element.PackageDirective
 import arrow.meta.quotes.element.ValueArgument
 import arrow.meta.quotes.element.WhenEntry
 import arrow.meta.quotes.element.whencondition.WhenCondition
@@ -50,6 +51,7 @@ import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtObjectDeclaration
+import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.psi.KtProperty
 import org.jetbrains.kotlin.psi.KtReturnExpression
@@ -333,3 +335,12 @@ fun Meta.classBody(
   map: ClassBody.(KtClassBody) -> Transform<KtClassBody>
 ): ExtensionPhase =
   quote(match, map) { ClassBody(it) }
+
+/**
+ * @see [PackageDirective]
+ */
+fun Meta.packageDirective(
+  match: KtPackageDirective.() -> Boolean,
+  map: PackageDirective.(KtPackageDirective) -> Transform<KtPackageDirective>
+): ExtensionPhase =
+  quote(match, map) { PackageDirective(it) }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/element/PackageDirective.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/element/PackageDirective.kt
@@ -1,0 +1,40 @@
+package arrow.meta.quotes.element
+
+import arrow.meta.quotes.Scope
+import arrow.meta.quotes.ScopedList
+import org.jetbrains.kotlin.psi.KtElement
+import org.jetbrains.kotlin.psi.KtPackageDirective
+import org.jetbrains.kotlin.psi.KtSimpleNameExpression
+
+/**
+ * <code>""" package $`package` """.`package`</code>
+ *
+ * A template destructuring [Scope] for a [KtPackageDirective].
+ *
+ * ``kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.Plugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.packageDirective
+ *
+ * val Meta.reformatPackage: Plugin
+ *  get() =
+ *  "ReformatPackage" {
+ *   meta(
+ *    packageDirective({ true }) { e ->
+ *     Transform.replace(
+ *      replacing = e,
+ *      newDeclaration = """ package $`package` """.`package`
+ *     )
+ *    }
+ *   )
+ *  }
+ *```
+ */
+data class PackageDirective(
+  override val value: KtPackageDirective?,
+  val `package`: Scope<KtElement> = Scope(value?.packageNameExpression),
+  val packages: ScopedList<KtSimpleNameExpression> = ScopedList(value?.packageNames ?: listOf()),
+  val lastPackage: Scope<KtSimpleNameExpression> = Scope(value?.lastReferenceExpression)
+) : Scope<KtPackageDirective>(value)

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/element/PackageDirective.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/element/PackageDirective.kt
@@ -7,7 +7,7 @@ import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtSimpleNameExpression
 
 /**
- * <code>""" package $`package` """.`package`</code>
+ * <code>""" $`package` """.`package`</code>
  *
  * A template destructuring [Scope] for a [KtPackageDirective].
  *
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtSimpleNameExpression
  *    packageDirective({ true }) { e ->
  *     Transform.replace(
  *      replacing = e,
- *      newDeclaration = """ package $`package` """.`package`
+ *      newDeclaration = """ $`package` """.`package`
  *     )
  *    }
  *   )

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
@@ -12,7 +12,6 @@ import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.psi.KtFileAnnotationList
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtImportList
-import org.jetbrains.kotlin.psi.KtPackageDirective
 import org.jetbrains.kotlin.psi.KtScript
 import org.jetbrains.kotlin.psi.stubs.KotlinFileStub
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
@@ -2,6 +2,7 @@ package arrow.meta.quotes.filebase
 
 import arrow.meta.quotes.Scope
 import arrow.meta.quotes.ScopedList
+import arrow.meta.quotes.element.PackageDirective
 import org.jetbrains.kotlin.com.intellij.openapi.fileTypes.FileType
 import org.jetbrains.kotlin.com.intellij.psi.PsiClass
 import org.jetbrains.kotlin.name.FqName
@@ -51,7 +52,7 @@ class File(
   val importList: Scope<KtImportList> = Scope(value.importList), // TODO KtImportList scope and quote template
   val fileAnnotationList: Scope<KtFileAnnotationList>? = Scope(value.fileAnnotationList), // TODO KtFileAnnotationList scope and quote template
   val importDirectives: ScopedList<KtImportDirective> = ScopedList(value = value.importDirectives, postfix = ", "),
-  val packageDirective: Scope<KtPackageDirective> = Scope(value.packageDirective), // TODO KtPackageDirective scope and quote template
+  val packageDirective: PackageDirective = PackageDirective(value.packageDirective),
   val packageFqName: FqName = value.packageFqName,
   val packageFqNameByTree: FqName = value.packageFqNameByTree,
   val script: Scope<KtScript>? = Scope(value.script), // TODO KtScript scope and quote template

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/PackageDirectiveTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/PackageDirectiveTest.kt
@@ -1,0 +1,41 @@
+package arrow.meta.quotes.scope
+
+import arrow.meta.plugin.testing.Code
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.CompilerTest.Companion.source
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.PackageDirectivePlugin
+import io.kotlintest.specs.AnnotationSpec
+
+class PackageDirectiveTest : AnnotationSpec() {
+  
+  @Test
+  fun `validate package is transformed correctly`() {
+    validate("test")
+  }
+  
+  @Test
+  fun `validate package names are reduced correctly`() {
+    validate("package_names")
+  }
+  
+  @Test
+  fun `validate last package name is transformed correctly`() {
+    validate("package_last_name")
+  }
+  
+  private fun validate(lastPackage: String): Unit {
+    assertThis(CompilerTest(
+      config = { listOf(addMetaPlugins(PackageDirectivePlugin())) },
+      code = { packageDeclaration(lastPackage) },
+      assert = { quoteOutputMatches(packageDeclaration(lastPackage)) }
+    ))
+  }
+  
+  private fun packageDeclaration(lastPackage: String): Code.Source {
+    return """
+           | //metadebug
+           | package arrow.meta.quotes.scope.$lastPackage
+           """.source
+  }
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/PackageDirectivePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/PackageDirectivePlugin.kt
@@ -21,7 +21,7 @@ private val Meta.packageDirectivePlugin
       packageDirective({ packageNames.last().text == "test" }) { e ->
         Transform.replace(
           replacing = e,
-          newDeclaration = """ package $`package` """.`package`
+          newDeclaration = """ $`package` """.`package`
         )
       }
     )
@@ -33,7 +33,7 @@ private val Meta.packageDirectivePackageNames
       packageDirective({ packageNames.last().text == "package_names" }) { e ->
         Transform.replace(
           replacing = e,
-          newDeclaration = """ package ${packages.value.map { it.text }.reduce { acc, packageName -> "$acc.$packageName" }} """.`package`
+          newDeclaration = """ ${packages.value.map { it.text }.reduce { acc, packageName -> "$acc.$packageName" }} """.`package`
         )
       }
     )
@@ -45,7 +45,7 @@ private val Meta.packageDirectiveLastPackageName
       packageDirective({ packageNames.last().text == "package_last_name" }) { e ->
         Transform.replace(
           replacing = e,
-          newDeclaration = """ package arrow.meta.quotes.scope.$lastPackage """.`package`
+          newDeclaration = """ arrow.meta.quotes.scope.$lastPackage """.`package`
         )
       }
     )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/PackageDirectivePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/PackageDirectivePlugin.kt
@@ -1,0 +1,52 @@
+package arrow.meta.quotes.scope.plugins
+
+import arrow.meta.Meta
+import arrow.meta.Plugin
+import arrow.meta.invoke
+import arrow.meta.phases.CompilerContext
+import arrow.meta.quotes.Transform
+import arrow.meta.quotes.packageDirective
+
+open class PackageDirectivePlugin : Meta {
+  override fun intercept(ctx: CompilerContext): List<Plugin> = listOf(
+    packageDirectivePlugin,
+    packageDirectivePackageNames,
+    packageDirectiveLastPackageName
+  )
+}
+
+private val Meta.packageDirectivePlugin
+  get() = "Package Directive Scope Plugin" {
+    meta(
+      packageDirective({ packageNames.last().text == "test" }) { e ->
+        Transform.replace(
+          replacing = e,
+          newDeclaration = """ package $`package` """.`package`
+        )
+      }
+    )
+  }
+
+private val Meta.packageDirectivePackageNames
+  get() = "Package Directive Package Names Scope Plugin" {
+    meta(
+      packageDirective({ packageNames.last().text == "package_names" }) { e ->
+        Transform.replace(
+          replacing = e,
+          newDeclaration = """ package ${packages.value.map { it.text }.reduce { acc, packageName -> "$acc.$packageName" }} """.`package`
+        )
+      }
+    )
+  }
+
+private val Meta.packageDirectiveLastPackageName
+  get() = "Package Directive Last Package Name Scope Plugin" {
+    meta(
+      packageDirective({ packageNames.last().text == "package_last_name" }) { e ->
+        Transform.replace(
+          replacing = e,
+          newDeclaration = """ package arrow.meta.quotes.scope.$lastPackage """.`package`
+        )
+      }
+    )
+  }


### PR DESCRIPTION
### Checklist for `KtPackageDirective`
 - [x] Added/replaced the inverse element in ElementScope
 - [x] Destructure and make available all methods related to rendering properties, but no logic
 - [x] Add documentation for element
 - [x] Testing added for validation to ensure all properties can be used as a commutative identity

#89 