### PR TITLE
PBT bug fix

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/BinaryExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/BinaryExpression.kt
@@ -25,7 +25,7 @@ import org.jetbrains.kotlin.psi.KtOperationReferenceExpression
  *     binaryExpression({ true }) { e ->
  *      Transform.replace(
  *       replacing = e,
- *       newDeclaration = """$left $operationReference $right""".binaryExpression
+ *       newDeclaration = """$left$operationReference$right""".binaryExpression
  *      )
  *      }
  *     )
@@ -39,5 +39,5 @@ class BinaryExpression(
   val operationReference: Scope<KtOperationReferenceExpression>? = Scope(value.operationReference)
 ): Scope<KtBinaryExpression>(value) {
   override fun ElementScope.identity(): BinaryExpression =
-    """$left $operationReference $right""".binaryExpression
+    """$left$operationReference$right""".binaryExpression
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/BinaryExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/BinaryExpression.kt
@@ -39,5 +39,5 @@ class BinaryExpression(
   val operationReference: Scope<KtOperationReferenceExpression>? = Scope(value.operationReference)
 ): Scope<KtBinaryExpression>(value) {
   override fun ElementScope.identity(): BinaryExpression =
-    """$left$operationReference$right""".binaryExpression
+    """$right$operationReference$left""".binaryExpression
 }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/QuoteTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/QuoteTest.kt
@@ -1,12 +1,34 @@
 package arrow.meta.quotes.scope
 
+import arrow.meta.plugin.testing.Code
 import arrow.meta.plugin.testing.CompilerTest
 import arrow.meta.plugin.testing.assertThis
-import arrow.meta.quotes.scope.expressions.*
+import arrow.meta.quotes.scope.expressions.binaryExpression
+import arrow.meta.quotes.scope.expressions.blockExpression
+import arrow.meta.quotes.scope.expressions.breakExpression
+import arrow.meta.quotes.scope.expressions.catchClauseExpression
+import arrow.meta.quotes.scope.expressions.classBodyExpressions
+import arrow.meta.quotes.scope.expressions.continueExpressions
+import arrow.meta.quotes.scope.expressions.dotQualifiedExpressions
+import arrow.meta.quotes.scope.expressions.forExpressions
+import arrow.meta.quotes.scope.expressions.functionalLiteralExpressions
+import arrow.meta.quotes.scope.expressions.ifExpressions
+import arrow.meta.quotes.scope.expressions.importDirectiveExpression
+import arrow.meta.quotes.scope.expressions.isExpressions
+import arrow.meta.quotes.scope.expressions.objectDeclarationExpression
+import arrow.meta.quotes.scope.expressions.packageExpression
+import arrow.meta.quotes.scope.expressions.returnExpressions
+import arrow.meta.quotes.scope.expressions.throwExpression
+import arrow.meta.quotes.scope.expressions.tryExpression
+import arrow.meta.quotes.scope.expressions.typeAliasExpressions
+import arrow.meta.quotes.scope.expressions.typeReferenceExpression
+import arrow.meta.quotes.scope.expressions.whenConditionExpression
+import arrow.meta.quotes.scope.expressions.whenEntryExpression
+import arrow.meta.quotes.scope.expressions.whileExpression
 import arrow.meta.quotes.scope.plugins.GenericPlugin
-import org.junit.Test
+import io.kotlintest.specs.AnnotationSpec
 
-class QuoteTest {
+class QuoteTest: AnnotationSpec() {
 
   @Test
   fun `Validate expression scope properties`() {
@@ -41,10 +63,12 @@ class QuoteTest {
       // whenExpression, // TODO failing compilation:  Expecting a when-condition, Expecting an expression, is-condition or in-condition
       whileExpression
     ).forEach { expression: String ->
+      val source = Code.Source(text = expression)
+
       assertThis(CompilerTest(
         config = { listOf(addMetaPlugins(GenericPlugin())) },
-        code = { expression.source },
-        assert = { quoteOutputMatches(expression.source) }
+        code = { source },
+        assert = { quoteOutputMatches(source) }
       ))
     }
   }


### PR DESCRIPTION
In quote test:
```
forEach { expression: String ->
      assertThis(CompilerTest(
        config = { listOf(addMetaPlugins(GenericPlugin())) },
        code = { expression.source },
        assert = { quoteOutputMatches(expression.source) }
      ))
    }
```
^ this is always going to pass because in testing, what is evaluated is the reference to the object.  That means even when the value of that reference changes, then you end up evaluating expression.source to expression.source. It's better to change the evaluation you're feeding in and comparing as static values.