### PR TITLE
Publication: remove previous build

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -27,10 +27,6 @@ jobs:
         sed -i "s/patchPluginXml {/patchPluginXml {\\nsinceBuild $SINCE_BUILD\\nuntilBuild $UNTIL_BUILD/g" idea-plugin/build.gradle
         sed -i "s/%SINCE_BUILD%/$SINCE_BUILD/g" .github/workflows/templates/updatePlugins.xml
         sed -i "s/%UNTIL_BUILD%/$UNTIL_BUILD/g" .github/workflows/templates/updatePlugins.xml
-    - name: Build with Gradle
-      env:
-        JAVA_OPTS: -Xms512m -Xmx1024m
-      run: ./gradlew buildMeta
     - name: Check properties
       id: properties
       run: |


### PR DESCRIPTION
**Reason**: failures on publication from #608 because generated sources during tests are being packaged when uploading the artifacts.