### PR TITLE
Gradle plugin: install IDEA plugin from a Gradle task

### DIFF
--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/InstallIdeaPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/InstallIdeaPlugin.kt
@@ -1,0 +1,78 @@
+package arrow.meta.plugin.gradle
+
+import com.sun.org.apache.xerces.internal.parsers.DOMParser
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import org.xml.sax.InputSource
+import java.io.File
+import java.net.URL
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.*
+
+open class InstallIdeaPlugin: DefaultTask() {
+
+  // TODO: Consider release version
+
+  @TaskAction
+  fun installPlugin() {
+    if (!inIdea()) {
+      println("Run this task from Intellij IDEA")
+      return
+    }
+
+    if (!pluginsDirExists()) {
+      println("Plugins directory not found")
+      return
+    }
+
+    if (ideaPluginExists()) {
+      println("Arrow Meta IDEA Plugin is already installed!")
+      return
+    }
+
+    println("Arrow Meta IDEA Plugin is not installed! Downloading ...")
+    val properties = Properties()
+    properties.load(this.javaClass.getResourceAsStream("plugin.properties"))
+    val compilerPluginVersion = properties.getProperty("COMPILER_PLUGIN_VERSION")
+    val parser = DOMParser()
+    parser.parse(InputSource(URL("https://meta.arrow-kt.io/idea-plugin/snapshots/$compilerPluginVersion/updatePlugins.xml").openStream()))
+    val artifactURL = parser.document.getElementsByTagName("plugin").item(0).attributes.getNamedItem("url").nodeValue
+    Files.copy(
+      URL(artifactURL).openStream(),
+      Paths.get(pluginsDir(), File(artifactURL).name)
+    )
+    // TODO: dynamic plugin to avoid restarting
+    println("Restart Intellij IDEA to finish the installation!")
+  }
+}
+
+internal fun inIdea(): Boolean =
+  System.getProperty("idea.active") == "true"
+
+internal fun pluginsDirExists(): Boolean =
+  when {
+    System.getProperty("idea.plugins.path") != null ->
+      File(System.getProperty("idea.plugins.path")).exists()
+    System.getProperty("jb.vmOptionsFile") != null ->
+      File(pluginsDirFromVmOptionsFile()).exists()
+    else ->
+      false
+  }
+
+private fun pluginsDir(): String =
+  when {
+    System.getProperty("idea.plugins.path") != null ->
+      System.getProperty("idea.plugins.path")
+    else -> {
+      pluginsDirFromVmOptionsFile()
+    }
+  }
+
+internal fun ideaPluginExists(): Boolean =
+  File(pluginsDir()).listFiles().any { it.name.startsWith("idea-plugin") }
+
+private fun pluginsDirFromVmOptionsFile(): String {
+  val configDir = File(System.getProperty("jb.vmOptionsFile")).parent
+  return Paths.get(configDir, "plugins").toString()
+}


### PR DESCRIPTION
## Goal

Instead of installing Arrow Meta IDEA plugin when applying the Arrow Meta Gradle Plugin, it's installed by a Gradle task.

## Screenshots

From command line:

![Screenshot from 2020-01-13 19-22-57](https://user-images.githubusercontent.com/22792183/72281126-22ea3980-363a-11ea-9d2b-856888b9caaa.png)

When applying the Gradle plugin from Intellij IDEA:

![Screenshot from 2020-01-13 19-07-28](https://user-images.githubusercontent.com/22792183/72280434-a014af00-3638-11ea-9051-43d75adc2c20.png)

When running `install-idea-plugin` task from Intellij IDEA:

![Screenshot from 2020-01-13 19-08-59](https://user-images.githubusercontent.com/22792183/72280509-c6d2e580-3638-11ea-8dc9-8747642225f2.png)

Other situations from Intellij IDEA:

![Screenshot from 2020-01-13 18-59-21](https://user-images.githubusercontent.com/22792183/72280567-e79b3b00-3638-11ea-9b63-1e07ac5fc03f.png)

![Screenshot from 2020-01-13 19-20-40](https://user-images.githubusercontent.com/22792183/72280989-e0286180-3639-11ea-9a83-fbea5c4b47b9.png)
