### PR TITLE
Fix #589. Install local dependencies for tests

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -25,16 +25,7 @@ jobs:
     - name: Build with Gradle
       env:
         JAVA_OPTS: -Xms512m -Xmx1024m
-      run: |
-        ./gradlew clean
-        ./gradlew :compiler-plugin:build
-        ./gradlew :idea-plugin:build
-        ./gradlew :meta-test:build
-        # 'build' task is not executed for :gradle-plugin because
-        # it depends on the publication of compiler-plugin 
-        # and it could fail when changing version
-        ./gradlew :gradle-plugin:jar
-        # :docs is considered in another workflow
+      run: ./gradlew buildMeta
     - name: Check next version
       env:
         JAVA_OPTS: -Xms512m -Xmx1024m

--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -30,16 +30,7 @@ jobs:
     - name: Build with Gradle
       env:
         JAVA_OPTS: -Xms512m -Xmx1024m
-      run: |
-        ./gradlew clean
-        ./gradlew :compiler-plugin:build
-        ./gradlew :idea-plugin:build
-        ./gradlew :meta-test:build
-        # 'build' task is not executed for :gradle-plugin because
-        # it depends on the publication of compiler-plugin 
-        # and it could fail when changing version
-        ./gradlew :gradle-plugin:jar
-        # :docs is considered in another workflow
+      run: ./gradlew buildMeta
     - name: Check properties
       id: properties
       run: |

--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,13 @@ subprojects { project ->
   }
 }
 
+// To run tests for Arrow TypeProofs Playground from Arrow Meta IDEA Plugin
+task publishArrowTypeProofsPlaygroundDependencies {
+  dependsOn ':compiler-plugin:publishToMavenLocal'
+  dependsOn ':gradle-plugin:publishToMavenLocal'
+  dependsOn ':prelude:publishToMavenLocal'
+}
+
 task cleanMeta {
   dependsOn ':compiler-plugin:clean'
   dependsOn ':gradle-plugin:clean'
@@ -75,11 +82,17 @@ task cleanMeta {
 }
 
 task buildMeta {
+  group = "Arrow Meta"
+  description = "Assembles and tests"
   dependsOn ':compiler-plugin:build'
+  // 'build' task is not executed for :gradle-plugin because it depends on the publication of compiler-plugin 
+  // and it could fail when changing version
   dependsOn ':gradle-plugin:jar'
+  dependsOn ':publishArrowTypeProofsPlaygroundDependencies'
   dependsOn ':idea-plugin:build'
   dependsOn ':meta-test:build'
   dependsOn ':prelude:build'
+  tasks.findByPath(':idea-plugin:build').mustRunAfter ':publishArrowTypeProofsPlaygroundDependencies'
 }
 
 task publishMeta {
@@ -91,6 +104,8 @@ task publishMeta {
 }
 
 task publishAndRunIde {
+  group = "Arrow Meta"
+  description = "Publishes and runs IDE on local workspace"
   dependsOn ':cleanMeta'
   dependsOn ':publishMeta'
   dependsOn ':idea-plugin:runIde'
@@ -117,7 +132,7 @@ task runValidation(type:Exec) {
 
 task buildMetaDoc {
     group = "Arrow Meta"
-    description = "Generate API Doc and validate"
+    description = "Generates API Doc and validates all the documentation"
     dependsOn 'generateDoc'
     dependsOn 'configureValidation'
     dependsOn 'runValidation'


### PR DESCRIPTION
PR on `ja-gradle-testing` branch by @jansorg and @i-walker 

Install Arrow Meta dependencies to run tests for Arrow TypeProofs Playground from Arrow Meta IDEA Plugin.