### PR TITLE
[WIP] proof-of-concept to let find usages show implicit method calls of the proof system

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/proofs/ArrowImplicitMethodsReferencesSearch.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/plugins/proofs/ArrowImplicitMethodsReferencesSearch.kt
@@ -1,0 +1,90 @@
+package arrow.meta.ide.plugins.proofs
+
+import arrow.meta.ide.dsl.application.ApplicationSyntax
+import arrow.meta.ide.plugins.proofs.markers.participatingTypes
+import arrow.meta.plugins.proofs.phases.coerceProof
+import com.intellij.openapi.application.QueryExecutorBase
+import com.intellij.openapi.fileEditor.FileEditorManager
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiManager
+import com.intellij.psi.PsiRecursiveElementVisitor
+import com.intellij.psi.PsiReference
+import com.intellij.psi.search.searches.MethodReferencesSearch
+import com.intellij.util.IncorrectOperationException
+import com.intellij.util.Processor
+import org.jetbrains.kotlin.asJava.elements.KtLightMethod
+import org.jetbrains.kotlin.idea.caches.resolve.util.getJavaMethodDescriptor
+import org.jetbrains.kotlin.psi.KtProperty
+
+/**
+ * Adds implicit calls of methods to the results of Find Usages.
+ */
+class ArrowImplicitMethodsReferencesSearch : QueryExecutorBase<PsiReference, MethodReferencesSearch.SearchParameters>(true), ApplicationSyntax {
+  override fun processQuery(queryParameters: MethodReferencesSearch.SearchParameters, consumer: Processor<in PsiReference>) {
+    val method = queryParameters.method
+    if (method !is KtLightMethod) {
+      return
+    }
+
+    // fixme handle dumb mode
+    // fixme use PsiManager batch processing?
+
+    // fixme currently this is a proof of concept with the currently opened files only
+    val currentFiles = FileEditorManager.getInstance(method.project).selectedFiles.mapNotNull {
+      PsiManager.getInstance(method.project).findFile(it)
+    }
+    if (currentFiles.isEmpty()) {
+      return
+    }
+
+    val visitor = object : PsiRecursiveElementVisitor() {
+      override fun visitElement(element: PsiElement) {
+        if (element is KtProperty) {
+          element.participatingTypes()?.let { (subtype, supertype) ->
+            val through = element.ctx()?.coerceProof(subtype, supertype)?.through
+            if (through == null || through.name.asString() != method.name) {
+              return
+            }
+
+            val rhs = element.initializer ?: return
+            consumer.process(StaticPsiReference(rhs))
+          }
+        } else {
+          // visit remaining elements
+          super.visitElement(element)
+        }
+      }
+    }
+
+    currentFiles.forEach(visitor::visitElement)
+  }
+}
+
+internal class StaticPsiReference(private val element: PsiElement) : PsiReference {
+  override fun getElement(): PsiElement = element
+
+  override fun getRangeInElement(): TextRange = TextRange.create(0, element.textLength)
+
+  override fun bindToElement(element: PsiElement): PsiElement {
+    throw IncorrectOperationException("unsupported")
+  }
+
+  override fun isReferenceTo(target: PsiElement): Boolean {
+    return element == target
+  }
+
+  override fun resolve(): PsiElement? {
+    return element
+  }
+
+  override fun getCanonicalText(): String {
+    return element.text
+  }
+
+  override fun handleElementRename(newElementName: String): PsiElement {
+    throw IncorrectOperationException("unsupported")
+  }
+
+  override fun isSoft(): Boolean = true
+}

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -28,6 +28,8 @@
         <projectService serviceImplementation="arrow.meta.ide.plugins.initial.CompilerContextService"
                         serviceInterface="arrow.meta.phases.CompilerContext"/>
         <highlightingPassFactory implementation="arrow.meta.ide.plugins.quotes.resolve.QuoteHighlightingPassFactory"/>
+
+        <methodReferencesSearch implementation="arrow.meta.ide.plugins.proofs.ArrowImplicitMethodsReferencesSearch" />
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.kotlin">


### PR DESCRIPTION
![arrow-find-usages](https://user-images.githubusercontent.com/11473063/83143037-9ffde300-a0f1-11ea-98c3-8a77e8480e8a.gif)

@raulraja 

**This is a proof of concept to show that it's possible**

- It only shows usages in the currently opened files
- It matching methods by name, this isn't good enough for a full implementation

Implementation:
- Takes a similar approach as the Scala plugin
- A methods reference extension adds results to the usage search of a particular method

Missing pieces:
- The extension has to locate all `PsiElements` in the project (or sub-scope), which are method calls to the queried method. I don't know enough about the proof system, but I assume that this data is not yet available. What we need is a mapping `implicitly called method name --> PsiElement where the proof system adds the call`.   
- This mapping has to provide results for all .kt files of the project, which are modified by the proof system
For example, for 
```
val myUnion1 : arrow.Union2<Int,String> = 0
```
the PsiElement of `0` has to be returned, because the proof system adds an implicit call of `first` to it
   - This sounds very similar to the Quote system cache, but I couldn't find the equivalent piece for the proof system