### PR TITLE
clean up on testing dsl Ide

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/IdeTest.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/IdeTest.kt
@@ -15,10 +15,10 @@ typealias Source = String
  * @see IdeResolution, [ideTest]
  * There is an example in [ideTest] KDoc's.
  */
-data class IdeTest<A, F : IdeSyntax>(
+data class IdeTest<F : IdeSyntax, A>(
   val code: Source,
   val test: IdeEnvironment.(code: Source, myFixture: CodeInsightTestFixture, ctx: F) -> A,
-  val result: IdeResolution<A, F>
+  val result: IdeResolution<F, A>
 )
 
 /**
@@ -26,4 +26,4 @@ data class IdeTest<A, F : IdeSyntax>(
  * [ResolutionSyntax] facilitates extensions for [IdeResolution].
  * @see ideTest
  */
-data class IdeResolution<A, F : IdeSyntax>(val message: String, val transform: F.(result: A) -> A?)
+data class IdeResolution<F : IdeSyntax, A>(val message: String, val transform: F.(result: A) -> A?)

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
@@ -15,10 +15,10 @@ import org.junit.Assert
  * testing methods such as property-based testing, unit tests and many more.
  * @see [arrow.meta.ide.testing.env.interpreter]
  */
-fun <A, F : IdeSyntax> IdeTest<A, F>.runTest(
+fun <F : IdeSyntax, A> IdeTest<F, A>.runTest(
   fixture: CodeInsightTestFixture,
   ctx: F,
-  interpreter: (test: IdeTest<A, F>, ctx: F, fixture: CodeInsightTestFixture) -> Unit = ::interpreter
+  interpreter: (test: IdeTest<F, A>, ctx: F, fixture: CodeInsightTestFixture) -> Unit = ::interpreter
 ): Unit =
   interpreter(this, ctx, fixture)
 
@@ -26,7 +26,7 @@ fun <A, F : IdeSyntax> IdeTest<A, F>.runTest(
  * [testResult] evaluates the actual result within the [IdeEnvironment]
  * @param ctx plugin context
  */
-fun <A, F : IdeSyntax> IdeTest<A, F>.testResult(ctx: F, fixture: CodeInsightTestFixture): A =
+fun <F : IdeSyntax, A> IdeTest<F, A>.testResult(ctx: F, fixture: CodeInsightTestFixture): A =
   test(IdeEnvironment, code, fixture, ctx)
 
 /**
@@ -34,7 +34,7 @@ fun <A, F : IdeSyntax> IdeTest<A, F>.testResult(ctx: F, fixture: CodeInsightTest
  * In addition, it throws an [AssertionError] with the [ideTest.result.message],
  * whenever the expected [ideTest.result] doesn't match the actual result from [testResult].
  */
-fun <A, F : IdeSyntax> interpreter(ideTest: IdeTest<A, F>, ctx: F, fixture: CodeInsightTestFixture): Unit =
+fun <F : IdeSyntax, A> interpreter(ideTest: IdeTest<F, A>, ctx: F, fixture: CodeInsightTestFixture): Unit =
   ideTest.run {
     val a = testResult(ctx, fixture)
     println("IdeTest results in $a")
@@ -123,9 +123,9 @@ fun <A, F : IdeSyntax> interpreter(ideTest: IdeTest<A, F>, ctx: F, fixture: Code
  * @param myFixture is a key component of the underlying Intellij Testing API.
  * @param ctx is the plugin context if unspecified it will use the [IdeEnvironment]
  */
-fun <A, F : IdeSyntax> ideTest(
+fun <F : IdeSyntax, A> ideTest(
   myFixture: CodeInsightTestFixture,
   ctx: F = IdeEnvironment as F,
-  tests: IdeEnvironment.() -> List<IdeTest<A, F>>
+  tests: IdeEnvironment.() -> List<IdeTest<F, A>>
 ): Unit =
   tests(IdeEnvironment).forEach { it.runTest(myFixture, ctx) }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/resolution/ResolutionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/resolution/ResolutionSyntax.kt
@@ -11,26 +11,38 @@ interface ResolutionSyntax {
    * @param transform describes the premises or shape of [A]
    * @see IdeResolution
    */
-  fun <A, F : IdeSyntax> IdeTestSyntax.failsWith(message: String, transform: F.(result: A) -> A?): IdeResolution<A, F> = IdeResolution(message, transform)
+  fun <F : IdeSyntax, A> IdeTestSyntax.failsWith(message: String, transform: F.(result: A) -> A?): IdeResolution<F, A> = IdeResolution(message, transform)
+
+  /**
+   * a convenience function to express [failsWith] in boolean logic.
+   */
+  fun <F : IdeSyntax, A> IdeTestSyntax.failsWhen(message: String, transform: F.(result: A) -> Boolean): IdeResolution<F, A> =
+    failsWith(message) { a: A -> if (transform(a)) a else null }
 
   /**
    * semantic sugar to define an [IdeResolution] that given [transform] completes successfully.
    * @param transform describes the premises or shape of [A].
    * @see IdeResolution
    */
-  fun <A, F : IdeSyntax> IdeTestSyntax.resolvesWith(message: String, transform: F.(result: A) -> A?): IdeResolution<A, F> = IdeResolution(message, transform)
+  fun <F : IdeSyntax, A> IdeTestSyntax.resolvesWith(message: String, transform: F.(result: A) -> A?): IdeResolution<F, A> = IdeResolution(message, transform)
+
+  /**
+   * a convenience function to express [resolvesWith] in boolean logic.
+   */
+  fun <F : IdeSyntax, A> IdeTestSyntax.resolvesWhen(message: String, transform: F.(result: A) -> Boolean): IdeResolution<F, A> =
+    resolvesWith(message) { a: A -> if (transform(a)) a else null }
 
   /**
    * this extension denotes that any test result in the test environment is accepted as a valid output.
    * Thereby, the Ide resolution always completes successfully, regardless of [A].
    * @see IdeResolution
    */
-  fun <A, F : IdeSyntax> IdeTestSyntax.resolves(message: String = "Any result is accepted."): IdeResolution<A, F> = IdeResolution(message) { it }
+  fun <F : IdeSyntax, A> IdeTestSyntax.resolves(message: String = "Any result is accepted."): IdeResolution<F, A> = IdeResolution(message) { it }
 
   /**
    * this extension denotes that any test result in the test environment fails.
    * Thereby, the Ide resolution always fails, regardless of [A].
    * @see IdeResolution
    */
-  fun <A, F : IdeSyntax> IdeTestSyntax.fails(message: String = "Failing Resolution"): IdeResolution<A, F> = IdeResolution(message) { null }
+  fun <F : IdeSyntax, A> IdeTestSyntax.fails(message: String = "Failing Resolution"): IdeResolution<F, A> = IdeResolution(message) { null }
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
@@ -60,4 +60,7 @@ object LightTestSyntax {
    */
   fun KtFile.highlighting(myFixture: CodeInsightTestFixture, toIgnore: List<Int>, changes: (KtFile) -> Boolean = { it.isScript() }): List<HighlightInfo> =
     CodeInsightTestFixtureImpl.instantiateAndRun(this, myFixture.editor, toIgnore.toIntArray(), changes(this)).filterNotNull()
+
+
+
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/types/LightTestSyntax.kt
@@ -60,7 +60,4 @@ object LightTestSyntax {
    */
   fun KtFile.highlighting(myFixture: CodeInsightTestFixture, toIgnore: List<Int>, changes: (KtFile) -> Boolean = { it.isScript() }): List<HighlightInfo> =
     CodeInsightTestFixtureImpl.instantiateAndRun(this, myFixture.editor, toIgnore.toIntArray(), changes(this)).filterNotNull()
-
-
-
 }

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/comprehensions/ComprehensionsTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/comprehensions/ComprehensionsTest.kt
@@ -15,14 +15,14 @@ class ComprehensionsTest : IdeTestSetUp() {
       myFixture = myFixture,
       ctx = IdeMetaPlugin()
     ) {
-      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+      listOf<IdeTest<IdeMetaPlugin, LineMarkerDescription>>(
         IdeTest(
           code = ComprehensionsTestCode.code1,
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.BIND)
           },
-          result = resolvesWith("LineMarkerTest for two LM on typed variables") {
-            it.takeIf { descriptor -> descriptor.lineMarker.size == 2 && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for two LM on typed variables") {
+            it.lineMarker.size == 2 && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -30,8 +30,8 @@ class ComprehensionsTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.BIND)
           },
-          result = resolvesWith("LineMarkerTest for two LM on untyped variables") {
-            it.takeIf { descriptor -> descriptor.lineMarker.size == 2 && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for two LM on untyped variables") {
+            it.lineMarker.size == 2 && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -39,8 +39,8 @@ class ComprehensionsTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.BIND)
           },
-          result = resolvesWith("LineMarkerTest for six LM on untyped variables") {
-            it.takeIf { descriptor -> descriptor.lineMarker.size == 6 && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for six LM on untyped variables") {
+            it.lineMarker.size == 6 && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -48,8 +48,8 @@ class ComprehensionsTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.BIND)
           },
-          result = resolvesWith("LineMarkerTest for four LM on untyped variables") {
-            it.takeIf { descriptor -> descriptor.lineMarker.size == 4 && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for four LM on untyped variables") {
+            it.lineMarker.size == 4 && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -57,8 +57,8 @@ class ComprehensionsTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.BIND)
           },
-          result = resolvesWith("LineMarkerTest for zero LM ") {
-            it.takeIf { descriptor -> descriptor.lineMarker.isEmpty() && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for zero LM ") {
+            it.lineMarker.isEmpty() && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -66,8 +66,8 @@ class ComprehensionsTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.BIND)
           },
-          result = resolvesWith("LineMarkerTest for no LM ") {
-            it.takeIf { descriptor -> descriptor.lineMarker.isEmpty() && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for no LM ") {
+            it.lineMarker.isEmpty() && it.slowLM.isEmpty()
           }
         )
       )

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/higherkinds/HigherKindTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/higherkinds/HigherKindTest.kt
@@ -15,14 +15,14 @@ class HigherKindTest : IdeTestSetUp() {
       myFixture = myFixture,
       ctx = IdeMetaPlugin()
     ) {
-      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+      listOf<IdeTest<IdeMetaPlugin, LineMarkerDescription>>(
         IdeTest(
           code = HigherKindsTestCode.code1,
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.HKT)
           },
-          result = resolvesWith("LineMarkerTest for one valid HKT") {
-            it.takeIf { description -> description.lineMarker.size == 1 && description.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for one valid HKT") {
+            it.lineMarker.size == 1 && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -30,8 +30,8 @@ class HigherKindTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.HKT)
           },
-          result = resolvesWith("LineMarkerTest for multiple valid HKT") {
-            it.takeIf { description -> description.lineMarker.size == 2 && description.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for multiple valid HKT") {
+            it.lineMarker.size == 2 && it.slowLM.isEmpty()
           }
         ),
         IdeTest(
@@ -39,8 +39,8 @@ class HigherKindTest : IdeTestSetUp() {
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.HKT)
           },
-          result = resolvesWith("LineMarkerTest for no valid HKT") {
-            it.takeIf { description -> description.lineMarker.isEmpty() && description.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for no valid HKT") {
+            it.lineMarker.isEmpty() && it.slowLM.isEmpty()
           }
         )
       )
@@ -53,14 +53,14 @@ class HigherKindTest : IdeTestSetUp() {
       myFixture = myFixture,
       ctx = IdeMetaPlugin()
     ) {
-      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+      listOf<IdeTest<IdeMetaPlugin, LineMarkerDescription>>(
         IdeTest(
           code = HigherKindsTestCode.code4,
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.POLY)
           },
-          result = resolvesWith("LineMarkerTest for Poly Icon") {
-            it.takeIf { description -> description.lineMarker.size == 2 && description.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for Poly Icon") {
+            it.lineMarker.size == 2 && it.slowLM.isEmpty()
           }
         )
       )

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/lens/LensTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/lens/LensTest.kt
@@ -15,14 +15,14 @@ class LensTest : IdeTestSetUp() {
       myFixture = myFixture,
       ctx = IdeMetaPlugin()
     ) {
-      listOf<IdeTest<LineMarkerDescription, IdeMetaPlugin>>(
+      listOf<IdeTest<IdeMetaPlugin, LineMarkerDescription>>(
         IdeTest(
           code = LensTestCode.code1,
           test = { code, myFixture, _ ->
             collectLM(code, myFixture, ArrowIcons.OPTICS)
           },
-          result = resolvesWith("LineMarkerTest for 3 LM ") {
-            it.takeIf { descriptor -> descriptor.lineMarker.size == 3 && descriptor.slowLM.isEmpty() }
+          result = resolvesWhen("LineMarkerTest for 3 LM ") {
+            it.lineMarker.size == 3 && it.slowLM.isEmpty()
           }
         )
       )

--- a/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/purity/PurityTest.kt
+++ b/idea-plugin/src/test/kotlin/arrow/meta/ide/plugins/purity/PurityTest.kt
@@ -14,17 +14,15 @@ class PurityTest : IdeTestSetUp() {
       myFixture = myFixture,
       ctx = IdeMetaPlugin()
     ) {
-      listOf<IdeTest<List<HighlightInfo>, IdeMetaPlugin>>(
+      listOf<IdeTest<IdeMetaPlugin, List<HighlightInfo>>>(
         IdeTest(
           PurityTestCode.code1,
           test = { code, myFixture, _ ->
             collectInspections(code, myFixture, listOf(purityInspection))
           },
-          result = resolvesWith("At least one impure Function that needs to be suspended") {
-            it.takeIf {
-              it.any { info ->
-                info.inspectionToolId == purityInspection.defaultFixText
-              }
+          result = resolvesWhen("At least one impure Function that needs to be suspended") {
+            it.any { info ->
+              info.inspectionToolId == purityInspection.defaultFixText
             }
           }
         )


### PR DESCRIPTION
adds boolean logic to tests algebra
turns around `<A, F>` to `<F, A>` signatures