### PR TITLE
Sync: consider Kotlin, Kotlin IDEA and Intellij IDEA versions

### DIFF
--- a/.github/workflows/kotlin-sync.yml
+++ b/.github/workflows/kotlin-sync.yml
@@ -18,12 +18,23 @@ jobs:
     - name: Update versions
       id: update
       run: |
-        LATEST_EAP_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-eap/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
-        echo "Latest EAP version: $LATEST_EAP_VERSION"
-        echo ::set-output name=version::"$LATEST_EAP_VERSION"
-        sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_EAP_VERSION/g" gradle.properties
-        NEW_VERSION=$(echo $LATEST_EAP_VERSION | cut -d- -f1)
-        sed -i "s/^VERSION_NAME=.*$/VERSION_NAME=${NEW_VERSION}-SNAPSHOT/g" gradle.properties
+        sudo apt-get install html2text
+        LATEST_KOTLIN_VERSION=$(curl https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
+        echo "Latest Kotlin version: $LATEST_KOTLIN_VERSION"
+        curl -o intellij-idea-releases.html https://www.jetbrains.com/intellij-repository/releases/
+        html2text -style pretty -o intellij-idea-releases.txt intellij-idea-releases.html
+        LATEST_INTELLIJ_IDEA_VERSION=$(grep -A 100 'com.jetbrains.intellij.idea' intellij-idea-releases.txt | grep -o -e '^[0-9]\+\.[0-9]\+\.\?[0-9]*' | head -2 | tail -1)
+        rm -f intellij-idea-releases*
+        echo "Latest Intellij IDEA version: $LATEST_INTELLIJ_IDEA_VERSION"
+        LATEST_KOTLIN_IDEA_VERSION=${LATEST_KOTLIN_VERSION}-release-IJ$(echo $LATEST_INTELLIJ_IDEA_VERSION | cut -d. -f1-2)-1
+        echo "Latest Kotlin IDEA version: $LATEST_KOTLIN_IDEA_VERSION"
+        sed -i "s/^VERSION_NAME=.*$/VERSION_NAME=${LATEST_KOTLIN_VERSION}-SNAPSHOT/g" gradle.properties
+        sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_VERSION/g" gradle.properties
+        sed -i "s/^KOTLIN_IDEA_VERSION=.*$/KOTLIN_IDEA_VERSION=$LATEST_KOTLIN_IDEA_VERSION/g" gradle.properties
+        sed -i "s/^INTELLIJ_IDEA_VERSION=.*$/INTELLIJ_IDEA_VERSION=$LATEST_INTELLIJ_IDEA_VERSION/g" gradle.properties
+        echo ::set-output name=kotlin-version::"$LATEST_KOTLIN_VERSION"
+        echo ::set-output name=kotlin-idea-version::"$LATEST_KOTLIN_IDEA_VERSION"
+        echo ::set-output name=intellij-idea-version::"$LATEST_INTELLIJ_IDEA_VERSION"
         echo ::set-output name=differences::$(git diff gradle.properties)
     - name: Build Arrow Meta
       if: steps.update.outputs.differences != ''
@@ -40,8 +51,8 @@ jobs:
       uses: peter-evans/create-pull-request@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: Sync with Kotlin version
-        title: "Sync with Kotlin version: ${{ steps.update.outputs.version }}"
+        commit-message: Sync versions for Kotlin, Kotlin IDEA plugin and Intellij IDEA
+        title: "Sync: Kotlin=${{ steps.update.outputs.kotlin-version }}, Kotlin IDEA=${{ steps.update.outputs.kotlin-idea-version }}, Intellij IDEA=${{ steps.update.outputs.intellij-idea-version }}"
         body: Generated automatically
         branch: sync/kotlin
         branch-suffix: short-commit-hash
@@ -53,7 +64,7 @@ jobs:
     - name: Prepare environment to create the issue (new package)
       if: failure()
       run: |
-        echo ${{ steps.update.outputs.version }} > version
+        echo "Kotlin=${{ steps.update.outputs.kotlin-version }}, Kotlin IDEA=${{ steps.update.outputs.kotlin-idea-version }}, Intellij IDEA=${{ steps.update.outputs.intellij-idea-version }}" > versions
         echo "* LINK: https://github.com/arrow-kt/arrow-meta/commit/$GITHUB_SHA/checks" >> stderr
         rm -rf /home/runner/work/_actions/actions/github-script/0.3.0/node_modules
         cd /home/runner/work/_actions/actions/github-script/0.3.0/
@@ -77,7 +88,7 @@ jobs:
             return content;
           }
           await github.issues.create({...context.repo, 
-            title: 'Sync with Kotlin Compiler: ' + readFile("file:///home/runner/work/arrow-meta/arrow-meta/version"), 
+            title: 'Sync: ' + readFile("file:///home/runner/work/arrow-meta/arrow-meta/versions"), 
             body: ' * FAILURE: \n' + readFile("file:///home/runner/work/arrow-meta/arrow-meta/stderr"),
             assignees: ['raulraja', 'i-walker', 'ahinchman1', 'rachelcarmena'],
             labels: ['critical', 'Kotlin version upgrade']});


### PR DESCRIPTION
### Reason
Just Kotlin version was considered by sync bot so far.
### Changes
With this pull request, **sync bot** will keep Kotlin, Kotlin IDEA and Intellij IDEA versions updated.
### **Expected result**
**Sync bot** will create a pull request tomorrow morning to update to latest versions.
### Next step 
Add tests with latest Kotlin DEV version and latest Kotlin EAP version to **sync bot**.