### PR TITLE
IDEA plugin: fix version in the repository

### DIFF
--- a/.github/workflows/templates/updatePlugins.xml
+++ b/.github/workflows/templates/updatePlugins.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugins>
-    <plugin id="io.arrow-kt.arrow" url="https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-idea-plugin/%MAIN_VERSION%/arrow-meta-idea-plugin-%SPECIFIC_VERSION%.jar" version="%SPECIFIC_VERSION%">
+    <plugin id="io.arrow-kt.arrow" url="https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/arrow-meta-idea-plugin/%MAIN_VERSION%/arrow-meta-idea-plugin-%SPECIFIC_VERSION%.jar" version="%MAIN_VERSION%">
+        <name>Arrow Meta</name>
+        <description>SNAPSHOT VERSION: %SPECIFIC_VERSION%</description>
         <idea-version since-build=%SINCE_BUILD% until-build=%UNTIL_BUILD% />
     </plugin>
 </plugins>


### PR DESCRIPTION
The specific snapshot version (like `1.3.61-20200109.183401-23`) is only known after publishing the artifact and it must match with the version in `plugin.xml` (inside jar file).

This minor PR fixes the version in the repository and adds additional information which will be available before installing the plugin.

**Note**: the specific version (in case of working with snapshot versions) can be checked in the plugins directory as well (it appears in the jar file).