### PR TITLE
Revamp Ide Testing DSL

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/IdeEnvironment.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/IdeEnvironment.kt
@@ -1,0 +1,6 @@
+package arrow.meta.ide.testing
+
+import arrow.meta.ide.dsl.IdeSyntax
+import arrow.meta.ide.testing.dsl.IdeTestSyntax
+
+object IdeEnvironment : IdeTestSyntax, IdeSyntax

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/IdeTest.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/IdeTest.kt
@@ -1,51 +1,29 @@
 package arrow.meta.ide.testing
 
-import arrow.meta.ide.testing.dsl.IdeTestSyntax
+import arrow.meta.ide.dsl.IdeSyntax
 import arrow.meta.ide.testing.env.ideTest
+import arrow.meta.ide.testing.env.resolution.ResolutionSyntax
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 
 typealias Source = String
 
 /**
- * [IdeTest] is a polymorphic aggregation of one complete test suite.
- * It is polymorphic over the TestResult [A], which is exactly what we yield in [test].
- * [myFixture] is a key component of the underlying IntelliJ Testing environment.
- * [test] defines what exact test is run on the [code] there is an example in [ideTest] KDoc's
+ * [IdeTest] eventually completes with a test result [A] and has [F] as its plugin context for dependencies and features.
+ * [test] results with [A] defines what exact test is run based on the [code].
  * [result] describes the expected shape of [A] with a custom message.
+ * [F] is the plugin context, where dependencies and features can be used to define [test] and/or [result].
  * @see IdeResolution, [ideTest]
+ * There is an example in [ideTest] KDoc's.
  */
-data class IdeTest<A>(
-  val myFixture: CodeInsightTestFixture,
+data class IdeTest<A, F : IdeSyntax>(
   val code: Source,
-  val test: IdeTestEnvironment.(code: Source, myFixture: CodeInsightTestFixture) -> A,
-  val result: IdeResolution<A>
+  val test: IdeEnvironment.(code: Source, myFixture: CodeInsightTestFixture, ctx: F) -> A,
+  val result: IdeResolution<A, F>
 )
 
-object IdeTestEnvironment : IdeTestSyntax
-
 /**
- * [transform] defines a valid representation of the TestResult of Type [A], where [null] stands for a wrong or unexpected representation.
- * [fails], [failsWith], [empty] and [resolves] facilitate syntactic sugar to express semantic implications of an expected result.
+ * [transform] defines a valid representation of the test result [A], where [null] stands for a wrong or unexpected representation.
+ * [ResolutionSyntax] facilitates extensions for [IdeResolution].
  * @see ideTest
  */
-data class IdeResolution<A>(val message: String, val transform: (result: A) -> A? = { it })
-
-/**
- * @see IdeResolution
- */
-fun <A> failsWith(message: String, transform: (result: A) -> A?): IdeResolution<A> = IdeResolution(message, transform)
-
-/**
- * @see IdeResolution
- */
-fun <A> resolves(message: String, transform: (result: A) -> A?): IdeResolution<A> = IdeResolution(message, transform)
-
-/**
- * @see IdeResolution
- */
-fun <A> empty(): IdeResolution<A> = IdeResolution("Empty IdeResolution")
-
-/**
- * @see IdeResolution
- */
-fun <A> fails(): IdeResolution<A> = IdeResolution("Failing IdeResolution") { null }
+data class IdeResolution<A, F : IdeSyntax>(val message: String, val transform: F.(result: A) -> A?)

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/dsl/IdeTestSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/dsl/IdeTestSyntax.kt
@@ -1,7 +1,9 @@
 package arrow.meta.ide.testing.dsl
 
 import arrow.meta.ide.testing.dsl.icon.IconProviderTestSyntax
+import arrow.meta.ide.testing.env.resolution.ResolutionSyntax
 import arrow.meta.ide.testing.dsl.lineMarker.LineMarkerTestSyntax
 import arrow.meta.ide.testing.env.IdeTestTypeSyntax
 
-interface IdeTestSyntax : IdeTestTypeSyntax, LineMarkerTestSyntax, IconProviderTestSyntax
+interface IdeTestSyntax : IdeTestTypeSyntax, LineMarkerTestSyntax, IconProviderTestSyntax,
+  ResolutionSyntax

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
@@ -1,90 +1,131 @@
 package arrow.meta.ide.testing.env
 
+import arrow.meta.ide.dsl.IdeSyntax
 import arrow.meta.ide.plugins.helloworld.helloWorld
+import arrow.meta.ide.testing.IdeEnvironment
 import arrow.meta.ide.testing.IdeTest
-import arrow.meta.ide.testing.IdeTestEnvironment
+import arrow.meta.ide.testing.dsl.IdeTestSyntax
 import arrow.meta.ide.testing.dsl.lineMarker.LineMarkerTestSyntax
+import com.intellij.testFramework.fixtures.CodeInsightTestFixture
 import org.junit.Assert
 
 /**
- * [runTest] executes the test with a custom [interpreter], which facilitates to run a test in any environment.
+ * [runTest] executes the test with a custom [interpreter], which facilitates to run a test in any environment, based on a plugin context [F].
  * Hence, the Testing DSL for IntelliJ supports pure or impure Test environments and allows to compose them in a variety of
  * testing methods such as property-based testing, unit tests and many more.
  * @see [arrow.meta.ide.testing.env.interpreter]
  */
-fun <A> IdeTest<A>.runTest(interpreter: (test: IdeTest<A>) -> Unit = ::interpreter): Unit =
-  interpreter(this)
+fun <A, F : IdeSyntax> IdeTest<A, F>.runTest(
+  fixture: CodeInsightTestFixture,
+  ctx: F,
+  interpreter: (test: IdeTest<A, F>, ctx: F, fixture: CodeInsightTestFixture) -> Unit = ::interpreter
+): Unit =
+  interpreter(this, ctx, fixture)
 
 /**
- * [testResult] evaluates the actual result within the [IdeTestEnvironment]
+ * [testResult] evaluates the actual result within the [IdeEnvironment]
+ * @param ctx plugin context
  */
-fun <A> IdeTest<A>.testResult(): A =
-  test(IdeTestEnvironment, code, myFixture)
+fun <A, F : IdeSyntax> IdeTest<A, F>.testResult(ctx: F, fixture: CodeInsightTestFixture): A =
+  test(IdeEnvironment, code, fixture, ctx)
 
 /**
- * The default [interpreter] evaluates and prints the actual result in an impure Environment.
+ * The default [interpreter] evaluates and prints the actual result [A] on the console.
  * In addition, it throws an [AssertionError] with the [ideTest.result.message],
  * whenever the expected [ideTest.result] doesn't match the actual result from [testResult].
  */
-fun <A> interpreter(ideTest: IdeTest<A>): Unit =
+fun <A, F : IdeSyntax> interpreter(ideTest: IdeTest<A, F>, ctx: F, fixture: CodeInsightTestFixture): Unit =
   ideTest.run {
-    val a = testResult()
+    val a = testResult(ctx, fixture)
     println("IdeTest results in $a")
-    Assert.assertNotNull(result.message, result.transform(a))
+    Assert.assertNotNull(result.message, result.transform(ctx, a))
   }
 
 /**
  * This extension runs each test for selected editor features.
- * Each Test class has to extend [IdeTestSetUp], in order to spin-up the underlying IntelliJ Testing Platform at RunTime.
+ * Each Test class has to extend [IdeTestSetUp], in order to spin-up the underlying Intellij Testing Platform at runtime.
+ * That also insures that the property [myFixture] is properly instantiated.
  * ```kotlin
  * class ExampleTest: IdeTestSetUp() {
  *   /** test features **/
  * }
  * ```
- * One IdeTest bundles the necessary components for a testSuit and the general schema looks like this:
+ * One IdeTest is composed by the source code, a test described with algebras in [IdeTestSyntax], and the expected result.
+ * Based on a dummy IdePlugin
  * ```kotlin
- * @Test
- * fun `test feature`(): Unit =
- *  ideTest(
- *   IdeTest(
- *     myFixture, // the IntelliJ test environment spins up this value automatically
- *     code = "val exampleCode = 2",
- *     test = { code, myFixture ->
- *       /**
- *       * In addition to the parameters above the [IdeTestEnvironment] is in Scope, which bundles test operations
- *       * over the [IdeSyntax] and implements [IdeTestSyntax]. The latter composes a symmetric API over [IdeSyntax] in respect to tests.
- *       * That means an interface such as [LineMarkerSyntax] from the [IdeSyntax] is tested with [LineMarkerTestSyntax] from the [IdeTestSyntax].
- *       **/
- *     },
- *     result = // here we define what behavior is expected
- *    ),
- *    ... // you may add more test suit's for the same feature with different code examples and test's
- *  )
+ * class MyIdePlugin : IdeSyntax, IdeInternalRegistry
  * ```
- *
+ * a general schema looks like this:
+ * ```kotlin:ank:playground
+ * import arrow.meta.ide.dsl.IdeSyntax
+ * import arrow.meta.ide.internal.registry.IdeInternalRegistry
+ * import arrow.meta.ide.testing.IdeTest
+ * import arrow.meta.ide.testing.Source
+ * import arrow.meta.ide.testing.env.IdeTestSetUp
+ * import arrow.meta.ide.testing.env.ideTest
+ * import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+ * import org.junit.Test
+ * //sampleStart
+ * class ExampleTest : IdeTestSetUp() {
+ *   @Test
+ *   fun `general test schema`(): Unit =
+ *     ideTest(
+ *       myFixture = myFixture, // the IntelliJ test environment spins up [myFixture] automatically at runtime.
+ *       ctx = MyIdePlugin() // add here your ide plugin, to get dependencies and created features in the scope of [test] and [result].
+ *     ) {
+ *       listOf(
+ *         IdeTest(
+ *           "val exampleCode = 2",
+ *           test = { code: Source, myFixture: CodeInsightTestFixture, ctx: MyIdePlugin ->
+ *             /**
+ *              * In addition to the parameters above the [IdeEnvironment] is in Scope, which bundles test operations in [IdeTestSyntax]
+ *              * over the [IdeSyntax]. [IdeTestSyntax] composes a symmetric API over [IdeSyntax] in respect to tests.
+ *              * That means an interface such as [LineMarkerSyntax] from the [IdeSyntax] is tested with [LineMarkerTestSyntax] from the [IdeTestSyntax].
+ *              * Furthermore, one can use the scope of [ctx] to use declared dependencies and features in the test.
+ *              **/
+ *           },
+ *           result = resolves("Any result is accepted") // here we define what behavior is expected
+ *         )... // you may add more test suit's for the same or related ide feature with different code examples and test's
+ *       )
+ *     }
+ * }
+ * //sampleEnd
+ * class MyIdePlugin : IdeSyntax, IdeInternalRegistry
+ * ```
  * Given the [helloWorld] ide plugin, one concrete example may look like this:
  * ```kotlin
  * @Test
- * fun `test if lineMarker is displayed`(): Unit =
+ * fun `hello World LineMarker is displayed`(): Unit =
  *   ideTest(
- *     IdeTest(
- *       myFixture = myFixture,
- *       code = """
- *       | fun helloWorld(): String =
- *       |   "Hello world!"
- *       """.trimIndent(),
- *       test = { code, myFixture ->
- *         collectLM(code, myFixture, ArrowIcons.ICON1) // this collect's all visible LineMarkers in the editor for a given Icon
- *       },
- *       result = resolves("LineMarker Test for helloWorld") {
- *         it.takeIf { collected ->
- *           collected.lineMarker.size == 1 // we expect that there is only one lineMarker in our example code
+ *     myFixture = myFixture,
+ *     ctx = IdeMetaPlugin()
+ *   ) {
+ *     listOf(
+ *       IdeTest(
+ *         code = """
+ *         | fun helloWorld(): String =
+ *         |   "Hello world!"
+ *         """.trimIndent(),
+ *         test = { code: Source, myFixture: CodeInsightTestFixture, ctx ->
+ *           collectLM(code, myFixture, ArrowIcons.ICON1) // this collect's all visible LineMarkers in the editor for the given Icon
+ *         },
+ *         result = resolvesWith("LineMarker Test for helloWorld") {
+ *           it.takeIf { collected ->
+ *             collected.lineMarker.size == 1 // we expect that there is only one lineMarker in our example code
+ *           }
  *         }
- *       }
+ *       )
  *     )
- *   )
+ *   }
  * ```
+ * The key in `result` is to define the shape of the expected outcome, whether the test represents a valid or invalid representation of [A].
  * @see [runTest], [IdeTest], [LineMarkerTestSyntax]
+ * @param myFixture is a key component of the underlying Intellij Testing API.
+ * @param ctx is the plugin context if unspecified it will use the [IdeEnvironment]
  */
-fun <A> ideTest(vararg tests: IdeTest<A>): Unit =
-  tests.toList().forEach { it.runTest() }
+fun <A, F : IdeSyntax> ideTest(
+  myFixture: CodeInsightTestFixture,
+  ctx: F = IdeEnvironment as F,
+  tests: IdeEnvironment.() -> List<IdeTest<A, F>>
+): Unit =
+  tests(IdeEnvironment).forEach { it.runTest(myFixture, ctx) }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
@@ -73,7 +73,7 @@ fun <A, F : IdeSyntax> interpreter(ideTest: IdeTest<A, F>, ctx: F, fixture: Code
  *       myFixture = myFixture, // the IntelliJ test environment spins up [myFixture] automatically at runtime.
  *       ctx = MyIdePlugin() // add here your ide plugin, to get dependencies and created features in the scope of [test] and [result].
  *     ) {
- *       listOf(
+ *       listOf<IdeTest<Unit, MyIdePlugin>>( // type inference is not able to resolve the types here
  *         IdeTest(
  *           "val exampleCode = 2",
  *           test = { code: Source, myFixture: CodeInsightTestFixture, ctx: MyIdePlugin ->
@@ -100,7 +100,7 @@ fun <A, F : IdeSyntax> interpreter(ideTest: IdeTest<A, F>, ctx: F, fixture: Code
  *     myFixture = myFixture,
  *     ctx = IdeMetaPlugin()
  *   ) {
- *     listOf(
+ *     listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
  *       IdeTest(
  *         code = """
  *         | fun helloWorld(): String =

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/resolution/ResolutionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/resolution/ResolutionSyntax.kt
@@ -1,0 +1,36 @@
+package arrow.meta.ide.testing.env.resolution
+
+import arrow.meta.ide.dsl.IdeSyntax
+import arrow.meta.ide.testing.IdeResolution
+import arrow.meta.ide.testing.dsl.IdeTestSyntax
+
+
+interface ResolutionSyntax {
+  /**
+   * semantic sugar to define an [IdeResolution] that given [transform] fails.
+   * @param transform describes the premises or shape of [A]
+   * @see IdeResolution
+   */
+  fun <A, F : IdeSyntax> IdeTestSyntax.failsWith(message: String, transform: F.(result: A) -> A?): IdeResolution<A, F> = IdeResolution(message, transform)
+
+  /**
+   * semantic sugar to define an [IdeResolution] that given [transform] completes successfully.
+   * @param transform describes the premises or shape of [A].
+   * @see IdeResolution
+   */
+  fun <A, F : IdeSyntax> IdeTestSyntax.resolvesWith(message: String, transform: F.(result: A) -> A?): IdeResolution<A, F> = IdeResolution(message, transform)
+
+  /**
+   * this extension denotes that any test result in the test environment is accepted as a valid output.
+   * Thereby, the Ide resolution always completes successfully, regardless of [A].
+   * @see IdeResolution
+   */
+  fun <A, F : IdeSyntax> IdeTestSyntax.resolves(message: String = "Any result is accepted."): IdeResolution<A, F> = IdeResolution(message) { it }
+
+  /**
+   * this extension denotes that any test result in the test environment fails.
+   * Thereby, the Ide resolution always fails, regardless of [A].
+   * @see IdeResolution
+   */
+  fun <A, F : IdeSyntax> IdeTestSyntax.fails(message: String = "Failing Resolution"): IdeResolution<A, F> = IdeResolution(message) { null }
+}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
@@ -2,10 +2,13 @@ package arrow.meta.ide.testing.env.types
 
 import arrow.meta.ide.dsl.utils.toNotNullable
 import arrow.meta.ide.testing.Source
+import com.intellij.codeHighlighting.Pass
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
 import com.intellij.psi.SyntaxTraverser
 import com.intellij.testFramework.fixtures.CodeInsightTestFixture
+import com.intellij.testFramework.fixtures.impl.CodeInsightTestFixtureImpl
 import com.intellij.util.containers.TreeTraversal
 import org.jetbrains.kotlin.idea.KotlinFileType
 import org.jetbrains.kotlin.psi.KtFile
@@ -49,4 +52,12 @@ object LightTestSyntax {
       val i: Int = indexOf(str)
       delete(i, i + str.length).filterFold(f(acc, i), str, f)
     }
+
+  /**
+   * instantiates the KtFile and returns highlighting information, filtering out [toIgnore].
+   * @param toIgnore specifies which information can be ignored. Please refer to [Pass] for instances.
+   * @param changes specifies if a file changes its highlighting
+   */
+  fun KtFile.highlighting(myFixture: CodeInsightTestFixture, toIgnore: List<Int>, changes: (KtFile) -> Boolean = { it.isScript() }): List<HighlightInfo> =
+    CodeInsightTestFixtureImpl.instantiateAndRun(this, myFixture.editor, toIgnore.toIntArray(), changes(this)).filterNotNull()
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/comprehensions/ComprehensionsTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/comprehensions/ComprehensionsTest.kt
@@ -1,75 +1,75 @@
 package arrow.meta.ide.plugins.comprehensions
 
+import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.resources.ArrowIcons
 import arrow.meta.ide.testing.IdeTest
+import arrow.meta.ide.testing.dsl.lineMarker.LineMarkerDescription
 import arrow.meta.ide.testing.env.IdeTestSetUp
 import arrow.meta.ide.testing.env.ideTest
-import arrow.meta.ide.testing.resolves
 import org.junit.Test
 
 class ComprehensionsTest : IdeTestSetUp() {
   @Test
   fun `ComprehensionsTest for LineMarkers`(): Unit =
     ideTest(
-      IdeTest(
-        code = ComprehensionsTestCode.code1,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.BIND)
-        },
-        result = resolves("LineMarkerTest for two LM on typed variables") {
-          it.takeIf { descriptor -> descriptor.lineMarker.size == 2 && descriptor.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = ComprehensionsTestCode.code2,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.BIND)
-        },
-        result = resolves("LineMarkerTest for two LM on untyped variables") {
-          it.takeIf { descriptor -> descriptor.lineMarker.size == 2 && descriptor.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = ComprehensionsTestCode.code3,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.BIND)
-        },
-        result = resolves("LineMarkerTest for six LM on untyped variables") {
-          it.takeIf { descriptor -> descriptor.lineMarker.size == 6 && descriptor.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = ComprehensionsTestCode.code4,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.BIND)
-        },
-        result = resolves("LineMarkerTest for four LM on untyped variables") {
-          it.takeIf { descriptor -> descriptor.lineMarker.size == 4 && descriptor.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = ComprehensionsTestCode.code5,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.BIND)
-        },
-        result = resolves("LineMarkerTest for zero LM ") {
-          it.takeIf { descriptor -> descriptor.lineMarker.isEmpty() && descriptor.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = ComprehensionsTestCode.code6,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.BIND)
-        },
-        result = resolves("LineMarkerTest for no LM ") {
-          it.takeIf { descriptor -> descriptor.lineMarker.isEmpty() && descriptor.slowLM.isEmpty() }
-        }
+      myFixture = myFixture,
+      ctx = IdeMetaPlugin()
+    ) {
+      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+        IdeTest(
+          code = ComprehensionsTestCode.code1,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.BIND)
+          },
+          result = resolvesWith("LineMarkerTest for two LM on typed variables") {
+            it.takeIf { descriptor -> descriptor.lineMarker.size == 2 && descriptor.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = ComprehensionsTestCode.code2,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.BIND)
+          },
+          result = resolvesWith("LineMarkerTest for two LM on untyped variables") {
+            it.takeIf { descriptor -> descriptor.lineMarker.size == 2 && descriptor.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = ComprehensionsTestCode.code3,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.BIND)
+          },
+          result = resolvesWith("LineMarkerTest for six LM on untyped variables") {
+            it.takeIf { descriptor -> descriptor.lineMarker.size == 6 && descriptor.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = ComprehensionsTestCode.code4,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.BIND)
+          },
+          result = resolvesWith("LineMarkerTest for four LM on untyped variables") {
+            it.takeIf { descriptor -> descriptor.lineMarker.size == 4 && descriptor.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = ComprehensionsTestCode.code5,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.BIND)
+          },
+          result = resolvesWith("LineMarkerTest for zero LM ") {
+            it.takeIf { descriptor -> descriptor.lineMarker.isEmpty() && descriptor.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = ComprehensionsTestCode.code6,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.BIND)
+          },
+          result = resolvesWith("LineMarkerTest for no LM ") {
+            it.takeIf { descriptor -> descriptor.lineMarker.isEmpty() && descriptor.slowLM.isEmpty() }
+          }
+        )
       )
-    )
+    }
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/comprehensions/ComprehensionsTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/comprehensions/ComprehensionsTest.kt
@@ -9,7 +9,7 @@ import org.junit.Test
 
 class ComprehensionsTest : IdeTestSetUp() {
   @Test
-  fun `ComprehensionsTest for LineMarkers`() =
+  fun `ComprehensionsTest for LineMarkers`(): Unit =
     ideTest(
       IdeTest(
         code = ComprehensionsTestCode.code1,

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/higherkinds/HigherKindTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/higherkinds/HigherKindTest.kt
@@ -1,61 +1,68 @@
 package arrow.meta.ide.plugins.higherkinds
 
+import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.resources.ArrowIcons
 import arrow.meta.ide.testing.IdeTest
+import arrow.meta.ide.testing.dsl.lineMarker.LineMarkerDescription
 import arrow.meta.ide.testing.env.IdeTestSetUp
 import arrow.meta.ide.testing.env.ideTest
-import arrow.meta.ide.testing.resolves
 import org.junit.Test
 
 class HigherKindTest : IdeTestSetUp() {
   @Test
-  fun `HKT Tests for LineMarkers`() =
+  fun `HKT lineMarker tests`(): Unit =
     ideTest(
-      IdeTest(
-        code = HigherKindsTestCode.code1,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.HKT)
-        },
-        result = resolves("LineMarkerTest for one valid HKT") {
-          it.takeIf { description -> description.lineMarker.size == 1 && description.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = HigherKindsTestCode.code2,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.HKT)
-        },
-        result = resolves("LineMarkerTest for multiple valid HKT") {
-          it.takeIf { description -> description.lineMarker.size == 2 && description.slowLM.isEmpty() }
-        }
-      ),
-      IdeTest(
-        code = HigherKindsTestCode.code3,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.HKT)
-        },
-        result = resolves("LineMarkerTest for no valid HKT") {
-          it.takeIf { description -> description.lineMarker.isEmpty() && description.slowLM.isEmpty() }
-        }
+      myFixture = myFixture,
+      ctx = IdeMetaPlugin()
+    ) {
+      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+        IdeTest(
+          code = HigherKindsTestCode.code1,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.HKT)
+          },
+          result = resolvesWith("LineMarkerTest for one valid HKT") {
+            it.takeIf { description -> description.lineMarker.size == 1 && description.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = HigherKindsTestCode.code2,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.HKT)
+          },
+          result = resolvesWith("LineMarkerTest for multiple valid HKT") {
+            it.takeIf { description -> description.lineMarker.size == 2 && description.slowLM.isEmpty() }
+          }
+        ),
+        IdeTest(
+          code = HigherKindsTestCode.code3,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.HKT)
+          },
+          result = resolvesWith("LineMarkerTest for no valid HKT") {
+            it.takeIf { description -> description.lineMarker.isEmpty() && description.slowLM.isEmpty() }
+          }
+        )
       )
-    )
+    }
 
 
   @Test
-  fun `HKT Tests for Poly LineMarkers`() =
+  fun `HKT poly lineMarker test`() =
     ideTest(
-      IdeTest(
-        code = HigherKindsTestCode.code4,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.POLY)
-        },
-        result = resolves("LineMarkerTest for Poly Icon") {
-          it.takeIf { description -> description.lineMarker.size == 2  && description.slowLM.isEmpty() }
-        }
+      myFixture = myFixture,
+      ctx = IdeMetaPlugin()
+    ) {
+      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+        IdeTest(
+          code = HigherKindsTestCode.code4,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.POLY)
+          },
+          result = resolvesWith("LineMarkerTest for Poly Icon") {
+            it.takeIf { description -> description.lineMarker.size == 2 && description.slowLM.isEmpty() }
+          }
+        )
       )
-    )
+    }
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/lens/LensTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/lens/LensTest.kt
@@ -1,25 +1,30 @@
 package arrow.meta.ide.plugins.lens
 
+import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.resources.ArrowIcons
 import arrow.meta.ide.testing.IdeTest
+import arrow.meta.ide.testing.dsl.lineMarker.LineMarkerDescription
 import arrow.meta.ide.testing.env.IdeTestSetUp
 import arrow.meta.ide.testing.env.ideTest
-import arrow.meta.ide.testing.resolves
 import org.junit.Test
 
 class LensTest : IdeTestSetUp() {
   @Test
   fun `Optics Test for LineMarkers`() =
     ideTest(
-      IdeTest(
-        code = LensTestCode.code1,
-        myFixture = myFixture,
-        test = { code, myFixture ->
-          collectLM(code, myFixture, ArrowIcons.OPTICS)
-        },
-        result = resolves("LineMarkerTest for 3 LM ") {
-          it.takeIf { descriptor -> descriptor.lineMarker.size == 3 && descriptor.slowLM.isEmpty() }
-        }
+      myFixture = myFixture,
+      ctx = IdeMetaPlugin()
+    ) {
+      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+        IdeTest(
+          code = LensTestCode.code1,
+          test = { code, myFixture, _ ->
+            collectLM(code, myFixture, ArrowIcons.OPTICS)
+          },
+          result = resolvesWith("LineMarkerTest for 3 LM ") {
+            it.takeIf { descriptor -> descriptor.lineMarker.size == 3 && descriptor.slowLM.isEmpty() }
+          }
+        )
       )
-    )
+    }
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/purity/PurityTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/purity/PurityTest.kt
@@ -1,27 +1,33 @@
 package arrow.meta.ide.plugins.purity
 
+import arrow.meta.ide.IdeMetaPlugin
 import arrow.meta.ide.testing.IdeTest
 import arrow.meta.ide.testing.env.IdeTestSetUp
 import arrow.meta.ide.testing.env.ideTest
-import arrow.meta.ide.testing.resolves
+import com.intellij.codeInsight.daemon.impl.HighlightInfo
 import org.junit.Test
 
 class PurityTest : IdeTestSetUp() {
   @Test
   fun `Impure Function`() =
     ideTest(
-      IdeTest(
-        myFixture,
-        PurityTestCode.code1,
-        test = { code, myFixture ->
-          collectInspections(code, myFixture, listOf(purityInspection))
-        },
-        result = resolves("At least one impure Function that needs to be suspended") {
-          it.filter { it.inspectionToolId == purityInspection.defaultFixText }
-            .takeIf {
-              it.isNotEmpty()
+      myFixture = myFixture,
+      ctx = IdeMetaPlugin()
+    ) {
+      listOf<IdeTest<List<HighlightInfo>, IdeMetaPlugin>>(
+        IdeTest(
+          PurityTestCode.code1,
+          test = { code, myFixture, _ ->
+            collectInspections(code, myFixture, listOf(purityInspection))
+          },
+          result = resolvesWith("At least one impure Function that needs to be suspended") {
+            it.takeIf {
+              it.any { info ->
+                info.inspectionToolId == purityInspection.defaultFixText
+              }
             }
-        }
+          }
+        )
       )
-    )
+    }
 }


### PR DESCRIPTION
Based on some feedback in testing. There is a new testing dsl in the Ide, 
which supports features described in the PluginScope `e.g.: IdeMetaPlugin`, which can then be used to describe tests. 
The data type IdeTest has now 3 fields the `code`, `test` to define a test and the expected result. 
The remaining dependencies to unfold that data structure into a test are now subject to functions and are not implicitly added. 
So we get the best out of both worlds, ascribing different interpreters for tests and a neat DSL without duplicating code. 