### PR TITLE
mergeable LineMarkers & further Rendering options

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/Noop.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/Noop.kt
@@ -25,4 +25,5 @@ object Noop {
   val boolean2False: (Any?, Any?) -> Boolean = { _, _ -> false }
   val boolean3True: (Any?, Any?, Any?) -> Boolean = { _, _, _ -> true }
   fun <A> string1(): (A) -> String = { _ -> "" }
+  fun <A, B> string2(): (A, B) -> String = { _, _ -> "" }
 }

--- a/docs/_data/sidebar.yml
+++ b/docs/_data/sidebar.yml
@@ -105,7 +105,7 @@ options:
         url: /docs/apidocs/testing-plugin/arrow.meta.plugin.testing/assert-this.html
 
       - title: IntelliJ Plugin Tests
-        url: /docs/apidocs/idea-plugin/arrow.meta.ide.testing.dsl.env/ide-test.html
+        url: /docs/apidocs/idea-plugin/arrow.meta.ide.testing.env/ide-test.html
 
   - title: API Docs
 

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
@@ -28,7 +28,6 @@ import javax.swing.Icon
  * In general, subscription techniques differ mainly in performance.
  */
 interface LineMarkerSyntax {
-  // TODO: Registration Impl may change to 2019.3 EAP
   // TODO: Add more Techniques such as the one from Elm
 
   /**
@@ -95,8 +94,8 @@ interface LineMarkerSyntax {
    *         icon = ArrowIcons.ICON2,
    *         message = { f ->
    *           HTML.withOptions { // check out DescriptorRenderer's companion for more options
-   *             unitReturnType = true
-   *             classifierNamePolicy = classifierNamePolicy()
+   *             unitReturnType = true // renders Unit Type
+   *             classifierNamePolicy = classifierNamePolicy() // define your own policies
    *             parameterNameRenderingPolicy = ParameterNameRenderingPolicy.ONLY_NON_SYNTHESIZED
    *           }.let { renderer ->
    *             f.resolveToDescriptorIfAny()?.let(renderer::render) ?: "Unresolved Descriptor"

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
@@ -2,18 +2,22 @@ package arrow.meta.ide.dsl.editor.lineMarker
 
 import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.dsl.utils.IdeUtils
+import arrow.meta.ide.dsl.utils.descriptorRender
 import arrow.meta.internal.Noop
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.codeInsight.daemon.GutterIconNavigationHandler
 import com.intellij.codeInsight.daemon.LineMarkerInfo
 import com.intellij.codeInsight.daemon.LineMarkerProvider
 import com.intellij.codeInsight.daemon.LineMarkerProviders
+import com.intellij.codeInsight.daemon.MergeableLineMarkerInfo
+import com.intellij.codeInsight.navigation.NavigationGutterIconBuilder
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiNameIdentifierOwner
 import com.intellij.psi.util.PsiTreeUtil
+import org.jetbrains.kotlin.renderer.DescriptorRenderer
 import java.awt.event.MouseEvent
 import javax.swing.Icon
 
@@ -39,32 +43,111 @@ interface LineMarkerSyntax {
     icon: Icon,
     transform: (PsiElement) -> A?,
     message: (element: A) -> String = Noop.string1(),
-    placed: GutterIconRenderer.Alignment = GutterIconRenderer.Alignment.RIGHT
+    placed: GutterIconRenderer.Alignment = GutterIconRenderer.Alignment.RIGHT,
+    navigate: (event: MouseEvent, element: PsiElement) -> Unit = Noop.effect2,
+    clickAction: AnAction? = null
   ): ExtensionPhase =
     addLineMarkerProvider(
       transform,
-      { lineMarkerInfo(icon, it, message as (PsiElement) -> String, placed) }
+      { lineMarkerInfo(icon, it, message as (PsiElement) -> String, placed, navigate, clickAction) }
+    )
+
+  /**
+   * Similar to [addLineMarkerProvider], but with mergeable LineMarkers, based on the predicate [mergeWith].
+   * @param commonIcon defines the common Icon after the merge
+   */
+  @Suppress("UNCHECKED_CAST")
+  fun <A : PsiElement> IdeMetaPlugin.addLineMarkerProviderM(
+    icon: Icon,
+    transform: (PsiElement) -> A?,
+    message: (element: A) -> String = Noop.string1(),
+    commonIcon: MergeableLineMarkerInfo<PsiElement>.(others: List<MergeableLineMarkerInfo<PsiElement>>) -> Icon = { icon },
+    mergeWith: MergeableLineMarkerInfo<PsiElement>.(other: MergeableLineMarkerInfo<*>) -> Boolean = { this.icon == it.icon },
+    placed: GutterIconRenderer.Alignment = GutterIconRenderer.Alignment.RIGHT,
+    navigate: (event: MouseEvent, element: PsiElement) -> Unit = Noop.effect2
+  ): ExtensionPhase =
+    addLineMarkerProvider(
+      transform,
+      { mergeableLineMarkerInfo(icon, it, message as (PsiElement) -> String, commonIcon, mergeWith, placed, navigate) }
     )
 
   /**
    * [addLineMarkerProvider] is a convenience extension, which registers the Leaf element of a composite PsiElement [A] e.g.: `KtClass`
    * and circumvents effort's to find the right PsiElement.
    * In addition, plugin developer's can compose sophisticated messages, as the whole scope of [A] can be exploited.
+   * ```kotlin:ank:playground
+   * import arrow.meta.Plugin
+   * import arrow.meta.ide.IdeMetaPlugin
+   * import arrow.meta.ide.resources.ArrowIcons
+   * import arrow.meta.invoke
+   * import com.intellij.psi.PsiElement
+   * import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
+   * import org.jetbrains.kotlin.psi.KtNamedFunction
+   * import org.jetbrains.kotlin.renderer.ParameterNameRenderingPolicy
+   * import org.jetbrains.kotlin.utils.addToStdlib.safeAs
+   *
+   * val IdeMetaPlugin.descriptorLineMarker: Plugin
+   *   get() = "Render Descriptor Plugin" {
+   *     meta(
+   *       addLineMarkerProvider(
+   *         transform = { e: PsiElement -> e.safeAs() },
+   *         composite = KtNamedFunction::class.java,
+   *         icon = ArrowIcons.ICON2,
+   *         message = { f ->
+   *           HTML.withOptions { // check out DescriptorRenderer's companion for more options
+   *             unitReturnType = true
+   *             classifierNamePolicy = classifierNamePolicy()
+   *             parameterNameRenderingPolicy = ParameterNameRenderingPolicy.ONLY_NON_SYNTHESIZED
+   *           }.let { renderer ->
+   *             f.resolveToDescriptorIfAny()?.let(renderer::render) ?: "Unresolved Descriptor"
+   *           }
+   *         }
+   *       )
+   *     )
+   *   }
+   * ```
    * @param composite In Contrast, lineMarkers constructed without this parameter have a clearly constrained message.
+   * @param message you may use a [DescriptorRenderer] for rendering descriptors see [descriptorRender]
    */
   @Suppress("UNCHECKED_CAST")
   fun <A : PsiNameIdentifierOwner> IdeMetaPlugin.addLineMarkerProvider(
     icon: Icon,
     transform: (PsiElement) -> A?,
     composite: Class<A>,
-    message: (A) -> String = Noop.string1(),
+    message: DescriptorRenderer.Companion.(A) -> String = Noop.string2(),
+    placed: GutterIconRenderer.Alignment = GutterIconRenderer.Alignment.RIGHT,
+    navigate: (event: MouseEvent, element: PsiElement) -> Unit = Noop.effect2,
+    clickAction: AnAction? = null
+  ): ExtensionPhase =
+    addLineMarkerProvider(
+      { transform(it)?.identifyingElement },
+      { identifier: PsiElement ->
+        PsiTreeUtil.getParentOfType(identifier, composite)?.let { psi: A ->
+          lineMarkerInfo(icon, identifier, { message(DescriptorRenderer.Companion, psi) }, placed, navigate, clickAction)
+        }
+      }
+    )
+
+  /**
+   * Similar to [addLineMarkerProvider], but with mergeable LineMarkers, based on the predicate [mergeWith].
+   * @param commonIcon defines the common Icon after the merge
+   */
+  @Suppress("UNCHECKED_CAST")
+  fun <A : PsiNameIdentifierOwner> IdeMetaPlugin.addLineMarkerProviderM(
+    icon: Icon,
+    transform: (PsiElement) -> A?,
+    composite: Class<A>,
+    message: DescriptorRenderer.Companion.(A) -> String = Noop.string2(),
+    commonIcon: MergeableLineMarkerInfo<PsiElement>.(others: List<MergeableLineMarkerInfo<PsiElement>>) -> Icon = { icon },
+    mergeWith: MergeableLineMarkerInfo<PsiElement>.(other: MergeableLineMarkerInfo<*>) -> Boolean = { this.icon == it.icon },
+    navigate: (event: MouseEvent, element: PsiElement) -> Unit = Noop.effect2,
     placed: GutterIconRenderer.Alignment = GutterIconRenderer.Alignment.RIGHT
   ): ExtensionPhase =
     addLineMarkerProvider(
       { transform(it)?.identifyingElement },
       { identifier: PsiElement ->
         PsiTreeUtil.getParentOfType(identifier, composite)?.let { psi: A ->
-          lineMarkerInfo(icon, identifier, { message(psi) }, placed)
+          mergeableLineMarkerInfo(icon, identifier, { message(DescriptorRenderer.Companion, psi) }, commonIcon, mergeWith, placed, navigate)
         }
       }
     )
@@ -94,9 +177,8 @@ interface LineMarkerSyntax {
 
   /**
    * @param clickAction if null this will place a breakpoint on a mouse click otherwise it executes the action
-   * @param isDumbAware specifies whether this LineMarkerInfo is available during index updates
    */
-  fun LineMarkerSyntax.lineMarkerInfo( // TODO:
+  fun LineMarkerSyntax.lineMarkerInfo(
     icon: Icon,
     element: PsiElement,
     message: (PsiElement) -> String,
@@ -114,5 +196,33 @@ interface LineMarkerSyntax {
         object : LineMarkerInfo.LineMarkerGutterIconRenderer<PsiElement>(this) {
           override fun getClickAction(): AnAction? = clickAction
         }
+    }
+
+  fun <R> LineMarkerSyntax.navigationGutter(
+    icon: Icon,
+    element: PsiElement,
+    config: NavigationGutterIconBuilder<PsiElement>.(element: PsiElement) -> R
+  ): R =
+    NavigationGutterIconBuilder.create(icon).config(element)
+
+  /**
+   * `MergeableLineMarkerInfo` can merge multiple LineMarkerInfo's into one, if [mergeWith] is true.
+   * @param commonIcon defines the common Icon after the merge
+   */
+  fun LineMarkerSyntax.mergeableLineMarkerInfo(
+    icon: Icon,
+    element: PsiElement,
+    message: (PsiElement) -> String,
+    commonIcon: MergeableLineMarkerInfo<PsiElement>.(others: List<MergeableLineMarkerInfo<PsiElement>>) -> Icon = { icon },
+    mergeWith: MergeableLineMarkerInfo<PsiElement>.(other: MergeableLineMarkerInfo<*>) -> Boolean = { this.icon == it.icon },
+    placed: GutterIconRenderer.Alignment = GutterIconRenderer.Alignment.LEFT,
+    navigate: (event: MouseEvent, element: PsiElement) -> Unit = Noop.effect2
+  ): MergeableLineMarkerInfo<PsiElement> =
+    object : MergeableLineMarkerInfo<PsiElement>(element, element.textRange, icon, message, navigate, placed) {
+      override fun canMergeWith(info: MergeableLineMarkerInfo<*>): Boolean =
+        mergeWith(info)
+
+      override fun getCommonIcon(infos: MutableList<MergeableLineMarkerInfo<PsiElement>>): Icon =
+        commonIcon(infos.toList())
     }
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
@@ -1,6 +1,5 @@
 package arrow.meta.ide.dsl.editor.lineMarker
 
-import arrow.meta.dsl.platform.cli
 import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.dsl.utils.IdeUtils
 import arrow.meta.ide.dsl.utils.descriptorRender
@@ -55,6 +54,7 @@ interface LineMarkerSyntax {
   /**
    * Similar to [addLineMarkerProvider], but with mergeable LineMarkers, based on the predicate [mergeWith].
    * @param commonIcon defines the common Icon after the merge
+   * @param navigate this function allows you to execute anything based on your use-case: actions, manipulations to PsiElements, opening Files or anything else.
    */
   @Suppress("UNCHECKED_CAST")
   fun <A : PsiElement> IdeMetaPlugin.addLineMarkerProviderM(
@@ -132,6 +132,7 @@ interface LineMarkerSyntax {
   /**
    * Similar to [addLineMarkerProvider], but with mergeable LineMarkers, based on the predicate [mergeWith].
    * @param commonIcon defines the common Icon after the merge
+   * @param navigate this function allows you to execute anything based on your use-case: actions, manipulations to PsiElements, opening Files or anything else.
    */
   @Suppress("UNCHECKED_CAST")
   fun <A : PsiNameIdentifierOwner> IdeMetaPlugin.addLineMarkerProviderM(
@@ -179,6 +180,7 @@ interface LineMarkerSyntax {
 
   /**
    * @param clickAction if null this will place a breakpoint on a mouse click otherwise it executes the action
+   * @param navigate this function allows you to execute anything based on your use-case: actions, manipulations to PsiElements, opening Files or anything else.
    */
   fun LineMarkerSyntax.lineMarkerInfo(
     icon: Icon,
@@ -210,6 +212,7 @@ interface LineMarkerSyntax {
   /**
    * `MergeableLineMarkerInfo` can merge multiple LineMarkerInfo's into one, if [mergeWith] is true.
    * @param commonIcon defines the common Icon after the merge
+   * @param navigate this function allows you to execute anything based on your use-case: actions, manipulations to PsiElements, opening Files or anything else.
    */
   fun LineMarkerSyntax.mergeableLineMarkerInfo(
     icon: Icon,

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
@@ -98,7 +98,6 @@ inline fun <reified K : PsiElement> K.replaceK(to: K): K? =
 
 /**
  * Renders descriptors with the specified options
- * create
  */
 internal val IdeMetaPlugin.descriptorRender: DescriptorRenderer
   get() = DescriptorRenderer.COMPACT_WITH_SHORT_TYPES.withOptions {

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
@@ -1,5 +1,6 @@
 package arrow.meta.ide.dsl.utils
 
+import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.phases.analysis.resolveFunctionType
 import arrow.meta.phases.analysis.returns
 import com.intellij.psi.PsiElement
@@ -15,6 +16,8 @@ import org.jetbrains.kotlin.psi.KtCallElement
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.renderer.DescriptorRenderer
+import org.jetbrains.kotlin.renderer.RenderingFormat
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
@@ -87,6 +90,20 @@ fun <F : CallableDescriptor> F.returns(ktFunction: KtNamedFunction, types: Kotli
  */
 inline fun <reified K : PsiElement> K.replaceK(to: K): K? =
   replace(to).safeAs()
+
+/**
+ * Renders descriptors with the specified options
+ * create
+ */
+internal val IdeMetaPlugin.descriptorRender: DescriptorRenderer
+  get() = DescriptorRenderer.COMPACT_WITH_SHORT_TYPES.withOptions {
+    textFormat = RenderingFormat.HTML
+    classifierNamePolicy = classifierNamePolicy()
+    unitReturnType = true
+  }
+
+internal val DescriptorRenderer.Companion.`br`: String
+  get() = "<br/>"
 
 fun <A> List<A?>.toNotNullable(): List<A> = fold(emptyList()) { acc: List<A>, r: A? -> if (r != null) acc + r else acc }
 

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/utils/IdeUtils.kt
@@ -11,8 +11,13 @@ import org.celtric.kotlin.html.code
 import org.celtric.kotlin.html.text
 import org.jetbrains.kotlin.builtins.KotlinBuiltIns
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.fir.declarations.FirCallableDeclaration
+import org.jetbrains.kotlin.fir.declarations.FirResolvePhase
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToCall
+import org.jetbrains.kotlin.idea.fir.firResolveState
+import org.jetbrains.kotlin.idea.fir.getOrBuildFir
 import org.jetbrains.kotlin.psi.KtCallElement
+import org.jetbrains.kotlin.psi.KtCallableDeclaration
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.psi.KtProperty
@@ -104,6 +109,12 @@ internal val IdeMetaPlugin.descriptorRender: DescriptorRenderer
 
 internal val DescriptorRenderer.Companion.`br`: String
   get() = "<br/>"
+
+/**
+ * this extension is an instance of the generalized version [getOrBuildFir]
+ */
+fun KtCallableDeclaration.toFir(phase: FirResolvePhase = FirResolvePhase.BODY_RESOLVE): FirCallableDeclaration<*> =
+  getOrBuildFir(firResolveState(), phase)
 
 fun <A> List<A?>.toNotNullable(): List<A> = fold(emptyList()) { acc: List<A>, r: A? -> if (r != null) acc + r else acc }
 

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/helloworld/DummyPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/helloworld/DummyPlugin.kt
@@ -2,11 +2,12 @@ package arrow.meta.ide.plugins.helloworld
 
 import arrow.meta.Plugin
 import arrow.meta.ide.IdeMetaPlugin
+import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
 import arrow.meta.ide.resources.ArrowIcons
 import arrow.meta.invoke
+import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
 import org.jetbrains.kotlin.psi.KtNamedFunction
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
-import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
 
 /**
  * The following section exemplifies a Hello World Ide Plugin
@@ -41,7 +42,10 @@ val IdeMetaPlugin.helloWorld: Plugin // TODO: Add Animation or example picture
       addLineMarkerProvider(
         icon = ArrowIcons.ICON1,
         composite = KtNamedFunction::class.java,
-        message = { f: KtNamedFunction -> "Teach your users about this feature in function $f" },
+        message = { f: KtNamedFunction ->
+          HTML.renderMessage("Teach your users about this feature in function") + "<br/>" +
+            f.resolveToDescriptorIfAny()?.let(HTML::render)
+        },
         transform = {
           it.safeAs<KtNamedFunction>()?.takeIf { f ->
             f.name == "helloWorld"

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/helloworld/DummyPlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/helloworld/DummyPlugin.kt
@@ -6,7 +6,8 @@ import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax
 import arrow.meta.ide.resources.ArrowIcons
 import arrow.meta.invoke
 import org.jetbrains.kotlin.idea.caches.resolve.resolveToDescriptorIfAny
-import org.jetbrains.kotlin.psi.KtNamedFunction
+import org.jetbrains.kotlin.idea.util.hasInlineModifier
+import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.utils.addToStdlib.safeAs
 
 /**
@@ -35,20 +36,21 @@ import org.jetbrains.kotlin.utils.addToStdlib.safeAs
  * For every function with the name `helloWorld`, our ide plugin will register a lineMarker with our custom icon. And whenever
  * the user hovers over the Icon, it will display the message.
  * @see [LineMarkerSyntax]
+ * @sample [helloWorld]
  */
 val IdeMetaPlugin.helloWorld: Plugin // TODO: Add Animation or example picture
   get() = "Hello World" {
     meta(
       addLineMarkerProvider(
         icon = ArrowIcons.ICON1,
-        composite = KtNamedFunction::class.java,
-        message = { f: KtNamedFunction ->
-          HTML.renderMessage("Teach your users about this feature in function") + "<br/>" +
-            f.resolveToDescriptorIfAny()?.let(HTML::render)
+        composite = KtClass::class.java,
+        message = { ktClass: KtClass ->
+          HTML.renderMessage("Teach your users about this feature for inline classes") + "<br/>" +
+            ktClass.resolveToDescriptorIfAny()?.let(HTML::render)
         },
         transform = {
-          it.safeAs<KtNamedFunction>()?.takeIf { f ->
-            f.name == "helloWorld"
+          it.safeAs<KtClass>()?.takeIf { ktClass ->
+            ktClass.hasInlineModifier()
           }
         }
       )


### PR DESCRIPTION
- adds mergeable LineMarkers indicated with *M* suffix in `addLineMarkerProviderM`
- current Rendering targets `Descriptors`
- One can render `KtElements` with Fir API's like in the following example, but I'd add Fir support in another PR: 
```kotlin
fun KtCallableDeclaration.toFir(phase: FirResolvePhase = FirResolvePhase.BODY_RESOLVE): String =
  buildString { getOrBuildFir(firResolveState(), phase).accept(FirRenderer(this@StringBuilder)) } 
```
Due to the different primitives in contrast to `DescriptorRenderer`:
`FirRenderer`: 
<img width="306" alt="Screenshot 2020-01-28 at 16 45 15" src="https://user-images.githubusercontent.com/46971368/73279702-d08a4a80-41ed-11ea-8bcc-5214ee72319c.png">
`DescriptorRenderer`:
<img width="497" alt="Screenshot 2020-01-28 at 16 47 21" src="https://user-images.githubusercontent.com/46971368/73279743-df70fd00-41ed-11ea-9294-c48c70deee7c.png">
