### PR TITLE
Configuration: fix custom tasks from main build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ plugins {
   // id 'org.jetbrains.kotlin.kapt' version "$KOTLIN_VERSION"
   id 'com.github.johnrengelman.shadow' version "$SHADOW_JAR_VERSION"
   id 'com.jfrog.bintray' version "$BINTRAY_VERSION"
+  id 'maven-publish'
 }
 
 apply plugin: "org.jetbrains.kotlin.jvm"
@@ -53,6 +54,15 @@ subprojects { project ->
 
   apply plugin: 'kotlin'
   apply plugin: 'org.jetbrains.dokka'
+  apply plugin: 'maven-publish'
+
+  publishing {
+      publications {
+          maven(MavenPublication) {
+              from components.java
+          }
+      }
+  }
 
   //dokka log spam `Can't find node by signature` comes from https://github.com/Kotlin/dokka/issues/269
   dokka {
@@ -77,19 +87,33 @@ subprojects { project ->
   }
 }
 
+task cleanMeta {
+  dependsOn ':compiler-plugin:clean'
+  dependsOn ':gradle-plugin:clean'
+  dependsOn ':idea-plugin:clean'
+  dependsOn ':testing-plugin:clean'
+}
+
 task buildMeta {
-  dependsOn 'clean'
-  dependsOn 'build'
-  dependsOn ':gradle-plugin:publishArrowPluginMarkerMavenPublicationToMavenLocal'
-  dependsOn ':gradle-plugin:publishPluginMavenPublicationToMavenLocal'
-  tasks.findByPath(':gradle-plugin:publishArrowPluginMarkerMavenPublicationToMavenLocal').mustRunAfter 'build'
-  tasks.findByPath(':gradle-plugin:publishPluginMavenPublicationToMavenLocal').mustRunAfter 'build'
+  dependsOn ':compiler-plugin:build'
+  dependsOn ':gradle-plugin:jar'
+  dependsOn ':idea-plugin:build'
+  dependsOn ':testing-plugin:build'
+}
+
+task publishMeta {
+  dependsOn ':compiler-plugin:publishToMavenLocal'
+  dependsOn ':gradle-plugin:publishToMavenLocal'
+  dependsOn ':idea-plugin:publishToMavenLocal'
+  dependsOn ':testing-plugin:publishToMavenLocal'
 }
 
 task publishAndRunIde {
-  dependsOn ':buildMeta'
+  dependsOn ':cleanMeta'
+  dependsOn ':publishMeta'
   dependsOn ':idea-plugin:runIde'
-  tasks.findByPath(':idea-plugin:runIde').mustRunAfter ':buildMeta'
+  tasks.findByPath(':publishMeta').mustRunAfter ':cleanMeta'
+  tasks.findByPath(':idea-plugin:runIde').mustRunAfter ':publishMeta'
 }
 
 wrapper {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,6 +1,5 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'maven-publish'
   id 'com.gradle.plugin-publish' version "$GRADLE_PLUGIN_PUBLISH_VERSION"
 }
 


### PR DESCRIPTION
- Move `maven-publish` from Arrow Meta Gradle Plugin to all the modules.
- Fix custom tasks from main `build.gradle`.