### PR TITLE
fix to not export package probably caused for choose runtime plugin

### DIFF
--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/InstallIdeaPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/InstallIdeaPlugin.kt
@@ -1,6 +1,6 @@
 package arrow.meta.plugin.gradle
 
-import com.sun.org.apache.xerces.internal.parsers.DOMParser
+import org.apache.xerces.parsers.DOMParser
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import org.xml.sax.InputSource


### PR DESCRIPTION
**Probable cause:** choose runtime plugin

**error**: Symbol is declared in module 'java.xml' which does not export package 'com.sun.org.apache.xerces.internal.parsers'

thanks @rachelcarmena !