### PR TITLE
Doc: fix style

### DIFF
--- a/docs/docs/_sass/components/_code.scss
+++ b/docs/docs/_sass/components/_code.scss
@@ -37,10 +37,6 @@ ul {
         &.highlight {
             border: 1px solid $code-border-color;
             margin-bottom: $code-margin;
-
-            .hljs {
-                padding: $code-padding;
-            }
         }
     }
 }

--- a/docs/docs/_sass/components/_doc-content.scss
+++ b/docs/docs/_sass/components/_doc-content.scss
@@ -53,6 +53,7 @@
 
     ul, ol {
         padding-left: ($base-point-grid * 3);
+        margin-bottom: ($base-point-grid * 2);
     }
 
     ul {


### PR DESCRIPTION
# Add margin-botton for ul elements

## From

![Screenshot from 2020-05-15 10-42-58](https://user-images.githubusercontent.com/22792183/82030899-5b0d9180-9699-11ea-8083-148db46c18f8.png)

## To

![Screenshot from 2020-05-15 10-42-22](https://user-images.githubusercontent.com/22792183/82030914-5f39af00-9699-11ea-8f85-fcd413339c55.png)

# Remove padding for hljs class

## From

![Screenshot from 2020-05-15 10-42-49](https://user-images.githubusercontent.com/22792183/82030816-3f09f000-9699-11ea-8aba-818c25393c3d.png)

## To

![Screenshot from 2020-05-15 10-42-14](https://user-images.githubusercontent.com/22792183/82030838-44ffd100-9699-11ea-86e0-12c82357e816.png)