### PR TITLE
Disable flaky test reported in #581 until it's fixed

### DIFF
--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/refinement/RefinementTests.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/refinement/RefinementTests.kt
@@ -3,6 +3,7 @@ package arrow.meta.plugins.refinement
 import arrow.meta.plugin.testing.CompilerTest
 import arrow.meta.plugin.testing.assertThis
 import org.junit.Test
+import org.junit.Ignore
 
 class RefinementTests {
 
@@ -152,6 +153,7 @@ class RefinementTests {
     ))
   }
 
+  @Ignore
   @Test
   fun `Runtime validation for nullable types accepts if valid`() {
     assertThis(CompilerTest(


### PR DESCRIPTION
It's necessary to re-run checks because it fails randomly.