### PR TITLE
set doc-header sticky position in small size

### DIFF
--- a/docs/_sass/components/_doc-header.scss
+++ b/docs/_sass/components/_doc-header.scss
@@ -89,3 +89,13 @@
     }
   }
 }
+
+@include bp(medium) {
+  #doc-wrapper {
+    .doc-header {
+      position: sticky;
+      top: 0;
+      z-index: 11;
+    }
+  }
+}


### PR DESCRIPTION
Sets `doc-header` sticky position in small screen size for docs section.

This closes #560 