### PR TITLE
PackageFragmentProvider in Meta DSL

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/initial/InitialIdePlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/initial/InitialIdePlugin.kt
@@ -3,6 +3,7 @@ package arrow.meta.ide.plugins.initial
 import arrow.meta.Plugin
 import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.phases.resolve.LOG
+import arrow.meta.ide.phases.resolve.metaSyntheticPackageFragmentProvider
 import arrow.meta.invoke
 import arrow.meta.plugins.higherkind.kindsTypeMismatch
 import arrow.meta.plugins.typeclasses.suppressUnusedParameter
@@ -26,6 +27,7 @@ val IdeMetaPlugin.initialIdeSetUp: Plugin
         diagnostic.logSuppression(result)
         result
       },
+      metaSyntheticPackageFragmentProvider,
       registerExtensionPoint(KotlinIndicesHelperExtension.Companion.extensionPointName,
         KotlinIndicesHelperExtension::class.java, ExtensionPoint.Kind.INTERFACE)
     )

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -29,7 +29,6 @@
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">
-        <packageFragmentProviderExtension implementation="arrow.meta.ide.phases.resolve.MetaSyntheticPackageFragmentProvider"/>
         <syntheticResolveExtension implementation="arrow.meta.ide.phases.resolve.MetaSyntheticResolveExtension" />
     </extensions>
 


### PR DESCRIPTION
removes the registration of `MetaSyntheticPackageFragmentProvider` in plugin.xml and uses the one from Meta. 
And Helps #462 