### PR TITLE
Configuration: disable next version checks

### DIFF
--- a/.github/workflows/build_artifacts.yml
+++ b/.github/workflows/build_artifacts.yml
@@ -12,24 +12,19 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-        architecture: x64
     - name: Build with Gradle
       run: ./gradlew buildMeta
-    - name: Check next version
-      run: |
-        echo "Is there an upcoming version to check?"
-        sed -i "s/mavenCentral()/mavenCentral()\\nmaven { url \"https:\/\/dl.bintray.com\/kotlin\/kotlin-dev\/\" }/g" build.gradle
-        for patch in $(ls -v .github/workflows/sandbox/*.diff); do
-          echo "Checking $patch ..."
-          PATCH_VERSION=$(basename -s .diff $patch)
-          NEXT_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep $PATCH_VERSION | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)
-          echo "For version $NEXT_VERSION ..."
-          git apply $patch
-          git status
-          sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$NEXT_VERSION/g" gradle.properties
-          ./gradlew clean :compiler-plugin:jar # TODO: build
-        done
+    #- name: Check next version
+    #  run: |
+    #    echo "Is there an upcoming version to check?"
+    #    sed -i "s/mavenCentral()/mavenCentral()\\nmaven { url \"https:\/\/dl.bintray.com\/kotlin\/kotlin-dev\/\" }/g" build.gradle
+    #    for patch in $(ls -v .github/workflows/sandbox/*.diff); do
+    #      echo "Checking $patch ..."
+    #      PATCH_VERSION=$(basename -s .diff $patch)
+    #      NEXT_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep $PATCH_VERSION | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)
+    #      echo "For version $NEXT_VERSION ..."
+    #      git apply $patch
+    #      git status
+    #      sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$NEXT_VERSION/g" gradle.properties
+    #      ./gradlew clean :compiler-plugin:jar # TODO: build
+    #    done

--- a/.github/workflows/kotlin-sync.yml
+++ b/.github/workflows/kotlin-sync.yml
@@ -11,24 +11,20 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Test latest Kotlin EAP version
-      run: |
-        LATEST_KOTLIN_EAP_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep eap | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)
-        echo "Kotlin EAP version = $LATEST_KOTLIN_EAP_VERSION" > versions
-        LATEST_KOTLIN_EAP_VERSION_NUMBER=$(echo $LATEST_KOTLIN_EAP_VERSION | cut -d- -f1)
-        for patch in $(ls -v .github/workflows/sandbox/*.diff); do
-          PATCH_VERSION_NUMBER=$(basename -s .diff $patch | cut -d- -f1)
-          if [[ "$(echo -e "$LATEST_KOTLIN_EAP_VERSION_NUMBER\n$PATCH_VERSION_NUMBER" | sort -V | tail -1)" == "$LATEST_KOTLIN_EAP_VERSION_NUMBER" ]]; then git apply $patch; fi
-        done
-        git status
-        sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_EAP_VERSION/g" gradle.properties
-        sed -i "s/mavenCentral()/mavenCentral()\\nmaven { url \"https:\/\/dl.bintray.com\/kotlin\/kotlin-dev\/\" }/g" build.gradle
-        echo "Latest Kotlin version: $LATEST_KOTLIN_EAP_VERSION"
-        ./gradlew clean :compiler-plugin:jar 2> stderr #TODO: build
+    #- name: Test latest Kotlin EAP version
+    #  run: |
+    #    LATEST_KOTLIN_EAP_VERSION=$(curl https://dl.bintray.com/kotlin/kotlin-dev/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep eap | tail -1 | cut -d'>' -f2 | cut -d'<' -f1)
+    #    echo "Kotlin EAP version = $LATEST_KOTLIN_EAP_VERSION" > versions
+    #    LATEST_KOTLIN_EAP_VERSION_NUMBER=$(echo $LATEST_KOTLIN_EAP_VERSION | cut -d- -f1)
+    #    for patch in $(ls -v .github/workflows/sandbox/*.diff); do
+    #      PATCH_VERSION_NUMBER=$(basename -s .diff $patch | cut -d- -f1)
+    #      if [[ "$(echo -e "$LATEST_KOTLIN_EAP_VERSION_NUMBER\n$PATCH_VERSION_NUMBER" | sort -V | tail -1)" == "$LATEST_KOTLIN_EAP_VERSION_NUMBER" ]]; then git apply $patch; fi
+    #    done
+    #    git status
+    #    sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_EAP_VERSION/g" gradle.properties
+    #    sed -i "s/mavenCentral()/mavenCentral()\\nmaven { url \"https:\/\/dl.bintray.com\/kotlin\/kotlin-dev\/\" }/g" build.gradle
+    #    echo "Latest Kotlin version: $LATEST_KOTLIN_EAP_VERSION"
+    #    ./gradlew clean :compiler-plugin:jar 2> stderr #TODO: build
     #- name: Test latest Kotlin DEV version
     #  run: |
     #    git checkout .
@@ -47,41 +43,41 @@ jobs:
     #    echo "Latest Kotlin version: $LATEST_KOTLIN_DEV_VERSION"
     #    echo "Latest org.jetbrains.kotlin.kapt.gradle.plugin version: $LATEST_KOTLIN_PLUGIN_DEV_VERSION"
     #    ./gradlew clean :compiler-plugin:jar 2> stderr #TODO: build
-    - name: Update versions
-      id: update
-      run: |
-        sudo apt-get install html2text
-        git checkout .
-        LATEST_KOTLIN_VERSION=$(curl https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
-        echo "Latest Kotlin version: $LATEST_KOTLIN_VERSION"
-        for patch in $(ls -v .github/workflows/sandbox/*.diff); do
-          PATCH_VERSION_NUMBER=$(basename -s .diff $patch | cut -d- -f1)
-          if [[ "$(echo -e "$LATEST_KOTLIN_VERSION\n$PATCH_VERSION_NUMBER" | sort -V | tail -1)" == "$LATEST_KOTLIN_VERSION" ]]; then git apply $patch; rm $patch; fi
-        done
-        git status
-        curl -o intellij-idea-releases.html https://www.jetbrains.com/intellij-repository/releases/
-        html2text -style pretty -o intellij-idea-releases.txt intellij-idea-releases.html
-        LATEST_INTELLIJ_IDEA_VERSION=$(grep -A 100 'com.jetbrains.intellij.idea' intellij-idea-releases.txt | grep -o -e '^[0-9]\+\.[0-9]\+\.\?[0-9]*' | sort | tail -1)
-        rm -f intellij-idea-releases*
-        echo "Latest Intellij IDEA version: $LATEST_INTELLIJ_IDEA_VERSION"
-        LATEST_KOTLIN_IDEA_VERSION=${LATEST_KOTLIN_VERSION}-release-IJ$(echo $LATEST_INTELLIJ_IDEA_VERSION | cut -d. -f1-2)-1
-        echo "Latest Kotlin IDEA version: $LATEST_KOTLIN_IDEA_VERSION"
-        sed -i "s/^VERSION_NAME=.*$/VERSION_NAME=${LATEST_KOTLIN_VERSION}-SNAPSHOT/g" gradle.properties
-        sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_VERSION/g" gradle.properties
-        sed -i "s/^KOTLIN_IDEA_VERSION=.*$/KOTLIN_IDEA_VERSION=$LATEST_KOTLIN_IDEA_VERSION/g" gradle.properties
-        sed -i "s/^INTELLIJ_IDEA_VERSION=.*$/INTELLIJ_IDEA_VERSION=$LATEST_INTELLIJ_IDEA_VERSION/g" gradle.properties
-        echo ::set-output name=kotlin-version::"$LATEST_KOTLIN_VERSION"
-        echo ::set-output name=kotlin-idea-version::"$LATEST_KOTLIN_IDEA_VERSION"
-        echo ::set-output name=intellij-idea-version::"$LATEST_INTELLIJ_IDEA_VERSION"
-        echo ::set-output name=differences::$(git diff gradle.properties)
-    - name: Build Arrow Meta
-      if: steps.update.outputs.differences != ''
-      run: |
-        echo "Kotlin=${{ steps.update.outputs.kotlin-version }}, Kotlin IDEA=${{ steps.update.outputs.kotlin-idea-version }}, Intellij IDEA=${{ steps.update.outputs.intellij-idea-version }}" > versions
-        ./gradlew clean :compiler-plugin:jar 2> stderr #TODO: build
-        ./gradlew :idea-plugin:jar 2> stderr #TODO: build
-        ./gradlew :meta-test:jar 2> stderr #TODO: build
-        ./gradlew :gradle-plugin:jar 2> stderr
+    #- name: Update versions
+    #  id: update
+    #  run: |
+    #    sudo apt-get install html2text
+    #    git checkout .
+    #    LATEST_KOTLIN_VERSION=$(curl https://repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-compiler/maven-metadata.xml | grep latest | cut -d'>' -f2 | cut -d'<' -f1)
+    #    echo "Latest Kotlin version: $LATEST_KOTLIN_VERSION"
+    #    for patch in $(ls -v .github/workflows/sandbox/*.diff); do
+    #      PATCH_VERSION_NUMBER=$(basename -s .diff $patch | cut -d- -f1)
+    #      if [[ "$(echo -e "$LATEST_KOTLIN_VERSION\n$PATCH_VERSION_NUMBER" | sort -V | tail -1)" == "$LATEST_KOTLIN_VERSION" ]]; then git apply $patch; rm $patch; fi
+    #    done
+    #    git status
+    #    curl -o intellij-idea-releases.html https://www.jetbrains.com/intellij-repository/releases/
+    #    html2text -style pretty -o intellij-idea-releases.txt intellij-idea-releases.html
+    #    LATEST_INTELLIJ_IDEA_VERSION=$(grep -A 100 'com.jetbrains.intellij.idea' intellij-idea-releases.txt | grep -o -e '^[0-9]\+\.[0-9]\+\.\?[0-9]*' | sort | tail -1)
+    #    rm -f intellij-idea-releases*
+    #    echo "Latest Intellij IDEA version: $LATEST_INTELLIJ_IDEA_VERSION"
+    #    LATEST_KOTLIN_IDEA_VERSION=${LATEST_KOTLIN_VERSION}-release-IJ$(echo $LATEST_INTELLIJ_IDEA_VERSION | cut -d. -f1-2)-1
+    #    echo "Latest Kotlin IDEA version: $LATEST_KOTLIN_IDEA_VERSION"
+    #    sed -i "s/^VERSION_NAME=.*$/VERSION_NAME=${LATEST_KOTLIN_VERSION}-SNAPSHOT/g" gradle.properties
+    #    sed -i "s/^KOTLIN_VERSION=.*$/KOTLIN_VERSION=$LATEST_KOTLIN_VERSION/g" gradle.properties
+    #    sed -i "s/^KOTLIN_IDEA_VERSION=.*$/KOTLIN_IDEA_VERSION=$LATEST_KOTLIN_IDEA_VERSION/g" gradle.properties
+    #    sed -i "s/^INTELLIJ_IDEA_VERSION=.*$/INTELLIJ_IDEA_VERSION=$LATEST_INTELLIJ_IDEA_VERSION/g" gradle.properties
+    #    echo ::set-output name=kotlin-version::"$LATEST_KOTLIN_VERSION"
+    #    echo ::set-output name=kotlin-idea-version::"$LATEST_KOTLIN_IDEA_VERSION"
+    #    echo ::set-output name=intellij-idea-version::"$LATEST_INTELLIJ_IDEA_VERSION"
+    #    echo ::set-output name=differences::$(git diff gradle.properties)
+    #- name: Build Arrow Meta
+    #  if: steps.update.outputs.differences != ''
+    #  run: |
+    #    echo "Kotlin=${{ steps.update.outputs.kotlin-version }}, Kotlin IDEA=${{ steps.update.outputs.kotlin-idea-version }}, Intellij IDEA=${{ steps.update.outputs.intellij-idea-version }}" > versions
+    #    ./gradlew clean :compiler-plugin:jar 2> stderr #TODO: build
+    #    ./gradlew :idea-plugin:jar 2> stderr #TODO: build
+    #    ./gradlew :meta-test:jar 2> stderr #TODO: build
+    #    ./gradlew :gradle-plugin:jar 2> stderr
     #- name: Prepare the environment to create the pull request
     #  id: prepare-pr
     #  if: steps.update.outputs.differences != ''


### PR DESCRIPTION
Reasons:

- WIP #706
- They should be updated after #706 because of using `1.4-M3` (not `1.4` yet)