### PR TITLE
Configuration: unify IDE Plugin name and add Gradle tasks metadata

### DIFF
--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
@@ -5,7 +5,6 @@ import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.io.File
 import io.github.classgraph.ClassGraph
-import org.jetbrains.kotlin.gradle.plugin.getKotlinPluginVersion
 import java.util.Properties
 
 /**
@@ -35,12 +34,16 @@ class ArrowGradlePlugin : Plugin<Project> {
         it.kotlinOptions.freeCompilerArgs += "-Xplugin=${classpathOf("compiler-plugin:$compilerPluginVersion")}"
       }
     }
-    project.tasks.register("install-idea-plugin", InstallIdeaPlugin::class.java)
+    val installIdeaPluginTask = project.tasks.register("install-idea-plugin", InstallIdeaPlugin::class.java)
+    installIdeaPluginTask.configure { task ->
+      task.group = "Arrow Meta"
+      task.description = "Installs the correspondent Arrow Meta IDE Plugin if it's not already installed."
+    }
 
     when {
       inIdea() && pluginsDirExists() && !ideaPluginExists() -> {
-        println("Arrow Meta IDEA Plugin is not installed!")
-        println("Run 'install-idea-plugin' Gradle task from Intellij IDEA to install it.")
+        println("Arrow Meta IDE Plugin is not installed!")
+        println("Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it.")
       }
     }
   }

--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/InstallIdeaPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/InstallIdeaPlugin.kt
@@ -11,7 +11,7 @@ import java.nio.file.Paths
 import java.util.Properties
 import java.util.zip.ZipFile
 
-private const val IDEA_PLUGIN_NAME = "Arrow Meta Intellij IDEA Plugin"
+private const val IDEA_PLUGIN_NAME = "Arrow Meta"
 
 open class InstallIdeaPlugin: DefaultTask() {
 
@@ -28,11 +28,11 @@ open class InstallIdeaPlugin: DefaultTask() {
     }
 
     if (ideaPluginExists()) {
-      println("Arrow Meta IDEA Plugin is already installed!")
+      println("$IDEA_PLUGIN_NAME IDE Plugin is already installed!")
       return
     }
 
-    println("Arrow Meta IDEA Plugin is not installed! Downloading ...")
+    println("$IDEA_PLUGIN_NAME IDE Plugin is not installed! Downloading ...")
     val properties = Properties()
     properties.load(this.javaClass.getResourceAsStream("plugin.properties"))
 

--- a/idea-plugin/build.gradle
+++ b/idea-plugin/build.gradle
@@ -39,7 +39,7 @@ buildSearchableOptions.enabled = false
 
 intellij {
   version = "$INTELLIJ_IDEA_VERSION"
-  pluginName = "Arrow Meta Intellij IDEA Plugin"
+  pluginName = "Arrow Meta"
   plugins = ["gradle", "gradle-java", "java", "org.jetbrains.kotlin:${KOTLIN_IDEA_VERSION}", "git4idea"]
 }
 


### PR DESCRIPTION
* **Unify IDE Plugin name**: It shouldn't end with `Plugin` word.
* **Add Gradle tasks metadata**: It's useful for finding the task to run it. Related documentation will be simpler.