### PR TITLE
Fix typeclass syntax navigation

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/resolve/scopes/ProofsSyntheticScopes.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/resolve/scopes/ProofsSyntheticScopes.kt
@@ -16,9 +16,7 @@ import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.ConstructorDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
-import org.jetbrains.kotlin.descriptors.ReceiverParameterDescriptor
 import org.jetbrains.kotlin.descriptors.SimpleFunctionDescriptor
-import org.jetbrains.kotlin.descriptors.Visibilities
 import org.jetbrains.kotlin.descriptors.annotations.Annotations
 import org.jetbrains.kotlin.descriptors.impl.ReceiverParameterDescriptorImpl
 import org.jetbrains.kotlin.incremental.components.LookupLocation
@@ -53,10 +51,12 @@ fun CompilerContext.syntheticMemberFunctions(receiverTypes: Collection<KotlinTyp
           val resultingFunction =
             it.substitute(substitutor).safeAs<SimpleFunctionDescriptor>()
               ?.createCustomCopy {
+                setPreserveSourceElement()
                 setDispatchReceiverParameter(dispatchReceiver).setDropOriginalInContainingParts()
                   .setOriginal(it)
               }
           val result = resultingFunction?.createCustomCopy {
+            setPreserveSourceElement()
             setDispatchReceiverParameter(ReceiverParameterDescriptorImpl(resultingFunction, ProofReceiverValue(receiverType), Annotations.EMPTY))
           }
           result

--- a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/resolve/scopes/ProofsSyntheticScopes.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/resolve/scopes/ProofsSyntheticScopes.kt
@@ -61,11 +61,6 @@ fun CompilerContext.syntheticMemberFunctions(receiverTypes: Collection<KotlinTyp
           }
           result
         }.filterIsInstance<SimpleFunctionDescriptor>()
-//        it.newCopyBuilder()
-//          .setDropOriginalInContainingParts()
-//          .setOriginal(it)
-//          .setDispatchReceiverParameter(dispatchReceiver)
-//          .build()
       }
   }
 


### PR DESCRIPTION
We want to be able to click on a type class syntax method call to go to its declaration. E.g:

![2020-04-20 12-37-50 2020-04-20 12_38_29](https://user-images.githubusercontent.com/6547526/79742906-e0548f00-8303-11ea-9506-dfb7d355927f.gif)

### Solution

When we generate the synthetic scope for function members we are losing information about the `source` element on the descriptor. We need to explicitly call to `setPreserveSourceElement()` each time we create a custom copy for a function description using the builder, otherwise it'll likely drop it. Source is needed for the IDE to track the declaration down and enable navigation.