### PR TITLE
3rd party extensions in Meta

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/internal/registry/IdeInternalRegistry.kt
@@ -8,6 +8,8 @@ import arrow.meta.ide.phases.editor.extension.ExtensionProvider
 import arrow.meta.ide.phases.editor.fileEditor.EditorProvider
 import arrow.meta.ide.phases.editor.intention.IntentionExtensionProvider
 import arrow.meta.ide.phases.editor.syntaxHighlighter.SyntaxHighlighterExtensionProvider
+import arrow.meta.ide.phases.additional.AdditionalIdePhase
+import arrow.meta.ide.phases.additional.AdditionalRegistry
 import arrow.meta.ide.phases.integration.indices.KotlinIndicesHelper
 import arrow.meta.ide.phases.resolve.LOG
 import arrow.meta.ide.phases.ui.ToolwindowProvider
@@ -104,6 +106,7 @@ interface IdeInternalRegistry : InternalRegistry {
             is ToolwindowProvider -> registerToolwindowProvider(phase)
             is EditorProvider -> registerEditorProvider(phase, ctx.app)
             is ApplicationProvider -> registerApplicationProvider(phase, ctx.app)
+            is AdditionalIdePhase -> ctx.app.registerAdditional(phase)
             is Composite -> phase.phases.forEach { composite -> rec(composite) }
             else -> LOG.error("Unsupported ide extension phase: $phase")
           }
@@ -131,6 +134,12 @@ interface IdeInternalRegistry : InternalRegistry {
         f(project, ctx)
       }
     }
+
+  fun Application.registerAdditional(phase: AdditionalIdePhase) {
+    getService(AdditionalRegistry::class.java)?.run {
+      register(this@registerAdditional, phase)
+    }
+  }
 
   fun Project.kotlinIndicesHelper(phase: KotlinIndicesHelper, ctx: CompilerContext): Unit =
     KotlinIndicesHelperExtension.registerExtension(

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/additional/AdditionalIdePhase.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/phases/additional/AdditionalIdePhase.kt
@@ -1,0 +1,24 @@
+package arrow.meta.ide.phases.additional
+
+import arrow.meta.ide.internal.registry.IdeInternalRegistry
+import arrow.meta.phases.ExtensionPhase
+import com.intellij.openapi.application.Application
+
+/**
+ * this interface is for plugins depending on Meta that define extensions that are
+ * not in the Meta DSL for the Ide.
+ * It allows one to register those extensions and make them available through the Meta DSL,
+ * as if the extension is part of it.
+ * The data type of those extensions should be a subtype of [AdditionalIdePhase],
+ * so that overriding [AdditionalRegistry] allows one to register the aforementioned extension in [register].
+ */
+interface AdditionalRegistry {
+  fun IdeInternalRegistry.register(app: Application, phase: AdditionalIdePhase)
+
+  companion object : AdditionalRegistry {
+    override fun IdeInternalRegistry.register(app: Application, phase: AdditionalIdePhase): Unit =
+      Unit
+  }
+}
+
+interface AdditionalIdePhase : ExtensionPhase

--- a/idea-plugin/src/main/resources/META-INF/plugin.xml
+++ b/idea-plugin/src/main/resources/META-INF/plugin.xml
@@ -24,12 +24,17 @@
         However if one wishes to disable, remove or manipulate a feature set of Ide extensions, one may choose to do so by utilising the Meta APIs instead of the plugin.xml-->
     <extensions defaultExtensionNs="com.intellij">
         <applicationInitializedListener implementation="arrow.meta.ide.internal.IdeRegistrar"/>
-        <applicationService serviceInterface="arrow.meta.ide.MetaIde" serviceImplementation="arrow.meta.ide.IdeMetaPlugin"/>
+        <applicationService serviceInterface="arrow.meta.ide.MetaIde"
+                            serviceImplementation="arrow.meta.ide.IdeMetaPlugin"/>
+        <applicationService serviceImplementation="arrow.meta.ide.phases.additional.AdditionalRegistry$Companion"
+                            serviceInterface="arrow.meta.ide.phases.additional.AdditionalRegistry"/>
+        <!--quote services-->
         <projectService serviceImplementation="arrow.meta.ide.plugins.quotes.cache.QuoteCacheService"
                         serviceInterface="arrow.meta.ide.plugins.quotes.cache.QuoteCache"/>
         <projectService serviceImplementation="arrow.meta.ide.plugins.quotes.highlighting.QuoteHighlightingCache"/>
         <projectService serviceImplementation="arrow.meta.ide.plugins.quotes.system.QuoteSystem"
                         serviceInterface="arrow.meta.ide.plugins.quotes.system.QuoteSystemService"/>
+        <!--cli service-->
         <projectService serviceImplementation="arrow.meta.ide.plugins.initial.CompilerContextService"
                         serviceInterface="arrow.meta.phases.CompilerContext"/>
     </extensions>


### PR DESCRIPTION
This allows users to define an `ExtensionPhase` that is registered as part of the IdeInternalRegistry, such that plugin devs and alike are no longer restricted by the set of Ide extensions that are implemented in Meta, but can define their own libraries on top of it and benefit from the DSL at the same time. 

I will link an example once, I can pull the Snapshot from master. 
But it boils down to composing one's algebra as Meta does in IdeSyntax compose them with `arrow.meta.ide.MetaIde` and registering them in the overridden service.
```kotlin
interface MySyntax : ExtensionYSyntax, ExtensionZSyntax // and many more each of them defing extension functions based on MyIdeSyntax

interface MyIdeSyntax : MySyntax, MetaIde
```
One example with an imaginary extension called `YExtension`:

```kotlin
sealed class YExtension<Y> : AdditionalIdePhase {
  data class AddY<Y>(val y: Y) : YExtension<Y>()
  data class RemoveY<Y>(val y: Y) : YExtension<Y>()
}
// it's syntax

interface ExtensionYSyntax {
  fun <Y> MyIdeSyntax.addY(y: Y): AdditionalIdePhase =
    AddY(y)
}

// at call-site
val MetaIdeSyntax.myYFeature: AdditionalIdePhase = 
  get() = addY("Add Me")
```

```kotlin
// in ones internals
class MyInternalRegistry : AdditionalRegistry {
  override fun IdeInternalRegistry.register(app: Application, phase: AdditionalIdePhase): Unit =
    when (phase) {
      is YExtension<*> -> registerYExtension(app, phase)
      else -> Unit
    }

  fun <Y> registerYExtension(app: Application, phase: YExtension<Y>): Unit =
    when (phase) {
      is YExtension.AddY<Y> -> TODO()
      is YExtension.RemoveY<Y> -> TODO()
    }
}
```

override the service in your plugin.xml
```xml
<idea-plugin>
 <!-- .... -->
<extensions defaultExtensionNs="com.intellij">
<applicationService serviceInterface="arrow.meta.ide.phases.additional.AdditionalRegistry" overrides="true" serviceImplementation="com.org.ide.MyInternalRegistry"/>
</extensions>
</idea-plugin>
```
Please, note that I will supply real-world examples in Docs or in `arrow-meta-examples` repo.
One may note, that we're working on removing this last repetitive step in future versions.
