### PR TITLE
IDEA Plugin: add compiler-plugin

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -31,6 +31,7 @@ jar {
     attributes["Implementation-Title"] = "arrow.meta.plugin.idea"
     attributes["Implementation-Version"] = project.version
   }
+  from configurations.compile.collect { it.isDirectory() ? it : zipTree(it) }
 }
 
 buildSearchableOptions.enabled = false


### PR DESCRIPTION
Checks:
- New content of the jar file
- Installation from settings
- Installation from `plugins` directory

Errors (#398 ) disappeared and the plugin is loaded OK when opening a project:

```
(...)

it's the IDEA plugin

(...)
``` 