### PR TITLE
Update 2020.1: fix doc generation

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -47,7 +47,7 @@ ank {
 task getLocalPaths {
     // Reason: local paths cannot be generated in Ank extension neither ext section
     doLast {
-        def libraries = ['kotlin-plugin.jar', 'platform-api.jar', 'platform-impl.jar', 'idea.jar']
+        def libraries = ['kotlin-plugin.jar', 'platform-api.jar', 'platform-impl.jar', 'idea.jar', 'testFramework.jar']
         def localPaths = libraries.collect{ library -> sourceSets.main.compileClasspath.find{ path -> path.name == "$library" } }
         def localPathsFile = new File("$LOCAL_PATHS_FILE")
         localPathsFile.write localPaths.join("\n")


### PR DESCRIPTION
## Note

* PR on `ide-update`
* Just fixing `Build Documentation` check.

## Changes

`com/intellij/testFramework/fixtures/CodeInsightTestFixture.class` is included in `testFramework.jar` instead of `idea.jar` in `ideaIC-2020.1`.

I didn't remove `idea.jar` because it's necessary for other classes.