### PR TITLE
Rename artifact ID for prelude module

### DIFF
--- a/prelude/build.gradle
+++ b/prelude/build.gradle
@@ -25,4 +25,13 @@ tasks.withType(AbstractArchiveTask) {
     reproducibleFileOrder = true
 }
 
+// Avoid local publication with module name (or project name)
+publishing {
+    publications {
+        maven(MavenPublication) {
+            artifactId = POM_ARTIFACT_ID
+        }
+    }
+}
+
 apply from: 'https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/gradle-mvn-push.gradle'

--- a/prelude/gradle.properties
+++ b/prelude/gradle.properties
@@ -1,4 +1,4 @@
 # Maven publishing configuration
 POM_NAME=Arrow Meta Prelude
-POM_ARTIFACT_ID=prelude
+POM_ARTIFACT_ID=arrow-meta-prelude
 POM_PACKAGING=jar

--- a/prelude/gradle.properties
+++ b/prelude/gradle.properties
@@ -1,4 +1,4 @@
 # Maven publishing configuration
 POM_NAME=Arrow Meta Prelude
-POM_ARTIFACT_ID=arrow-meta-prelude
+POM_ARTIFACT_ID=prelude
 POM_PACKAGING=jar


### PR DESCRIPTION
The artifact is being published in local repository with the module name (`prelude`) and in OSS repository with the artifact ID (`arrow-meta-prelude`). 

This PR fixes the name for `arrow-meta-prelude` for local repository because that library will be part of Arrow.