### PR TITLE
Fix dependencies for gradle-plugin

### DIFF
--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -31,10 +31,10 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$KOTLIN_VERSION"
   implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
   implementation "io.github.classgraph:classgraph:$CLASS_GRAPH_VERSION"
-  compile "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
+  implementation "xerces:xercesImpl:$XERCES_VERSION"
   runtime "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION"
-  runtimeOnly "xerces:xercesImpl:$XERCES_VERSION"
-  runtimeOnly "io.arrow-kt:compiler-plugin:$VERSION_NAME"
+  runtime "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
+  runtime "io.arrow-kt:compiler-plugin:$VERSION_NAME"
 }
 
 compileKotlin {


### PR DESCRIPTION
`runtimeOnly` is not considered when publishing the artifact into OSS (just local repository).

List of dependencies for gradle-plugin before this fix: https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/gradle-plugin/1.3.61-SNAPSHOT/gradle-plugin-1.3.61-20200424.120403-65.pom

```
  <dependencies>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-scripting-compiler-embeddable</artifactId>
      <version>1.3.61</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-script-util</artifactId>
      <version>1.3.61</version>
      <scope>compile</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-stdlib</artifactId>
      <version>1.3.61</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-gradle-plugin-api</artifactId>
      <version>1.3.61</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>org.jetbrains.kotlin</groupId>
      <artifactId>kotlin-gradle-plugin</artifactId>
      <version>1.3.61</version>
      <scope>runtime</scope>
    </dependency>
    <dependency>
      <groupId>io.github.classgraph</groupId>
      <artifactId>classgraph</artifactId>
      <version>4.8.47</version>
      <scope>runtime</scope>
    </dependency>
  </dependencies>
```

Discovered when trying to install the plugin from Gradle:

![Screenshot from 2020-04-24 15-19-57](https://user-images.githubusercontent.com/22792183/80216891-144eed80-863f-11ea-8796-b2e41a23c656.png)
