### PR TITLE
Suppress thread death error is caused by the Kotlin script engine

### DIFF
--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -58,6 +58,7 @@ patchPluginXml {
 
 runIde {
   jvmArgs '-Xmx8G'
+  systemProperties['idea.is.internal'] = "false"
 }
 
 test {


### PR DESCRIPTION
cc @i-walker 
Unhandled exceptions are passed to IntelliJ's `DefaultErrorHandler`
`DefaultErrorHandler` detects the plugin, which likely caused the exception. That's the kotlin plugin for the ThreadDeath exception, because the first frame of the stack trace belongs to the Kotlin plugin.
We can't override that extension of the Kotlin plugin.

The error reporter of the plugin is then queried if the error should be reported.
`org.jetbrains.kotlin.idea.reporter.KotlinReportSubmitter#showErrorInRelease` is the implementation of the Kotlin plugin. System property `val KOTLIN_FATAL_ERROR_NOTIFICATION_PROPERTY = "kotlin.fatal.error.notification"` controls if errors should be suppressed.

- Now we can use this property to hide the ThreadDeath exception.
**That's a rather bad hack, but the only way I see to hide the exception.**
Another fix would be to fix the Kotlin plugin, but that's probably a lot more work to do properly.

- Because the errors are always shown if the IDE is in internal mode, we're turning internal mode of for `runIDE`. User's don't have internal mode enabled by default.
