### PR TITLE
Update Arrow Meta Intellij IDEA Plugin documentation

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -37,15 +37,15 @@ buildSearchableOptions.enabled = false
 
 intellij {
   version = "$INTELLIJ_IDEA_VERSION"
-  pluginName = "Arrow plugin"
+  pluginName = "Arrow Meta Intellij IDEA Plugin"
   plugins = ["gradle", "java", "org.jetbrains.kotlin:${KOTLIN_IDEA_VERSION}"]
 }
 
-patchPluginXml {
+/*patchPluginXml {
   changeNotes """
       Add change notes here.<br>
       <em>most HTML tags may be used</em>"""
-}
+}*/
 
 runIde {
   jvmArgs '-Xmx2G'

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -1,12 +1,11 @@
 <idea-plugin>
-    <id>arrow-plugin</id>
-    <name>Arrow</name>
+    <id>io.arrow-kt.arrow</id>
+    <name>Arrow Meta</name>
 
     <vendor email="hello@47deg.com" url="https://arrow-kt.io/">Arrow</vendor>
 
     <description><![CDATA[
-    The Arrow Intellij IDEA plugin.<br>
-    <em>most HTML tags may be used</em>
+    The Arrow Meta Intellij IDEA plugin.
     ]]></description>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html

--- a/idea-plugin/src/main/resources/META-INF/pluginIcon.svg
+++ b/idea-plugin/src/main/resources/META-INF/pluginIcon.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96px" height="107px" viewBox="0 0 96 107" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 56.3 (101010) - https://sketch.com -->
+    <title>1D529572-0E03-4E3B-B088-5641C8D16165</title>
+    <desc>Created with sketchtool.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="9.97548296%" x2="50%" y2="99.7788683%" id="linearGradient-1">
+            <stop stop-color="#CE1010" offset="0%"></stop>
+            <stop stop-color="#9D1212" offset="99.9181799%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="9.6303304%" x2="50%" y2="99.7141409%" id="linearGradient-2">
+            <stop stop-color="#F63F18" offset="0%"></stop>
+            <stop stop-color="#950F0F" offset="99.9366554%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="-7.62502133%" x2="50%" y2="76.062468%" id="linearGradient-3">
+            <stop stop-color="#132532" offset="0%"></stop>
+            <stop stop-color="#132532" stop-opacity="0" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="91.6085379%" id="linearGradient-4">
+            <stop stop-color="#E5E5E5" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Arrow-Website" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Arrow-Meta-Hover" transform="translate(-115.000000, -98.000000)">
+            <g id="sidebar" transform="translate(0.000000, 40.000000)">
+                <g id="logos/arrow-meta/color" transform="translate(103.000000, 58.000000)">
+                    <polygon id="Path-Copy" fill="url(#linearGradient-1)" points="60 0 12 96 61.8349609 71.125"></polygon>
+                    <polygon id="Path-Copy-2" fill="url(#linearGradient-2)" transform="translate(84.000000, 48.000000) scale(-1, 1) translate(-84.000000, -48.000000) " points="108 0 60 96 108 72"></polygon>
+                    <rect id="bound-copy" opacity="0.261579241" x="46" y="56" width="28" height="28"></rect>
+                    <polygon id="Path-5-Copy-5" fill-opacity="0.7" fill="url(#linearGradient-3)" points="12 96 60.0029907 72 108 96 60 117.773437"></polygon>
+                    <polygon id="Path-Copy" fill="#FFFFFF" points="60.0794811 48 36 96 61 83.5625"></polygon>
+                    <polygon id="Path-Copy-2" fill="url(#linearGradient-4)" transform="translate(72.000000, 72.000000) scale(-1, 1) translate(-72.000000, -72.000000) " points="84 48 60 96 84 84"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/idea-plugin/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/idea-plugin/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="96px" height="107px" viewBox="0 0 96 107" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: sketchtool 56.3 (101010) - https://sketch.com -->
+    <title>1D529572-0E03-4E3B-B088-5641C8D16165</title>
+    <desc>Created with sketchtool.</desc>
+    <defs>
+        <linearGradient x1="50%" y1="9.97548296%" x2="50%" y2="99.7788683%" id="linearGradient-1">
+            <stop stop-color="#CE1010" offset="0%"></stop>
+            <stop stop-color="#9D1212" offset="99.9181799%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="9.6303304%" x2="50%" y2="99.7141409%" id="linearGradient-2">
+            <stop stop-color="#F63F18" offset="0%"></stop>
+            <stop stop-color="#950F0F" offset="99.9366554%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="-7.62502133%" x2="50%" y2="76.062468%" id="linearGradient-3">
+            <stop stop-color="#132532" offset="0%"></stop>
+            <stop stop-color="#132532" stop-opacity="0" offset="100%"></stop>
+        </linearGradient>
+        <linearGradient x1="50%" y1="0%" x2="50%" y2="91.6085379%" id="linearGradient-4">
+            <stop stop-color="#E5E5E5" offset="0%"></stop>
+            <stop stop-color="#FFFFFF" offset="100%"></stop>
+        </linearGradient>
+    </defs>
+    <g id="Arrow-Website" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Arrow-Meta-Hover" transform="translate(-115.000000, -98.000000)">
+            <g id="sidebar" transform="translate(0.000000, 40.000000)">
+                <g id="logos/arrow-meta/color" transform="translate(103.000000, 58.000000)">
+                    <polygon id="Path-Copy" fill="url(#linearGradient-1)" points="60 0 12 96 61.8349609 71.125"></polygon>
+                    <polygon id="Path-Copy-2" fill="url(#linearGradient-2)" transform="translate(84.000000, 48.000000) scale(-1, 1) translate(-84.000000, -48.000000) " points="108 0 60 96 108 72"></polygon>
+                    <rect id="bound-copy" opacity="0.261579241" x="46" y="56" width="28" height="28"></rect>
+                    <polygon id="Path-5-Copy-5" fill-opacity="0.7" fill="url(#linearGradient-3)" points="12 96 60.0029907 72 108 96 60 117.773437"></polygon>
+                    <polygon id="Path-Copy" fill="#FFFFFF" points="60.0794811 48 36 96 61 83.5625"></polygon>
+                    <polygon id="Path-Copy-2" fill="url(#linearGradient-4)" transform="translate(72.000000, 72.000000) scale(-1, 1) translate(-72.000000, -72.000000) " points="84 48 60 96 84 84"></polygon>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
This **minor** PR tries to improve the documentation about IDEA plugin. These data will be shown in the Intellij IDEA plugin page and in the list of installed plugins.

## Screenshots

### Before this PR

For instance, from installed plugins:

![Screenshot from 2019-11-25 19-01-21](https://user-images.githubusercontent.com/22792183/71906820-20d03880-316b-11ea-9abb-051e8e7f2c81.png)

### After this PR

![Screenshot from 2020-01-07 17-22-17](https://user-images.githubusercontent.com/22792183/71910627-8e339780-3172-11ea-9529-1e0614ebdeb4.png)

## Note

Though the icon is shown correctly, it doesn't have the desired properties: http://www.jetbrains.org/intellij/sdk/docs/basics/plugin_structure/plugin_icon_file.html. It would be necessary to resize to 32x36 and then change the size to 40x40 with offset `x=4` and `y=2`.

The logo for a dark theme:

```
idea-plugin/src/main/resources/META-INF/pluginIcon_dark.svg
```

could be improved:

![Screenshot from 2020-01-07 17-22-55](https://user-images.githubusercontent.com/22792183/71910658-9f7ca400-3172-11ea-847f-02200b5ddc8e.png)

## Note

**Arrow** below **Arrow Meta** is the "vendor". It allows to look for other plugins published by the same "vendor".