### PR TITLE
reencode Services

### DIFF
--- a/.github/workflows/sandbox/1.3.70-eap.diff
+++ b/.github/workflows/sandbox/1.3.70-eap.diff
@@ -1142,10 +1142,10 @@ index c96a5fc..d3f2128 100644
  KOTLIN_TEST_VERSION=3.4.2
  ASSERTJ_VERSION=3.13.2
 diff --git a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ApplicationSyntax.kt b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ApplicationSyntax.kt
-index 541cdd1..2187a75 100644
+index d767ad2..b56bee1 100644
 --- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ApplicationSyntax.kt
 +++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ApplicationSyntax.kt
-@@ -258,10 +258,9 @@ interface ApplicationSyntax {
+@@ -323,10 +323,9 @@ interface ApplicationSyntax {
      initialize: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
      afterProjectClosed: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
      dispose: ProjectLifecycle.() -> Unit = Noop.effect1,
@@ -1153,22 +1153,20 @@ index 541cdd1..2187a75 100644
 -    postStartupActivitiesPassed: ProjectLifecycle.(Project) -> Unit = Noop.effect2
 +    beforeProjectLoaded: ProjectLifecycle.(Project) -> Unit = Noop.effect2
    ): ExtensionPhase =
--    ApplicationProvider.ProjectListener(projectLifecycleListener(initialize, afterProjectClosed, dispose, beforeProjectLoaded, postStartupActivitiesPassed))
-+    ApplicationProvider.ProjectListener(projectLifecycleListener(initialize, afterProjectClosed, dispose, beforeProjectLoaded))
+-    ApplicationProvider.ProjectListener(projectLifecycleListener(beforeProjectLoaded, initialize, postStartupActivitiesPassed, afterProjectClosed, dispose))
++    ApplicationProvider.ProjectListener(projectLifecycleListener(beforeProjectLoaded, initialize, afterProjectClosed, dispose))
  
    /**
     * Order: [beforeProjectLoaded] then [initialize] then [postStartupActivitiesPassed] then [afterProjectClosed]
-@@ -270,8 +269,7 @@ interface ApplicationSyntax {
+@@ -334,7 +333,6 @@ interface ApplicationSyntax {
+   fun ApplicationSyntax.projectLifecycleListener(
+     beforeProjectLoaded: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
      initialize: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
+-    postStartupActivitiesPassed: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
      afterProjectClosed: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
-     dispose: ProjectLifecycle.() -> Unit = Noop.effect1,
--    beforeProjectLoaded: ProjectLifecycle.(Project) -> Unit = Noop.effect2,
--    postStartupActivitiesPassed: ProjectLifecycle.(Project) -> Unit = Noop.effect2
-+    beforeProjectLoaded: ProjectLifecycle.(Project) -> Unit = Noop.effect2
+     dispose: ProjectLifecycle.() -> Unit = Noop.effect1
    ): ProjectLifecycle =
-     object : ProjectLifecycle {
-       override fun projectComponentsInitialized(project: Project): Unit =
-@@ -283,9 +281,6 @@ interface ApplicationSyntax {
+@@ -348,9 +346,6 @@ interface ApplicationSyntax {
        override fun afterProjectClosed(project: Project): Unit =
          afterProjectClosed(this, project)
  
@@ -1178,6 +1176,28 @@ index 541cdd1..2187a75 100644
        override fun dispose(): Unit = dispose(this)
      }
  
+@@ -360,10 +355,9 @@ interface ApplicationSyntax {
+   fun ApplicationSyntax.addProjectLifecycleListener(
+     beforeProjectLoaded: (Project) -> Unit = Noop.effect1,
+     initialize: (Project) -> Unit = Noop.effect1,
+-    postStartupActivitiesPassed: (Project) -> Unit = Noop.effect1,
+     afterProjectClosed: (Project) -> Unit = Noop.effect1
+   ): ExtensionPhase =
+-    ApplicationProvider.ProjectListener(projectLifecycleListener(beforeProjectLoaded, initialize, postStartupActivitiesPassed, afterProjectClosed))
++    ApplicationProvider.ProjectListener(projectLifecycleListener(beforeProjectLoaded, initialize, afterProjectClosed))
+ 
+   fun ApplicationSyntax.projectLifecycleListener(
+     beforeProjectLoaded: (Project) -> Unit = Noop.effect1,
+@@ -380,9 +374,6 @@ interface ApplicationSyntax {
+ 
+       override fun afterProjectClosed(project: Project): Unit =
+         afterProjectClosed(project)
+-
+-      override fun postStartupActivitiesPassed(project: Project): Unit =
+-        postStartupActivitiesPassed(project)
+     }
+ 
+   /**
 diff --git a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/color/ColorSettingsSyntax.kt b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/color/ColorSettingsSyntax.kt
 index d88523d..42b0f60 100644
 --- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/color/ColorSettingsSyntax.kt
@@ -1296,30 +1316,30 @@ index 1c00571..022116c 100644
      ToolwindowProvider.Notification(toolId, type, html, icon, listener, project)
  
 diff --git a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
-index 1a9e65f..fa7b41e 100644
+index dfb1e33..f31b045 100644
 --- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
 +++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
-@@ -45,7 +45,7 @@ import com.intellij.openapi.project.Project
+@@ -44,7 +44,7 @@ import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+ import com.intellij.openapi.project.Project
  import com.intellij.openapi.project.impl.ProjectLifecycleListener
- import com.intellij.openapi.util.Disposer
  import com.intellij.openapi.wm.ToolWindowManager
 -import com.intellij.serviceContainer.PlatformComponentManagerImpl
 +import com.intellij.serviceContainer.ComponentManagerImpl
  import com.intellij.ui.content.ContentFactory
  import com.intellij.util.messages.Topic
  import org.jetbrains.kotlin.container.useImpl
-@@ -115,8 +115,8 @@ internal interface IdeInternalRegistry : InternalRegistry {
-         is ApplicationProvider.ReplaceService<*> -> phase.run { app.replaceService(service as Class<Any>, instance) }
+@@ -129,8 +129,8 @@ internal interface IdeInternalRegistry : InternalRegistry {
+         is ApplicationProvider.OverrideService -> phase.run { app.overrideService(from, to, override) }
          is ApplicationProvider.Listener -> app.addApplicationListener(phase.listener, app)
          is ApplicationProvider.ProjectListener -> app.registerTopic(ProjectLifecycleListener.TOPIC, phase.listener) // Alternative use ProjectManagerListener.TOPIC
 -        is ApplicationProvider.UnloadServices -> app.safeAs<PlatformComponentManagerImpl>()?.unloadServices(phase.container)?.forEach { LOG.info("Meta Unloaded Service:$it") }
 -        ApplicationProvider.StopServicePreloading -> app.safeAs<PlatformComponentManagerImpl>()?.stopServicePreloading()
 +        is ApplicationProvider.UnloadServices -> app.safeAs<ComponentManagerImpl>()?.unloadServices(phase.container)?.forEach { LOG.info("Meta Unloaded Service:$it") }
 +        ApplicationProvider.StopServicePreloading -> app.safeAs<ComponentManagerImpl>()?.stopServicePreloading()
+         is ApplicationProvider.MetaModuleListener -> phase.run { app.messageBus.connect(app).subscribe(ProjectTopics.MODULES, listener) }
        }
      }
-       ?: LOG.warn("The registration process failed for extension:$phase from arrow.meta.ide.phases.application.ApplicationProvider.\nPlease raise an Issue in Github: https://github.com/arrow-kt/arrow-meta")
-@@ -127,12 +127,12 @@ internal interface IdeInternalRegistry : InternalRegistry {
+@@ -142,12 +142,12 @@ internal interface IdeInternalRegistry : InternalRegistry {
        ?: LOG.error("Service:${fromService.simpleName} could not be OVERRIDDEN properly.\nPlease raise an Issue in Github: https://github.com/arrow-kt/arrow-meta")
  
    fun <T : Any> ComponentManager.registerService(service: Class<T>, instance: T): Unit =
@@ -1334,7 +1354,7 @@ index 1a9e65f..fa7b41e 100644
        ?.replaceServiceInstance(service, instance, this)
        ?: LOG.error("Service:${service.simpleName} could not be REPLACED properly.\nPlease raise an Issue in Github: https://github.com/arrow-kt/arrow-meta")
  
-@@ -147,7 +147,7 @@ internal interface IdeInternalRegistry : InternalRegistry {
+@@ -162,7 +162,7 @@ internal interface IdeInternalRegistry : InternalRegistry {
      ToolWindowManager.getInstance(project).let { manager ->
        manager.getToolWindow(id)?.activate(null)
          ?: manager.registerToolWindow(id, canCloseContent, anchor).let { window ->
@@ -1343,10 +1363,10 @@ index 1a9e65f..fa7b41e 100644
            window.contentManager.addContent(ContentFactory.SERVICE.getInstance().createContent(content(project, window), "", isLockable))
          }
      }
-@@ -229,4 +229,4 @@ internal interface IdeInternalRegistry : InternalRegistry {
-   private object IdeRegistryContext {
-     val dispose: Disposable = Disposer.newDisposable()
-   }
+@@ -240,4 +240,4 @@ internal interface IdeInternalRegistry : InternalRegistry {
+       is ExtensionProvider.RegisterExtension -> phase.run { Extensions.getRootArea().registerExtensionPoint(EP_NAME.name, aClass.name, kind) }
+       is ExtensionProvider.AddLanguageAnnotator -> LanguageAnnotators.INSTANCE.addExplicitExtension(phase.lang, phase.impl)
+     }
 -}
 \ No newline at end of file
 +}

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ProjectLifecycle.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ProjectLifecycle.kt
@@ -1,0 +1,6 @@
+package arrow.meta.ide.dsl.application
+
+import com.intellij.openapi.Disposable
+import com.intellij.openapi.project.impl.ProjectLifecycleListener
+
+interface ProjectLifecycle : ProjectLifecycleListener, Disposable

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/IdeRegistrar.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/IdeRegistrar.kt
@@ -6,6 +6,9 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import kotlin.contracts.ExperimentalContracts
 
+/**
+ * entry point of Meta in the Ide
+ */
 class IdeRegistrar : ApplicationInitializedListener {
   val LOG = Logger.getInstance("#arrow.AppRegistrar")
 

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
@@ -106,6 +106,12 @@ internal interface IdeInternalRegistry : InternalRegistry {
         is ApplicationProvider.AppService<*> -> phase.run { instance(app.getService(service))?.let { app.registerService(service as Class<Any>, it) } }
         is ApplicationProvider.ReplaceAppService<*> -> phase.run { app.replaceService(service as Class<Any>, instance(app.getService(service))) }
         is ApplicationProvider.ProjectService<*> -> phase.run {
+          /**
+           * Investigate other registry options in:
+           * com/intellij/serviceContainer/PlatformComponentManagerImpl.kt:163: createComponent
+           * com.intellij.openapi.project.impl.ProjectImpl.init
+           * com/intellij/idea/ApplicationLoader.kt:261: preloadServices
+           */
           app.registerTopic(ProjectLifecycleListener.TOPIC, object : ProjectLifecycleListener {
             override fun projectComponentsInitialized(project: Project): Unit =
               instance(project, project.getService(service))?.let {

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
@@ -2,7 +2,6 @@ package arrow.meta.ide.internal.registry
 
 import arrow.meta.dsl.platform.ide
 import arrow.meta.ide.IdePlugin
-import arrow.meta.ide.dsl.application.ServiceKind
 import arrow.meta.ide.phases.IdeContext
 import arrow.meta.ide.phases.analysis.MetaIdeAnalyzer
 import arrow.meta.ide.phases.application.ApplicationProvider
@@ -28,6 +27,7 @@ import arrow.meta.phases.resolve.DeclarationAttributeAlterer
 import arrow.meta.phases.resolve.PackageProvider
 import arrow.meta.phases.resolve.synthetics.SyntheticResolver
 import arrow.meta.phases.resolve.synthetics.SyntheticScopeProvider
+import com.intellij.ProjectTopics
 import com.intellij.codeInsight.intention.IntentionManager
 import com.intellij.codeInsight.intention.impl.config.IntentionManagerSettings
 import com.intellij.ide.AppLifecycleListener
@@ -43,7 +43,6 @@ import com.intellij.openapi.extensions.Extensions
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.impl.ProjectLifecycleListener
-import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.serviceContainer.PlatformComponentManagerImpl
 import com.intellij.ui.content.ContentFactory
@@ -75,19 +74,22 @@ internal interface IdeInternalRegistry : InternalRegistry {
     intercept(ctx).forEach {
       println("Registering ide plugin: $it extensions: ${it.meta}")
       it.meta(ctx).forEach { phase ->
-        when (phase) {
-          is ExtensionPhase.Empty, is CollectAdditionalSources, is Composite, is Config, is ExtraImports,
-          is PreprocessedVirtualFileFactory, is StorageComponentContainer, is PackageProvider, is AnalysisHandler, is ClassBuilder,
-          is Codegen, is DeclarationAttributeAlterer, is SyntheticResolver,
-          is IRGeneration, is SyntheticScopeProvider -> Unit // filter out ExtensionPhases which happen in the compiler
-          is ExtensionProvider<*> -> registerExtensionProvider(phase, ctx.app)
-          is AnActionExtensionProvider -> registerAnActionExtensionProvider(phase)
-          is IntentionExtensionProvider -> registerIntentionExtensionProvider(phase)
-          is SyntaxHighlighterExtensionProvider -> registerSyntaxHighlighterExtensionProvider(phase)
-          is ToolwindowProvider -> registerToolwindowProvider(phase)
-          is ApplicationProvider -> registerApplicationProvider(phase)
-          else -> LOG.error("Unsupported ide extension phase: $phase")
-        }
+        fun rec(phase: ExtensionPhase): Unit =
+          when (phase) {
+            is ExtensionPhase.Empty, is CollectAdditionalSources, is Config, is ExtraImports,
+            is PreprocessedVirtualFileFactory, is StorageComponentContainer, is PackageProvider, is AnalysisHandler, is ClassBuilder,
+            is Codegen, is DeclarationAttributeAlterer, is SyntheticResolver,
+            is IRGeneration, is SyntheticScopeProvider -> Unit // filter out ExtensionPhases which happen in the compiler
+            is ExtensionProvider<*> -> registerExtensionProvider(phase, ctx.app)
+            is AnActionExtensionProvider -> registerAnActionExtensionProvider(phase)
+            is IntentionExtensionProvider -> registerIntentionExtensionProvider(phase)
+            is SyntaxHighlighterExtensionProvider -> registerSyntaxHighlighterExtensionProvider(phase)
+            is ToolwindowProvider -> registerToolwindowProvider(phase)
+            is ApplicationProvider -> registerApplicationProvider(phase)
+            is Composite -> phase.phases.forEach { composite -> rec(composite) }
+            else -> LOG.error("Unsupported ide extension phase: $phase")
+          }
+        rec(phase)
       }
     }
     LOG.info("subscribing meta registrars took ${System.currentTimeMillis() - start}ms")
@@ -101,22 +103,27 @@ internal interface IdeInternalRegistry : InternalRegistry {
   fun registerApplicationProvider(phase: ApplicationProvider): Unit =
     ApplicationManager.getApplication()?.let { app ->
       when (phase) {
-        is ApplicationProvider.Service<*> -> phase.run {
-          when (kind) {
-            ServiceKind.Application -> app.registerService(service as Class<Any>, instance)
-            ServiceKind.Project -> app.messageBus.connect(app).subscribe(ProjectLifecycleListener.TOPIC, object : ProjectLifecycleListener {
-              override fun projectComponentsInitialized(project: Project): Unit = // true, because Meta Ide is still component based, not service based.
-                project.registerService(service as Class<Any>, instance)
-            })
-          }
+        is ApplicationProvider.AppService<*> -> phase.run { app.registerService(service as Class<Any>, instance) }
+        is ApplicationProvider.ProjectService<*> -> phase.run {
+          app.messageBus.connect(app).subscribe(ProjectLifecycleListener.TOPIC, object : ProjectLifecycleListener {
+            override fun projectComponentsInitialized(project: Project): Unit =
+              project.registerService(service as Class<Any>, instance(project, project.getService(service) as Nothing?))
+          })
+        }
+        is ApplicationProvider.ReplaceProjectService<*> -> phase.run {
+          app.messageBus.connect(app).subscribe(ProjectLifecycleListener.TOPIC, object : ProjectLifecycleListener {
+            override fun projectComponentsInitialized(project: Project): Unit =
+              project.replaceService(service as Class<Any>, instance(project, project.getService(service) as Nothing?))
+          })
         }
         is ApplicationProvider.AppListener -> app.messageBus.connect(app).subscribe(AppLifecycleListener.TOPIC, phase.listener)
         is ApplicationProvider.OverrideService -> phase.run { app.overrideService(from, to, override) }
-        is ApplicationProvider.ReplaceService<*> -> phase.run { app.replaceService(service as Class<Any>, instance) }
+        is ApplicationProvider.ReplaceAppService<*> -> phase.run { app.replaceService(service as Class<Any>, instance) }
         is ApplicationProvider.Listener -> app.addApplicationListener(phase.listener, app)
         is ApplicationProvider.ProjectListener -> app.registerTopic(ProjectLifecycleListener.TOPIC, phase.listener) // Alternative use ProjectManagerListener.TOPIC
         is ApplicationProvider.UnloadServices -> app.safeAs<PlatformComponentManagerImpl>()?.unloadServices(phase.container)?.forEach { LOG.info("Meta Unloaded Service:$it") }
         ApplicationProvider.StopServicePreloading -> app.safeAs<PlatformComponentManagerImpl>()?.stopServicePreloading()
+        is ApplicationProvider.MetaModuleListener -> phase.run { app.messageBus.connect(app).subscribe(ProjectTopics.MODULES, listener) }
       }
     }
       ?: LOG.warn("The registration process failed for extension:$phase from arrow.meta.ide.phases.application.ApplicationProvider.\nPlease raise an Issue in Github: https://github.com/arrow-kt/arrow-meta")
@@ -215,9 +222,9 @@ internal interface IdeInternalRegistry : InternalRegistry {
       }
     }
 
-  fun <E> registerExtensionProvider(phase: ExtensionProvider<E>, disposable: Disposable = IdeRegistryContext.dispose): Unit =
+  fun <E> registerExtensionProvider(phase: ExtensionProvider<E>, disposable: Disposable): Unit =
     when (phase) {
-      is ExtensionProvider.AddExtension -> phase.run { Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(impl, loadingOrder, disposable) } // fixme: IdeContext needs to be removed
+      is ExtensionProvider.AddExtension -> phase.run { Extensions.getRootArea().getExtensionPoint(EP_NAME).registerExtension(impl, loadingOrder, disposable) }
       is ExtensionProvider.AddLanguageExtension -> phase.run { LE.addExplicitExtension(lang, impl) }
       is ExtensionProvider.AddFileTypeExtension -> phase.run { FE.addExplicitExtension(fileType, impl) }
       is ExtensionProvider.AddClassExtension -> phase.run { CE.addExplicitExtension(forClass, impl) }
@@ -225,8 +232,4 @@ internal interface IdeInternalRegistry : InternalRegistry {
       is ExtensionProvider.RegisterExtension -> phase.run { Extensions.getRootArea().registerExtensionPoint(EP_NAME.name, aClass.name, kind) }
       is ExtensionProvider.AddLanguageAnnotator -> LanguageAnnotators.INSTANCE.addExplicitExtension(phase.lang, phase.impl)
     }
-
-  private object IdeRegistryContext {
-    val dispose: Disposable = Disposer.newDisposable()
-  }
 }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/application/ApplicationProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/application/ApplicationProvider.kt
@@ -2,29 +2,65 @@ package arrow.meta.ide.phases.application
 
 import arrow.meta.ide.dsl.application.ApplicationSyntax
 import arrow.meta.ide.dsl.application.ProjectLifecycle
-import arrow.meta.ide.dsl.application.ServiceKind
 import arrow.meta.phases.ExtensionPhase
 import com.intellij.ide.AppLifecycleListener
 import com.intellij.ide.plugins.ContainerDescriptor
 import com.intellij.openapi.application.ApplicationListener
+import com.intellij.openapi.project.ModuleListener
+import com.intellij.openapi.project.Project
 
 /**
  * @see ApplicationSyntax
  */
 sealed class ApplicationProvider : ExtensionPhase {
+  /**
+   * @see ApplicationSyntax
+   */
+  data class AppService<A : Any>(val service: Class<A>, val instance: A) : ApplicationProvider()
 
-  data class Service<A : Any>(val service: Class<A>, val instance: A, val kind: ServiceKind) : ApplicationProvider()
+  /**
+   * @see ApplicationSyntax
+   */
+  data class ProjectService<A : Any>(val service: Class<A>, val instance: (Project, A?) -> A) : ApplicationProvider()
 
+  /**
+   * @see ApplicationSyntax
+   */
   data class OverrideService(val from: Class<*>, val to: Class<*>, val override: Boolean) : ApplicationProvider()
 
-  data class ReplaceService<A : Any>(val service: Class<A>, val instance: A) : ApplicationProvider()
+  /**
+   * @see ApplicationSyntax
+   */
+  data class ReplaceAppService<A : Any>(val service: Class<A>, val instance: A) : ApplicationProvider()
 
+  /**
+   * @see ApplicationSyntax
+   */
+  data class ReplaceProjectService<A : Any>(val service: Class<A>, val instance: (Project, A?) -> A) : ApplicationProvider()
+
+  /**
+   * @see ApplicationSyntax
+   */
   data class Listener(val listener: ApplicationListener) : ApplicationProvider()
 
+  /**
+   * @see ApplicationSyntax
+   */
   data class AppListener(val listener: AppLifecycleListener) : ApplicationProvider()
 
+  /**
+   * @see ApplicationSyntax
+   */
   data class ProjectListener(val listener: ProjectLifecycle) : ApplicationProvider()
 
+  /**
+   * @see ApplicationSyntax
+   */
+  data class MetaModuleListener(val listener: ModuleListener) : ApplicationProvider()
+
+  /**
+   * @see ApplicationSyntax
+   */
   object StopServicePreloading : ApplicationProvider()
 
   /**

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/application/ApplicationProvider.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/application/ApplicationProvider.kt
@@ -8,6 +8,7 @@ import com.intellij.ide.plugins.ContainerDescriptor
 import com.intellij.openapi.application.ApplicationListener
 import com.intellij.openapi.project.ModuleListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.impl.ProjectLifecycleListener
 
 /**
  * @see ApplicationSyntax
@@ -16,12 +17,12 @@ sealed class ApplicationProvider : ExtensionPhase {
   /**
    * @see ApplicationSyntax
    */
-  data class AppService<A : Any>(val service: Class<A>, val instance: A) : ApplicationProvider()
+  data class AppService<A : Any>(val service: Class<A>, val instance: (Any?) -> A?) : ApplicationProvider()
 
   /**
    * @see ApplicationSyntax
    */
-  data class ProjectService<A : Any>(val service: Class<A>, val instance: (Project, A?) -> A) : ApplicationProvider()
+  data class ProjectService<A : Any>(val service: Class<A>, val instance: (Project, Any?) -> A?) : ApplicationProvider()
 
   /**
    * @see ApplicationSyntax
@@ -31,12 +32,12 @@ sealed class ApplicationProvider : ExtensionPhase {
   /**
    * @see ApplicationSyntax
    */
-  data class ReplaceAppService<A : Any>(val service: Class<A>, val instance: A) : ApplicationProvider()
+  data class ReplaceAppService<A : Any>(val service: Class<A>, val instance: (Any?) -> A) : ApplicationProvider()
 
   /**
    * @see ApplicationSyntax
    */
-  data class ReplaceProjectService<A : Any>(val service: Class<A>, val instance: (Project, A?) -> A) : ApplicationProvider()
+  data class ReplaceProjectService<A : Any>(val service: Class<A>, val instance: (Project, Any?) -> A) : ApplicationProvider()
 
   /**
    * @see ApplicationSyntax
@@ -51,7 +52,7 @@ sealed class ApplicationProvider : ExtensionPhase {
   /**
    * @see ApplicationSyntax
    */
-  data class ProjectListener(val listener: ProjectLifecycle) : ApplicationProvider()
+  data class ProjectListener(val listener: ProjectLifecycleListener) : ApplicationProvider()
 
   /**
    * @see ApplicationSyntax

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/quotes/QuotePlugin.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/quotes/QuotePlugin.kt
@@ -1,14 +1,14 @@
 package arrow.meta.ide.plugins.quotes
 
 import arrow.meta.CliPlugin
-import arrow.meta.ide.IdePlugin
 import arrow.meta.ide.IdeMetaPlugin
-import arrow.meta.ide.plugins.quotes.lifecycle.quoteProjectOpened
-import arrow.meta.ide.plugins.quotes.resolve.quoteSyntheticPackageFragmentProvider
+import arrow.meta.ide.IdePlugin
 import arrow.meta.ide.invoke
 import arrow.meta.ide.plugins.quotes.lifecycle.quoteLifecycle
-import arrow.meta.invoke as cli
+import arrow.meta.ide.plugins.quotes.lifecycle.quoteProjectOpened
+import arrow.meta.ide.plugins.quotes.resolve.quoteSyntheticPackageFragmentProvider
 import com.intellij.openapi.startup.StartupActivity
+import arrow.meta.invoke as cli
 
 /**
  * Please, view the sub directories `cache` , `resolve` and `system` for quotes related IDE features.
@@ -29,8 +29,8 @@ val IdeMetaPlugin.quotes: IdePlugin
  * quotes cli integration with the Ide
  */
 val IdeMetaPlugin.quotesCli: CliPlugin
- get() = "Quotes Cli Integration".cli {
-   meta(
-     quoteSyntheticPackageFragmentProvider
-   )
- }
+  get() = "Quotes Cli Integration".cli {
+    meta(
+      quoteSyntheticPackageFragmentProvider
+    )
+  }

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
@@ -109,10 +109,8 @@ fun <A, F : IdeSyntax> interpreter(ideTest: IdeTest<A, F>, ctx: F, fixture: Code
  *         test = { code: Source, myFixture: CodeInsightTestFixture, ctx ->
  *           collectLM(code, myFixture, ArrowIcons.ICON1) // this collect's all visible LineMarkers in the editor for the given Icon
  *         },
- *         result = resolvesWith("LineMarker Test for helloWorld") {
- *           it.takeIf { collected ->
- *             collected.lineMarker.size == 1 // we expect that there is only one lineMarker in our example code
- *           }
+ *         result = resolvesWhen("LineMarker Test for helloWorld") {
+ *           it.lineMarker.size == 1 // we expect that there is only one lineMarker in our example code
  *         }
  *       )
  *     )


### PR DESCRIPTION
adds a better encoding for project and application services.
```kotlin
addProjectService(
  service = MyService::class.java,
  instance = { project: Project, hijackedService: MyService? ->
    object : MyService {
      override fun printLn(f: KtNamedFunction): Unit =
        println("Function: ${f.name} returns ${f.resolveToDescriptorIfAny()?.returnType ?: "ERROR"}")
    }
  }
)
```
This algebra also provides the hijacked services from 3rd parties, given that the services has been instatiated by a plugn one depends.
- [X] add ModuleListener
- [x] update Docs