### PR TITLE
Fix for upcoming identity law

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/element/PackageDirective.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/element/PackageDirective.kt
@@ -44,8 +44,8 @@ data class PackageDirective(
 ) : Scope<KtPackageDirective>(value) {
 
   override fun ElementScope.identity(): Scope<KtPackageDirective> =
-    """$`package`""".`package`
-
-  fun ElementScope.secondIdentity(): Scope<KtPackageDirective> =
-    """$packages""".`package`
+    when {
+      packages.isEmpty() -> """$`package`""".`package`
+      else -> """$packages""".`package`
+    }
 }

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/WhenExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/WhenExpression.kt
@@ -1,5 +1,6 @@
 package arrow.meta.quotes.expression
 
+import arrow.meta.phases.analysis.ElementScope
 import arrow.meta.quotes.Scope
 import arrow.meta.quotes.ScopedList
 import org.jetbrains.kotlin.psi.KtExpression
@@ -41,4 +42,10 @@ class WhenExpression(
   val entries: ScopedList<KtWhenEntry> = ScopedList(value?.entries.orEmpty()),
   val `(expression)`: Scope<KtExpression> = Scope(value?.subjectExpression),
   val `else`: Scope<KtExpression> = Scope(value?.elseExpression)
-) : Scope<KtWhenExpression>(value)
+) : Scope<KtWhenExpression>(value) {
+  override fun ElementScope.identity(): Scope<KtWhenExpression> =
+    """
+    | when $`(expression)`{ 
+    |   $entries
+    | }""".`when`
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ClassBodyPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/ClassBodyPlugin.kt
@@ -41,14 +41,7 @@ private val Meta.enumBody
         classBody({ true }) { c ->
           Transform.replace(
             replacing = c,
-            newDeclaration =
-            """
-            | {
-            |  $enumEntries
-            |
-            |  $functions
-            | }
-            """.classBody
+            newDeclaration = identity()
           )
         }
       )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/PackageDirectivePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/PackageDirectivePlugin.kt
@@ -33,7 +33,7 @@ private val Meta.packageDirectivePackageNames
       packageDirective({ packageNames.last().text == "package_names" }) { element ->
         Transform.replace(
           replacing = element,
-          newDeclaration = secondIdentity()
+          newDeclaration = identity()
         )
       }
     )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/WhenExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/WhenExpressionPlugin.kt
@@ -19,11 +19,7 @@ val Meta.whenExpressionPlugin
       whenExpression({ true }) { e ->
         Transform.replace(
           replacing = e,
-          newDeclaration =
-          """
-            | when $`(expression)`{ 
-            |   $entries
-            | }""".`when`
+          newDeclaration = identity()
         )
       }
     )

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/templates/WhenExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/templates/WhenExpressionTest.kt
@@ -30,7 +30,7 @@ class WhenExpressionTest  {
     assertThis(CompilerTest(
       config = { listOf(addMetaPlugins(WhenExpressionPlugin())) },
       code = { whenExpression },
-      assert = { compiles } //quoteOutputMatches(whenExpression) }
+      assert = { quoteOutputMatches(whenExpression) }
     ))
   }
 }


### PR DESCRIPTION
- Remove `secondIdentity` for `PackageDirective`. Reason: if we have `identity` and `secondIdentity` for an element, it won't be possible to ensure the identity law.
- Move new declarations to `identity`.
- Check of quote output in any case.

cc @ahinchman1 