### PR TITLE
Fix #499: remove hard-coded dependencies for Gradle Plugin

### DIFF
--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -5,7 +5,6 @@ apply plugin: 'com.github.johnrengelman.shadow'
 dependencies {
     // WARNING: don't change the configuration name because it's used by shadowJar
     compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
-    compileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     compileOnly "com.intellij:openapi:$OPENAPI_VERSION"
     compile "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION"
     compile("org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION") {
@@ -13,6 +12,7 @@ dependencies {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-compiler"
         exclude group: "org.jetbrains.kotlin", module: "kotlin-compiler-embeddable"
     }
+    api "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
 
     testCompileOnly "org.jetbrains.kotlin:kotlin-compiler-embeddable:$KOTLIN_VERSION"
     testImplementation("io.kotlintest:kotlintest-runner-junit4:$KOTLIN_TEST_VERSION") {

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -32,8 +32,6 @@ dependencies {
   implementation "org.jetbrains.kotlin:kotlin-gradle-plugin:$KOTLIN_VERSION"
   implementation "io.github.classgraph:classgraph:$CLASS_GRAPH_VERSION"
   implementation "xerces:xercesImpl:$XERCES_VERSION"
-  runtime "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$KOTLIN_VERSION"
-  runtime "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
   runtime "io.arrow-kt:compiler-plugin:$VERSION_NAME"
 }
 

--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
@@ -27,12 +27,9 @@ class ArrowGradlePlugin : Plugin<Project> {
     val properties = Properties()
     properties.load(this.javaClass.getResourceAsStream("plugin.properties"))
     val compilerPluginVersion = properties.getProperty("COMPILER_PLUGIN_VERSION")
-    val kotlinVersion = project.getKotlinPluginVersion()
     project.extensions.create("arrow", ArrowExtension::class.java)
     project.afterEvaluate { p ->
-      p.dependencies.add("kotlinCompilerClasspath", "org.jetbrains.kotlin:kotlin-script-util:$kotlinVersion")
-      p.dependencies.add("kotlinCompilerClasspath", "org.jetbrains.kotlin:kotlin-compiler-embeddable:$kotlinVersion")
-      p.dependencies.add("kotlinCompilerClasspath", "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$kotlinVersion")
+      p.dependencies.add("kotlinCompilerClasspath", "io.arrow-kt:compiler-plugin:$compilerPluginVersion")
 
       p.tasks.withType(KotlinCompile::class.java).configureEach {
         it.kotlinOptions.freeCompilerArgs += "-Xplugin=${classpathOf("compiler-plugin:$compilerPluginVersion")}"


### PR DESCRIPTION
## Changes
- Compiler Plugin define all the transitive dependencies
- Gradle Plugin just needs the Compiler Plugin dependency

## Additional checks
- Checked with [the playground for typeproofs](https://github.com/arrow-kt/arrow-typeproofs)
- Shadowed JAR content doesn't change with this improvement.