### PR TITLE
Sync: test latest Kotlin EAP and DEV versions

### DIFF
--- a/.github/workflows/kotlin-sync.yml
+++ b/.github/workflows/kotlin-sync.yml
@@ -15,10 +15,30 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    - name: Test latest Kotlin EAP version
+      run: |
+        LATEST_KOTLIN_EAP_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-eap/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
+        echo "Kotlin=$LATEST_KOTLIN_EAP_VERSION" > versions
+        sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_EAP_VERSION/g" gradle.properties
+        sed -i "s/mavenCentral()/mavenCentral()\\nmaven { url \"https:\/\/dl.bintray.com\/kotlin\/kotlin-eap\/\" }/g" build.gradle
+        echo "Latest Kotlin version: $LATEST_KOTLIN_EAP_VERSION"
+        ./gradlew clean :compiler-plugin:build 2> stderr
+    - name: Test latest Kotlin DEV version
+      run: |
+        git checkout gradle.properties
+        git checkout build.gradle
+        LATEST_KOTLIN_DEV_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
+        echo "Kotlin=$LATEST_KOTLIN_DEV_VERSION" > versions
+        sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_DEV_VERSION/g" gradle.properties
+        sed -i "s/mavenCentral()/mavenCentral()\\nmaven { url \"https:\/\/dl.bintray.com\/kotlin\/kotlin-dev\/\" }/g" build.gradle
+        echo "Latest Kotlin version: $LATEST_KOTLIN_DEV_VERSION"
+        ./gradlew clean :compiler-plugin:build 2> stderr
     - name: Update versions
       id: update
       run: |
         sudo apt-get install html2text
+        git checkout gradle.properties
+        git checkout build.gradle
         LATEST_KOTLIN_VERSION=$(curl https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
         echo "Latest Kotlin version: $LATEST_KOTLIN_VERSION"
         curl -o intellij-idea-releases.html https://www.jetbrains.com/intellij-repository/releases/
@@ -39,7 +59,8 @@ jobs:
     - name: Build Arrow Meta
       if: steps.update.outputs.differences != ''
       run: |
-        ./gradlew :compiler-plugin:build 2> stderr
+        echo "Kotlin=${{ steps.update.outputs.kotlin-version }}, Kotlin IDEA=${{ steps.update.outputs.kotlin-idea-version }}, Intellij IDEA=${{ steps.update.outputs.intellij-idea-version }}" > versions
+        ./gradlew clean :compiler-plugin:build 2> stderr
         ./gradlew :idea-plugin:build 2> stderr
         ./gradlew :testing-plugin:build 2> stderr
         ./gradlew :gradle-plugin:jar 2> stderr
@@ -47,6 +68,7 @@ jobs:
       id: prepare-pr
       if: steps.update.outputs.differences != ''
       run: |
+        rm -f versions
         rm -f stderr
         LAST_COMMIT_HASH=$(git log -1 --pretty=%h)
         echo "::set-output name=last-commit-hash::$LAST_COMMIT_HASH"
@@ -69,8 +91,11 @@ jobs:
     - name: Prepare environment to create the issue (new package)
       if: failure()
       run: |
-        echo "Kotlin=${{ steps.update.outputs.kotlin-version }}, Kotlin IDEA=${{ steps.update.outputs.kotlin-idea-version }}, Intellij IDEA=${{ steps.update.outputs.intellij-idea-version }}" > versions
-        echo "* LINK: https://github.com/arrow-kt/arrow-meta/commit/$GITHUB_SHA/checks" >> stderr
+        echo -e "I've found this error:\n\n" > issue.log
+        echo -e "* **VERSIONS**: $(cat versions)\n" >> issue.log
+        echo -e "* **NOTE**: If you want to reproduce the error in a local environment, replace the versions in \`gradle.properties\` file and add \`https://dl.bintray.com/kotlin/kotlin-eap/\` repository or \`https://dl.bintray.com/kotlin/kotlin-dev/\` repository for Kotlin EAP version or Kotlin DEV version, respectively.\n" >> issue.log
+        echo -e "* **ERROR LOG**: https://github.com/rachelcarmena/test/commit/$GITHUB_SHA/checks\n" >> issue.log
+        echo -e "* **ERROR**:\n\n$(cat stderr)\n" >> issue.log
         rm -rf /home/runner/work/_actions/actions/github-script/0.3.0/node_modules
         cd /home/runner/work/_actions/actions/github-script/0.3.0/
         npm install
@@ -94,6 +119,6 @@ jobs:
           }
           await github.issues.create({...context.repo, 
             title: 'Sync: ' + readFile("file:///home/runner/work/arrow-meta/arrow-meta/versions"), 
-            body: ' * FAILURE: \n' + readFile("file:///home/runner/work/arrow-meta/arrow-meta/stderr"),
+            body: readFile("file:///home/runner/work/arrow-meta/arrow-meta/issue.log"),
             assignees: ['raulraja', 'i-walker', 'ahinchman1', 'rachelcarmena'],
             labels: ['critical', 'Kotlin version upgrade']});

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ buildscript {
   repositories {
     mavenCentral()
     maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
-    maven { url "https://dl.bintray.com/kotlin/kotlin-eap/" }
   }
   dependencies {
     classpath "org.jetbrains.dokka:dokka-gradle-plugin:$DOKKA_VERSION"
@@ -43,7 +42,6 @@ allprojects {
     mavenCentral()
     jcenter()
     maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
-    maven { url 'https://dl.bintray.com/kotlin/kotlin-eap/' }
     maven { url 'https://jitpack.io' } 
   }
 }


### PR DESCRIPTION
- Remove EAP repository from `build.gradle` by default.
- Add DEV or EAP repository according to the test.
- Check `compiler-plugin` with latest Kotlin DEV version and latest Kotlin EAP version. 
- Create an issue in case of failure.