### PR TITLE
Dynamic transform new source path

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/Node.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/Node.kt
@@ -28,7 +28,8 @@ sealed class Node {
     override val pkg: Package?,
     override val imports: List<Import>,
     val commands: List<Command>,
-    val decls: List<Decl>
+    val decls: List<Decl>,
+    val path: String?
   ) : Node(), Entry
 
   data class Script(

--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
@@ -10,6 +10,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.descriptors.annotations.AnnotationUseSiteTarget
 import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtAnnotation
 import org.jetbrains.kotlin.psi.KtAnnotationEntry
@@ -389,7 +390,17 @@ open class Converter {
     pkg = v.packageDirective?.takeIf { it.packageNames.isNotEmpty() }?.let(::convertPackage),
     imports = v.importDirectives.map(::convertImportDirective),
     commands = convertCommands(v),
-    decls = v.declarations.map(::convertDecl)
+    decls = v.declarations.map(::convertDecl),
+    path = null
+  ).map(v)
+
+  open fun convertFile(v: KtFile, sourcePath: FqName?) = Node.File(
+    anns = convertAnnotationSets(v),
+    pkg = v.packageDirective?.takeIf { it.packageNames.isNotEmpty() }?.let(::convertPackage),
+    imports = v.importDirectives.map(::convertImportDirective),
+    commands = convertCommands(v),
+    decls = v.declarations.map(::convertDecl),
+    path = sourcePath?.asString()
   ).map(v)
 
   open fun convertFor(v: KtForExpression) = Node.Expr.For(

--- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/kastree/ast/psi/Converter.kt
@@ -385,16 +385,7 @@ open class Converter {
     else -> error("Unrecognized expression type from $v")
   }
 
-  open fun convertFile(v: KtFile) = Node.File(
-    anns = convertAnnotationSets(v),
-    pkg = v.packageDirective?.takeIf { it.packageNames.isNotEmpty() }?.let(::convertPackage),
-    imports = v.importDirectives.map(::convertImportDirective),
-    commands = convertCommands(v),
-    decls = v.declarations.map(::convertDecl),
-    path = null
-  ).map(v)
-
-  open fun convertFile(v: KtFile, sourcePath: FqName?) = Node.File(
+  open fun convertFile(v: KtFile, sourcePath: FqName? = null) = Node.File(
     anns = convertAnnotationSets(v),
     pkg = v.packageDirective?.takeIf { it.packageNames.isNotEmpty() }?.let(::convertPackage),
     imports = v.importDirectives.map(::convertImportDirective),

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -446,6 +446,8 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override fun String.file(fileName: String): File = File(delegate.createFile(if(fileName.contains(".kt")) fileName else "$fileName.kt", this))
 
+  override fun String.file(fileName: String, filePath: String) = File(delegate.createFile(if(fileName.contains(".kt")) fileName else "$fileName.kt", this), sourcePath = FqName(filePath))
+
   override val String.functionLiteral: FunctionLiteral
     get() = FunctionLiteral((expression.value as KtLambdaExpression).functionLiteral)
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -325,6 +325,8 @@ interface ElementScope {
   
   fun String.file(fileName: String): File
 
+  fun String.file(fileName: String, filePath: String): File
+
   val String.functionLiteral: FunctionLiteral
   
   val String.classBody: ClassBody

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
@@ -58,5 +58,6 @@ class File(
   val fileType: FileType = value.fileType,
   val declarations: ScopedList<KtDeclaration> = ScopedList(value = value.declarations, postfix = ", "),
   val stub: KotlinFileStub? = value.stub,
-  val classes: Array<PsiClass> = value.classes
+  val classes: Array<PsiClass> = value.classes,
+  val sourcePath: FqName? = null
 ): Scope<KtFile>(value)

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformNewSourceTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformNewSourceTest.kt
@@ -53,7 +53,7 @@ class TransformNewSourceTest : AnnotationSpec() {
         )
       }
     ))
-    }
+  }
   
   @Test
   fun `Check if the file is modified and another file is created`() {
@@ -80,6 +80,51 @@ class TransformNewSourceTest : AnnotationSpec() {
                  fun say(name: String) = println(name)
                }
             """.source
+          )
+        )
+      }
+    ))
+  }
+
+  @Test
+  fun `validate single extra file is created with custom path`() {
+    assertThis(CompilerTest(
+      config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
+      code = {
+        """ class NewSourceWithCustomPath {} """.source
+      },
+      assert = { quoteFileMatches("NewSourceWithCustomPath_Generated.kt",
+        """
+          package arrow
+          class NewSourceWithCustomPath_Generated
+        """.source,
+        "build/generated/source/kapt/test/files"
+      )}
+    ))
+  }
+
+  @Test
+  fun `validate multiple extra files are created with custom path`() {
+    assertThis(CompilerTest(
+      config = { metaDependencies + addMetaPlugins(TransformMetaPlugin()) },
+      code = {
+        """ class NewMultipleSourceWithCustomPath {} """.source
+      },
+      assert = {
+        allOf(
+          quoteFileMatches("NewMultipleSourceWithCustomPath_Generated.kt",
+            """
+             package arrow
+             class NewMultipleSourceWithCustomPath_Generated
+            """.source,
+            "build/generated/source/kapt/test/files"
+          ),
+          quoteFileMatches("NewMultipleSourceWithCustomPath_Generated_2.kt",
+            """
+             package arrow
+             class NewMultipleSourceWithCustomPath_Generated_2
+            """.source,
+            "build/generated/source/kapt/test/files/source"
           )
         )
       }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformNewSourceTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/TransformNewSourceTest.kt
@@ -93,12 +93,12 @@ class TransformNewSourceTest : AnnotationSpec() {
       code = {
         """ class NewSourceWithCustomPath {} """.source
       },
-      assert = { quoteFileMatches("NewSourceWithCustomPath_Generated.kt",
-        """
+      assert = { quoteFileMatches( filename = "NewSourceWithCustomPath_Generated.kt",
+        source = """
           package arrow
           class NewSourceWithCustomPath_Generated
         """.source,
-        "build/generated/source/kapt/test/files"
+        sourcePath = "build/generated/source/kapt/test/files"
       )}
     ))
   }
@@ -112,19 +112,19 @@ class TransformNewSourceTest : AnnotationSpec() {
       },
       assert = {
         allOf(
-          quoteFileMatches("NewMultipleSourceWithCustomPath_Generated.kt",
-            """
+          quoteFileMatches( filename = "NewMultipleSourceWithCustomPath_Generated.kt",
+            source = """
              package arrow
              class NewMultipleSourceWithCustomPath_Generated
             """.source,
-            "build/generated/source/kapt/test/files"
+            sourcePath = "build/generated/source/kapt/test/files"
           ),
-          quoteFileMatches("NewMultipleSourceWithCustomPath_Generated_2.kt",
-            """
+          quoteFileMatches( filename = "NewMultipleSourceWithCustomPath_Generated_2.kt",
+            source = """
              package arrow
              class NewMultipleSourceWithCustomPath_Generated_2
             """.source,
-            "build/generated/source/kapt/test/files/source"
+            sourcePath = "build/generated/source/kapt/test/files/source"
           )
         )
       }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformNewSourcePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformNewSourcePlugin.kt
@@ -11,7 +11,7 @@ import arrow.meta.quotes.plus
 import org.jetbrains.kotlin.psi.KtClass
 
 val Meta.transformNewSource: List<CliPlugin>
-  get() = listOf(transformNewSourceSingleGeneration, transformNewSourceWithManyTransformation, transformNewSourceMultipleGeneration)
+  get() = listOf(transformNewSourceSingleGeneration, transformNewSourceWithManyTransformation, transformNewSourceMultipleGeneration, transformNewSourceSingleGenerationWithCustomPath, transformNewSourceMultipleGenerationWithCustomPath)
 
 private val Meta.transformNewSourceSingleGeneration: CliPlugin
   get() = "Transform New Source" {
@@ -96,3 +96,38 @@ private fun CompilerContext.generateSupplierClass(declaration: ClassDeclaration)
     }
   """.file("${name}_Generated")
 )}
+
+private val Meta.transformNewSourceSingleGenerationWithCustomPath: CliPlugin
+  get() = "Transform New Source" {
+    meta(
+      classDeclaration({ name == "NewSourceWithCustomPath" }) {
+        Transform.newSources(
+          """
+            package arrow
+            
+            class ${name}_Generated
+          """.file("${name}_Generated.kt", filePath = "build/generated/source/kapt/test/files")
+        )
+      }
+    )
+  }
+
+private val Meta.transformNewSourceMultipleGenerationWithCustomPath: CliPlugin
+  get() = "Transform New Multiple Source" {
+    meta(
+      classDeclaration({ name == "NewMultipleSourceWithCustomPath" }) {
+        Transform.newSources(
+          """
+            package arrow
+            
+            class ${name}_Generated 
+          """.file("${name}_Generated", "build/generated/source/kapt/test/files"),
+          """
+            package arrow
+            
+            class ${name}_Generated_2
+          """.file("${name}_Generated_2", "build/generated/source/kapt/test/files/source")
+        )
+      }
+    )
+  }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformNewSourcePlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/transform/plugins/TransformNewSourcePlugin.kt
@@ -106,7 +106,7 @@ private val Meta.transformNewSourceSingleGenerationWithCustomPath: CliPlugin
             package arrow
             
             class ${name}_Generated
-          """.file("${name}_Generated.kt", filePath = "build/generated/source/kapt/test/files")
+          """.file("${name}_Generated.kt", "build/generated/source/kapt/test/files")
         )
       }
     )

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilationAssertions.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilationAssertions.kt
@@ -12,6 +12,7 @@ import java.nio.file.Paths
 private const val META_PREFIX = "//meta"
 private const val METHOD_CALL = "[^(]+\\(\\)(\\.\\S+)?"
 private const val VARIABLE = "[^(]+"
+private const val DEFAULT_SOURCE_PATH = "build/generated/source/kapt/main"
 
 /**
  * Allows checking if a compiler plugin is working as expected.
@@ -166,7 +167,7 @@ private fun assertQuoteFileMatches(
   compilationResult: Result,
   actualFileName: String,
   expectedSource: Code.Source,
-  actualFileDirectoryPath: Path = Paths.get("", *System.getProperty("arrow.meta.generated.source.output").split("/").toTypedArray())
+  actualFileDirectoryPath: Path = Paths.get("", *(System.getProperty("arrow.meta.generated.source.output") ?: DEFAULT_SOURCE_PATH).split("/").toTypedArray())
 ): Unit {
   assertCompiles(compilationResult)
   val actualSource = actualFileDirectoryPath.resolve(actualFileName).toFile().readText()

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilationAssertions.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilationAssertions.kt
@@ -8,7 +8,6 @@ import java.net.URLClassLoader
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import javax.script.ScriptEngineManager
 
 private const val META_PREFIX = "//meta"
 private const val METHOD_CALL = "[^(]+\\(\\)(\\.\\S+)?"
@@ -96,8 +95,10 @@ private val interpreter: (CompilerTest) -> Unit = {
       Assert.CompilationResult.Fails -> assertFails(compilationResult)
       is Assert.FailsWith -> assertFailsWith(compilationResult, singleAssert.f)
       is Assert.QuoteOutputMatches -> assertQuoteOutputMatches(compilationResult, singleAssert.source)
+      is Assert.QuoteOutputWithCustomPathMatches -> assertQuoteOutputMatches(compilationResult, singleAssert.source, singleAssert.sourcePath)
       is Assert.EvalsTo -> assertEvalsTo(compilationResult, singleAssert.source, singleAssert.output)
       is Assert.QuoteFileMatches -> assertQuoteFileMatches(compilationResult, singleAssert.filename, singleAssert.source)
+      is Assert.QuoteFileWithCustomPathMatches -> assertQuoteFileMatches(compilationResult, singleAssert.filename, singleAssert.source, actualFileDirectoryPath = Paths.get("", *singleAssert.sourcePath.split("/").toTypedArray()))
       else -> TODO()
     }
 
@@ -152,6 +153,13 @@ private fun assertQuoteOutputMatches(compilationResult: Result, expectedSource: 
   expectedSource = expectedSource,
   actualFileName = "$DEFAULT_FILENAME.meta",
   actualFileDirectoryPath = Paths.get(compilationResult.outputDirectory.parent, "sources")
+)
+
+private fun assertQuoteOutputMatches(compilationResult: Result, expectedSource: Code.Source, expectedSourcePath: String): Unit = assertQuoteFileMatches(
+  compilationResult = compilationResult,
+  expectedSource = expectedSource,
+  actualFileName = "$DEFAULT_FILENAME.meta",
+  actualFileDirectoryPath = Paths.get(expectedSourcePath, "sources")
 )
 
 private fun assertQuoteFileMatches(

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -103,7 +103,6 @@ interface ConfigSyntax {
     get() {
       val currentVersion = System.getProperty("CURRENT_VERSION")
       val arrowVersion = System.getProperty("ARROW_VERSION")
-      System.setProperty("arrow.meta.generated.source.output", "build/generated/source/kapt/test")
       val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin:$currentVersion")))
       val arrowAnnotations = Dependency("arrow-annotations:$arrowVersion")
       return CompilerTest.addCompilerPlugins(compilerPlugin) + CompilerTest.addDependencies(arrowAnnotations) + CompilerTest.addDependencies(prelude(currentVersion))

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -204,6 +204,14 @@ interface AssertSyntax {
    * @param source Code snippet with the expected quote output.
    */
   fun quoteOutputMatches(source: Code.Source): Assert.SingleAssert = Assert.QuoteOutputMatches(source)
+
+  /**
+   * Checks that quote output during the compilation matches with the code snippet provided.
+   *
+   * @param source Code snippet with the expected quote output.
+   * @param sourcePath Source path of the expected file.
+   */
+  fun quoteOutputMatches(source: Code.Source, sourcePath: String): Assert.SingleAssert = Assert.QuoteOutputWithCustomPathMatches(source, sourcePath)
   
   /**
    * Checks that quote output during the compilation matches with the code snippet provided for a specific file.
@@ -212,6 +220,16 @@ interface AssertSyntax {
    * @param source Code snippet with the expected quote output.
    */
   fun quoteFileMatches(filename: String, source: Code.Source): Assert.SingleAssert = Assert.QuoteFileMatches(filename, source)
+
+  /**
+   * Checks that quote output during the compilation matches with the code snippet provided for a specific file.
+   *
+   * @param filename Name of the specific file that will be evaluated.
+   * @param source Code snippet with the expected quote output.
+   * @param sourcePath Source path of the expected file.
+   */
+  fun quoteFileMatches(filename: String, source: Code.Source, sourcePath: String): Assert.SingleAssert = Assert.QuoteFileWithCustomPathMatches(filename, source, sourcePath)
+
 
   /**
    * Checks if a code snippet evals to a provided value after the compilation.
@@ -248,7 +266,9 @@ sealed class Assert {
   internal data class Many(val asserts: List<SingleAssert>) : Assert()
 
   internal data class QuoteOutputMatches(val source: Code.Source) : SingleAssert()
+  internal data class QuoteOutputWithCustomPathMatches(val source: Code.Source, val sourcePath: String) : SingleAssert()
   internal data class QuoteFileMatches(val filename: String, val source: Code.Source) : SingleAssert()
+  internal data class QuoteFileWithCustomPathMatches(val filename: String, val source: Code.Source, val sourcePath: String) : SingleAssert()
   internal data class EvalsTo(val source: Code.Source, val output: Any?) : SingleAssert()
   internal data class FailsWith(val f: (String) -> Boolean) : SingleAssert()
   internal sealed class CompilationResult : SingleAssert() {


### PR DESCRIPTION
**This is related to https://github.com/arrow-kt/arrow-meta/issues/591** 

This PR brings a new feature to `Transform.newSources` api that allows we set custom source pathes in its generation:

```kotlin
Transform.newSources(
  """
    package arrow  
    class ${name}_Generated
  """.file("${name}_Generated.kt", "build/generated/source/kapt/test/files")
)
```

an other `file` function with a second parameter allows us to specify its path, also it could be used with multi source generation:

```kotlin
Transform.newSources(
  """
    package arrow       
    class ${name}_Generated 
  """.file("${name}_Generated", "build/generated/source/kapt/test/files"),
  """
    package arrow      
    class ${name}_Generated_2
  """.file("${name}_Generated_2", "build/generated/source/kapt/test/files/source")
)
```

With that it can be used to create structured and architectured generated sources. Also there's a new api to test custom path generated sources:

```kotlin
quoteFileMatches("NewMultipleSourceWithCustomPath_Generated_2.kt",
  """
    package arrow
    class NewMultipleSourceWithCustomPath_Generated_2
  """.source,
  "build/generated/source/kapt/test/files/source"
)
```

With this new api we can specify which source we want to test.