### PR TITLE
Fix patch for #631

### DIFF
--- a/.github/workflows/sandbox/1.3.70-eap.diff
+++ b/.github/workflows/sandbox/1.3.70-eap.diff
@@ -1,5 +1,5 @@
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/MetaCliProcessor.kt b/compiler-plugin/src/main/kotlin/arrow/meta/MetaCliProcessor.kt
-index 83b8358..7ea6ded 100644
+index 83b83589..7ea6dedd 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/MetaCliProcessor.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/MetaCliProcessor.kt
 @@ -1,7 +1,9 @@
@@ -19,7 +19,7 @@ index 83b8358..7ea6ded 100644
 +  override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {}
  }
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/MetaCommandLineProcessor.kt b/compiler-plugin/src/main/kotlin/arrow/meta/MetaCommandLineProcessor.kt
-index 908ac85..3ed2efb 100644
+index 908ac851..3ed2efb4 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/MetaCommandLineProcessor.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/MetaCommandLineProcessor.kt
 @@ -1,7 +1,9 @@
@@ -39,7 +39,7 @@ index 908ac85..3ed2efb 100644
 +  override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {}
  }
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/dsl/codegen/ir/IrSyntax.kt b/compiler-plugin/src/main/kotlin/arrow/meta/dsl/codegen/ir/IrSyntax.kt
-index 8c4fde2..f52d034 100644
+index 8c4fde2a..f52d0342 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/dsl/codegen/ir/IrSyntax.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/dsl/codegen/ir/IrSyntax.kt
 @@ -4,7 +4,7 @@ import arrow.meta.Meta
@@ -1279,7 +1279,7 @@ index 8c4fde2..f52d034 100644
 +  }
  }
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/dsl/resolve/ResolveSyntax.kt b/compiler-plugin/src/main/kotlin/arrow/meta/dsl/resolve/ResolveSyntax.kt
-index cc6655f..5d10395 100644
+index cc6655f3..5d103954 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/dsl/resolve/ResolveSyntax.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/dsl/resolve/ResolveSyntax.kt
 @@ -54,7 +54,6 @@ interface ResolveSyntax {
@@ -1299,7 +1299,7 @@ index cc6655f..5d10395 100644
          )
      }
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt b/compiler-plugin/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
-index 202dc27..1a08257 100644
+index 202dc277..1a082575 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
 @@ -23,8 +23,8 @@ import arrow.meta.phases.resolve.synthetics.SyntheticResolver
@@ -1411,7 +1411,7 @@ index 202dc27..1a08257 100644
 \ No newline at end of file
 +}
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IRGeneration.kt b/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IRGeneration.kt
-index 2867bd7..0b19295 100644
+index 2867bd7c..0b19295b 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IRGeneration.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IRGeneration.kt
 @@ -2,9 +2,8 @@ package arrow.meta.phases.codegen.ir
@@ -1437,7 +1437,7 @@ index 2867bd7..0b19295 100644
  }
 \ No newline at end of file
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IrUtils.kt b/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IrUtils.kt
-index d8c5529..f10f281 100644
+index d8c5529d..f10f2819 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IrUtils.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/codegen/ir/IrUtils.kt
 @@ -1,7 +1,7 @@
@@ -1569,7 +1569,7 @@ index d8c5529..f10f281 100644
          valueArgumentsCount = irConstructorSymbol.owner.descriptor.valueParameters.size,
          constructorTypeArgumentsCount = declaredTypeParameters.size
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/phases/resolve/DeclarationAttributeAlterer.kt b/compiler-plugin/src/main/kotlin/arrow/meta/phases/resolve/DeclarationAttributeAlterer.kt
-index fcbbb97..7b2596e 100644
+index fcbbb97c..7b2596e4 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/resolve/DeclarationAttributeAlterer.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/resolve/DeclarationAttributeAlterer.kt
 @@ -5,7 +5,6 @@ import arrow.meta.phases.ExtensionPhase
@@ -1589,7 +1589,7 @@ index fcbbb97..7b2596e 100644
    ): Modality?
  }
 diff --git a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/ir/ProofsIrCodegen.kt b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/ir/ProofsIrCodegen.kt
-index c524759..e488b95 100644
+index c5247590..651a5aaf 100644
 --- a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/ir/ProofsIrCodegen.kt
 +++ b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/ir/ProofsIrCodegen.kt
 @@ -54,7 +54,7 @@ class ProofsIrCodegen(
@@ -1610,8 +1610,30 @@ index c524759..e488b95 100644
        val upperBound = givenTypeParamUpperBound.givenUpperBound
        if (upperBound != null) insertGivenCall(givenTypeParamUpperBound, expression)
        else insertExtensionSyntaxCall(expression)
+@@ -168,9 +168,9 @@ class ProofsIrCodegen(
+       ?: expression.extensionReceiver?.type?.toKotlinType()
+       ?: (if (expression.valueArgumentsCount > 0) expression.getValueArgument(0)?.type?.toKotlinType() else null)
+     val targetType =
+-      (expression.descriptor.dispatchReceiverParameter?.containingDeclaration as? FunctionDescriptor)?.dispatchReceiverParameter?.type
+-        ?: expression.descriptor.extensionReceiverParameter?.type
+-        ?: expression.descriptor.valueParameters.firstOrNull()?.type
++      (expression.symbol.descriptor.dispatchReceiverParameter?.containingDeclaration as? FunctionDescriptor)?.dispatchReceiverParameter?.type
++        ?: expression.symbol.descriptor.extensionReceiverParameter?.type
++        ?: expression.symbol.descriptor.valueParameters.firstOrNull()?.type
+     if (targetType != null && valueType != null && targetType != valueType && !baseLineTypeChecker.isSubtypeOf(valueType, targetType)) {
+       expression.apply {
+         val proofCall = extensionProofCall(valueType, targetType)
+@@ -196,7 +196,7 @@ class ProofsIrCodegen(
+               expression.mapValueParametersIndexed { n: Int, v: ValueParameterDescriptor ->
+                 val valueArgument = expression.getValueArgument(n)
+                 val valueType2 = valueArgument?.type?.toKotlinType()!!
+-                val targetType2 = expression.descriptor.valueParameters[n].type
++                val targetType2 = expression.symbol.descriptor.valueParameters[n].type
+                 val proofCall2 = extensionProofCall(valueType2, targetType2) as? IrMemberAccessExpression
+                 if (proofCall2 != null) {
+                   proofCall2.extensionReceiver = valueArgument
 diff --git a/gradle.properties b/gradle.properties
-index d37ca09..80d5c39 100644
+index d37ca090..80d5c392 100644
 --- a/gradle.properties
 +++ b/gradle.properties
 @@ -3,8 +3,8 @@ GROUP=io.arrow-kt


### PR DESCRIPTION
@danimontoya `expression.descriptor` changes to  `expression.symbol.descriptor` for 1.3.7x.