### PR TITLE
Union folding truncate

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/proofs/folding/unionTypes.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/proofs/folding/unionTypes.kt
@@ -34,7 +34,11 @@ private fun KtTypeReference.foldString(): String =
     .replace(" ", "") // trim not working?
     .split("|")
     .distinct()
-    .joinToString(separator = " | ")
+    .joinToString(
+      separator = " | ",
+      limit = 5,
+      truncated = "..."
+    )
 
 
 private fun KtElement.foldTypeString(): String =


### PR DESCRIPTION
Visually limiting the amount of types used by the Union (up until 5) when its folded and trucated with `...`.