### PR TITLE
Meta scope for KtCallExpression

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -52,6 +52,7 @@ import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockCodeFragment
 import org.jetbrains.kotlin.psi.KtBreakExpression
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
 import org.jetbrains.kotlin.psi.KtContinueExpression
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -117,6 +118,9 @@ class DefaultElementScope(project: Project) : ElementScope {
 
   override val String.callArguments: Scope<KtValueArgumentList>
     get() = Scope(delegate.createCallArguments(trimMargin().trim()))
+
+  override val String.callExpression: Scope<KtCallExpression>
+    get() = Scope(delegate.createExpression(this) as KtCallExpression)
 
   override val String.typeArguments: Scope<KtTypeArgumentList>
     get() = Scope(delegate.createTypeArguments(trimMargin().trim()))

--- a/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/phases/analysis/ElementScope.kt
@@ -18,6 +18,7 @@ import arrow.meta.quotes.element.whencondition.WhenCondition
 import arrow.meta.quotes.expression.AnnotatedExpression
 import arrow.meta.quotes.expression.BinaryExpression
 import arrow.meta.quotes.expression.BlockExpression
+import arrow.meta.quotes.expression.CallExpression
 import arrow.meta.quotes.expression.DotQualifiedExpression
 import arrow.meta.quotes.expression.IfExpression
 import arrow.meta.quotes.expression.IsExpression
@@ -48,6 +49,7 @@ import org.jetbrains.kotlin.psi.KtAnnotationEntry
 import org.jetbrains.kotlin.psi.KtAnonymousInitializer
 import org.jetbrains.kotlin.psi.KtBlockCodeFragment
 import org.jetbrains.kotlin.psi.KtCallableReferenceExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtConstructorDelegationCall
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtEnumEntry
@@ -294,6 +296,8 @@ interface ElementScope {
   val String.delegatedSuperTypeEntry: Scope<KtConstructorDelegationCall>
   
   val String.block: BlockExpression
+
+  val String.callExpression: Scope<KtCallExpression>
 
   val String.`for`: ForExpression
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/MetaExtensions.kt
@@ -16,6 +16,7 @@ import arrow.meta.quotes.element.WhenEntry
 import arrow.meta.quotes.element.whencondition.WhenCondition
 import arrow.meta.quotes.expression.BinaryExpression
 import arrow.meta.quotes.expression.BlockExpression
+import arrow.meta.quotes.expression.CallExpression
 import arrow.meta.quotes.expression.DotQualifiedExpression
 import arrow.meta.quotes.expression.IfExpression
 import arrow.meta.quotes.expression.IsExpression
@@ -39,6 +40,7 @@ import arrow.meta.quotes.nameddeclaration.stub.typeparameterlistowner.TypeAlias
 import org.jetbrains.kotlin.psi.KtBinaryExpression
 import org.jetbrains.kotlin.psi.KtBlockExpression
 import org.jetbrains.kotlin.psi.KtBreakExpression
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtCatchClause
 import org.jetbrains.kotlin.psi.KtClass
 import org.jetbrains.kotlin.psi.KtClassBody
@@ -97,6 +99,15 @@ fun Meta.breakExpression(
   map: BreakExpression.(KtBreakExpression) -> Transform<KtBreakExpression>
 ) : ExtensionPhase =
   quote(match, map) { BreakExpression(it) }
+
+/**
+ * @see [CallExpression]
+ */
+fun Meta.callExpression(
+  match: KtCallExpression.() -> Boolean,
+  map: CallExpression.(KtCallExpression) -> Transform<KtCallExpression>
+) : ExtensionPhase =
+  quote(match, map) { CallExpression(it) }
 
 /**
  * @see [CatchClause]

--- a/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/CallExpression.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/quotes/expression/CallExpression.kt
@@ -1,0 +1,50 @@
+package arrow.meta.quotes.expression
+
+import arrow.meta.phases.analysis.ElementScope
+import arrow.meta.quotes.Scope
+import arrow.meta.quotes.ScopedList
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtTypeArgumentList
+import org.jetbrains.kotlin.psi.KtValueArgumentList
+import org.jetbrains.kotlin.psi.KtLambdaArgument
+import org.jetbrains.kotlin.psi.KtValueArgument
+import org.jetbrains.kotlin.psi.KtTypeProjection
+
+/**
+ * <code>"""$calleeExpression$argumentList""".callExpression</code>
+ *
+ * A template destructuring [Scope] for a [KtCallExpression].
+ *
+ * ```kotlin:ank:silent
+ * import arrow.meta.Meta
+ * import arrow.meta.CliPlugin
+ * import arrow.meta.invoke
+ * import arrow.meta.quotes.Transform
+ * import arrow.meta.quotes.callExpression
+ *
+ * val Meta.reformatBlock: CliPlugin
+ *   get() =
+ *     "Reformat Call Expression" {
+ *       meta(
+ *         callExpression({ true }) { expression ->
+ *           Transform.replace(
+ *             replacing = expression,
+ *             newDeclaration = """$calleeExpression$argumentList""".callExpression
+ *           )
+ *         }
+ *       )
+ *     }
+ */
+class CallExpression(
+  override val value: KtCallExpression,
+  val calleeExpression: Scope<KtExpression>? = Scope(value.calleeExpression),
+  val argumentList: Scope<KtValueArgumentList>? = Scope(value.valueArgumentList),
+  val typeArgumentList: Scope<KtTypeArgumentList>? = Scope(value.typeArgumentList),
+  val lambdaArguments: ScopedList<KtLambdaArgument>? = ScopedList(value.lambdaArguments),
+  val valueArguments: ScopedList<KtValueArgument>? = ScopedList(value.valueArguments),
+  val typeArguments: ScopedList<KtTypeProjection>? = ScopedList(value.typeArguments)
+): Scope<KtCallExpression>(value) {
+  override fun ElementScope.identity(): Scope<KtCallExpression> =
+    """$calleeExpression(${argumentList?.value?.arguments?.joinToString(", ") { it.text }})""".callExpression
+}

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/CallExpressionPlugin.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/plugins/CallExpressionPlugin.kt
@@ -1,0 +1,27 @@
+package arrow.meta.quotes.scope.plugins
+
+import arrow.meta.CliPlugin
+import arrow.meta.Meta
+import arrow.meta.invoke
+import arrow.meta.phases.CompilerContext
+import arrow.meta.quotes.Transform
+import arrow.meta.quotes.callExpression
+
+open class CallExpressionPlugin : Meta {
+  override fun intercept(ctx: CompilerContext): List<CliPlugin> = listOf(
+    callExpressionPlugin
+  )
+}
+
+val Meta.callExpressionPlugin: CliPlugin
+  get() =
+    "Call Expression Scope Plugin" {
+      meta(
+        callExpression({ true }) { expression ->
+          Transform.replace(
+            replacing = expression,
+            newDeclaration = identity()
+          )
+        }
+      )
+    }

--- a/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/templates/CallExpressionTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/quotes/scope/templates/CallExpressionTest.kt
@@ -1,0 +1,60 @@
+package arrow.meta.quotes.scope.templates
+
+import arrow.meta.plugin.testing.CompilerTest
+import arrow.meta.plugin.testing.assertThis
+import arrow.meta.quotes.scope.plugins.CallExpressionPlugin
+import org.junit.Test
+
+class CallExpressionTest {
+  companion object {
+    private val callExpression = """
+      | println()
+      | """.callExpression()
+
+    private val oneParameter = """
+      | println("wassup?")
+      | """.callExpression()
+
+    private val multipleParameters = """
+      | fun multipleParams(one: String, two: String) {
+      |   println(one)
+      |   println(two)
+      | }
+      |
+      | multipleParams("yo", "wassup?")
+      | """.callExpression()
+
+    private fun String.callExpression(): String = """
+      | //metadebug
+      |
+      | class Wrapper {
+      |   fun whatever() {
+      |     $this
+      |   }
+      | }
+      |"""
+  }
+
+  @Test
+  fun `Validate call expression scope properties`() {
+    callExpression.verify
+  }
+
+  @Test
+  fun `Validate call expression with one parameter scope properties`() {
+    oneParameter.verify
+  }
+
+  @Test
+  fun `Validate call expression with multiple parameters scope properties`() {
+    multipleParameters.verify
+  }
+
+  private val String.verify
+    get() = assertThis(CompilerTest(
+      config = { listOf(addMetaPlugins(CallExpressionPlugin())) },
+      code = { source },
+      assert = { quoteOutputMatches(source) }
+    ))
+}
+


### PR DESCRIPTION
WIP: Do not merge.

Adding scope for call expressions as this will make pattern matching desugaring transformations easier to handle (on separate branch pattern-matching, will rely on this PR once it's ready to merge).

Still need to verify the KtCallExpression attribute semantics, so putting this into WIP status.