### PR TITLE
IDEA Plugin: configuration for installation

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -67,7 +67,7 @@ jobs:
       run: |
         echo "Publish Gradle Plugin in Gradle Plugins Portal ..."
         ./gradlew -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET publishPlugins
-    - name: Publish IDEA plugin
+    - name: Publish IDEA plugin repository
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -17,6 +17,16 @@ jobs:
       with:
         java-version: 1.8
         architecture: x64
+    - name: Set compatibility IDEA versions
+      run: |
+        KOTLIN_VERSION=$(grep KOTLIN_VERSION gradle.properties | cut -d= -f2)
+        BRANCH_NUMBER=$(grep INTELLIJ_IDEA_VERSION gradle.properties | cut -d= -f2 | cut -b 3-4,6)
+        curl -o plugin.xml https://raw.githubusercontent.com/JetBrains/kotlin/v$KOTLIN_VERSION/idea/resources/META-INF/plugin.xml.$BRANCH_NUMBER
+        SINCE_BUILD=$(cat plugin.xml | grep -o -e 'since-build="[^"]\+"' | cut -d= -f2)
+        UNTIL_BUILD=$(cat plugin.xml | grep -o -e 'until-build="[^"]\+"' | cut -d= -f2)
+        sed -i "s/patchPluginXml {/patchPluginXml {\\nsinceBuild $SINCE_BUILD\\nuntilBuild $UNTIL_BUILD/g" idea-plugin/build.gradle
+        sed -i "s/%SINCE_BUILD%/$SINCE_BUILD/g" .github/workflows/templates/updatePlugins.xml
+        sed -i "s/%UNTIL_BUILD%/$UNTIL_BUILD/g" .github/workflows/templates/updatePlugins.xml
     - name: Build with Gradle
       env:
         JAVA_OPTS: -Xms512m -Xmx1024m
@@ -57,3 +67,20 @@ jobs:
       run: |
         echo "Publish Gradle Plugin in Gradle Plugins Portal ..."
         ./gradlew -Dgradle.publish.key=$GRADLE_PUBLISH_KEY -Dgradle.publish.secret=$GRADLE_PUBLISH_SECRET publishPlugins
+    - name: Publish IDEA plugin
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        S3_BUCKET: ${{ secrets.S3_BUCKET }}
+      if: steps.properties.outputs.is-snapshot == 'true'
+      run: |
+        VERSION_NAME=$(grep VERSION_NAME gradle.properties | cut -d= -f2)
+        VERSION_NUMBER=$(echo $VERSION_NAME | cut -d- -f1)
+        curl -o maven-metadata.xml https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-idea-plugin/$VERSION_NAME/maven-metadata.xml
+        TIMESTAMP=$(grep timestamp maven-metadata.xml | cut -d'>' -f2 | cut -d'<' -f1)
+        BUILD_NUMBER=$(grep buildNumber maven-metadata.xml | cut -d'>' -f2 | cut -d'<' -f1)
+        sed -i "s/%MAIN_VERSION%/$VERSION_NAME/g" .github/workflows/templates/updatePlugins.xml
+        sed -i "s/%SPECIFIC_VERSION%/$VERSION_NUMBER-$TIMESTAMP-$BUILD_NUMBER/g" .github/workflows/templates/updatePlugins.xml
+        mkdir -p artifacts/idea-plugin/snapshots/$VERSION_NAME
+        cp .github/workflows/templates/updatePlugins.xml artifacts/idea-plugin/snapshots/$VERSION_NAME/
+        aws s3 cp artifacts s3://$S3_BUCKET --recursive > aws_sync_jekyll.log

--- a/.github/workflows/templates/updatePlugins.xml
+++ b/.github/workflows/templates/updatePlugins.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plugins>
+    <plugin id="io.arrow-kt.arrow" url="https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-idea-plugin/%MAIN_VERSION%/arrow-meta-idea-plugin-%SPECIFIC_VERSION%.jar" version="%SPECIFIC_VERSION%">
+        <idea-version since-build=%SINCE_BUILD% until-build=%UNTIL_BUILD% />
+    </plugin>
+</plugins>

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -41,11 +41,11 @@ intellij {
   plugins = ["gradle", "java", "org.jetbrains.kotlin:${KOTLIN_IDEA_VERSION}"]
 }
 
-/*patchPluginXml {
-  changeNotes """
+patchPluginXml {
+  /*changeNotes """
       Add change notes here.<br>
-      <em>most HTML tags may be used</em>"""
-}*/
+      <em>most HTML tags may be used</em>"""*/
+}
 
 runIde {
   jvmArgs '-Xmx2G'


### PR DESCRIPTION
## Changes

- Minor change in `idea-plugin/build.gradle` to have `patchPluginXml` task.
- Add a template for IDEA plugin repository:
  * It's useful for installing IDEA plugin when adding a new repository. However, that's not the main purpose. See the following point :wink: 
  * It's useful for trying to install IDEA plugin from Gradle Plugin. It's necessary to have a way to download it. And the version will match with the current Gradle Plugin (see #245).
- Update publish artifacts task:
  * Add the same `since-build` and `until-build` as Kotlin IDEA plugin.
  * Publish the IDEA plugin repository file in S3 bucket to have URLs like `https://meta.arrow-kt.io/artifacts/idea-plugin/snapshots/<version>/updatePlugins.xml`