### PR TITLE
Clean dependencies

### DIFF
--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -23,9 +23,6 @@ dependencies {
     testRuntimeOnly project(':compiler-plugin')
 
     testRuntimeOnly("org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION")
-    testRuntimeOnly("io.arrow-kt:arrow-annotations:$ARROW_VERSION") {
-        exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
-    }
     testRuntimeOnly("io.arrow-kt:arrow-optics:$ARROW_VERSION") {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
     }

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -23,11 +23,7 @@ dependencies {
     testRuntimeOnly project(':compiler-plugin')
 
     testRuntimeOnly("org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION")
-    testCompileOnly "io.arrow-kt:arrow-core-data:$ARROW_VERSION"
     testRuntimeOnly("io.arrow-kt:arrow-annotations:$ARROW_VERSION") {
-        exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
-    }
-    testRuntimeOnly("io.arrow-kt:arrow-core-data:$ARROW_VERSION") {
         exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
     }
     testRuntimeOnly("io.arrow-kt:arrow-optics:$ARROW_VERSION") {

--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/GivenTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/GivenTest.kt
@@ -117,15 +117,13 @@ class GivenTest {
   """.trimIndent()
 
   private fun givenTest(source: String, expected: Pair<String, Any?>) {
-    val arrowVersion = System.getProperty("ARROW_VERSION")
-    val arrowCoreData = Dependency("arrow-core-data:$arrowVersion")
     val codeSnippet = """
        $prelude
        $source
       """
     assertThis(CompilerTest(
       config = {
-        metaDependencies + addDependencies(arrowCoreData)
+        metaDependencies
       },
       code = {
         codeSnippet.source

--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/TypeClassesTest.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/TypeClassesTest.kt
@@ -10,8 +10,6 @@ class TypeClassesTest {
 
     //@Test
     fun `simple case`() {
-        val arrowVersion = System.getProperty("ARROW_VERSION")
-        val arrowCoreData = Dependency("arrow-core-data:$arrowVersion")
         val codeSnippet = """
        import arrowx.*
        import arrow.*
@@ -25,7 +23,7 @@ class TypeClassesTest {
 
         assertThis(CompilerTest(
             config = {
-                metaDependencies + addDependencies(arrowCoreData)
+                metaDependencies
             },
             code = {
                 codeSnippet.source
@@ -38,8 +36,6 @@ class TypeClassesTest {
 
   @Test
   fun `polymorphic constrain`() {
-    val arrowVersion = System.getProperty("ARROW_VERSION")
-    val arrowCoreData = Dependency("arrow-core-data:$arrowVersion")
     val codeSnippet = """
        import arrow.*
        import arrowx.*
@@ -55,7 +51,7 @@ class TypeClassesTest {
       """
     assertThis(CompilerTest(
       config = {
-        metaDependencies + addDependencies(arrowCoreData)
+        metaDependencies
       },
       code = {
         codeSnippet.source

--- a/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/kinds.kt
+++ b/compiler-plugin/src/test/kotlin/arrow/meta/plugins/typeclasses/kinds.kt
@@ -24,8 +24,6 @@ class KindsTest {
 
   @Test
   fun `Platform types can be kinded ad-hoc by proof`() {
-    val arrowVersion = System.getProperty("ARROW_VERSION")
-    val arrowCoreData = Dependency("arrow-core-data:$arrowVersion")
     val codeSnippet = """
       $prelude
         object `List(_)`
@@ -53,7 +51,7 @@ class KindsTest {
       """
     assertThis(CompilerTest(
       config = {
-        metaDependencies + addDependencies(arrowCoreData)
+        metaDependencies
       },
       code = {
         codeSnippet.source

--- a/meta-test/build.gradle
+++ b/meta-test/build.gradle
@@ -20,10 +20,6 @@ dependencies {
     testImplementation "io.kotlintest:kotlintest-runner-junit4:$KOTLIN_TEST_VERSION"
     testRuntimeOnly "org.junit.vintage:junit-vintage-engine:$JUNIT_VINTAGE_VERSION"
     testRuntimeOnly project(':prelude')
-    testRuntimeOnly("io.arrow-kt:arrow-annotations:$ARROW_VERSION") {
-        exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
-    }
-    testRuntimeOnly project(':prelude')
 }
 
 compileKotlin {
@@ -40,7 +36,6 @@ test {
         events "passed", "skipped", "failed", "standardOut", "standardError"
     }
     systemProperty "CURRENT_VERSION", "$VERSION_NAME"
-    systemProperty "ARROW_VERSION", "$ARROW_VERSION"
 }
 
 jar {

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/CompilerTestDSL.kt
@@ -102,10 +102,8 @@ interface ConfigSyntax {
   val metaDependencies: List<Config>
     get() {
       val currentVersion = System.getProperty("CURRENT_VERSION")
-      val arrowVersion = System.getProperty("ARROW_VERSION")
       val compilerPlugin = CompilerPlugin("Arrow Meta", listOf(Dependency("compiler-plugin:$currentVersion")))
-      val arrowAnnotations = Dependency("arrow-annotations:$arrowVersion")
-      return CompilerTest.addCompilerPlugins(compilerPlugin) + CompilerTest.addDependencies(arrowAnnotations) + CompilerTest.addDependencies(prelude(currentVersion))
+      return CompilerTest.addCompilerPlugins(compilerPlugin) + CompilerTest.addDependencies(prelude(currentVersion))
     }
 }
 

--- a/prelude/src/main/kotlin/arrow/extension.kt
+++ b/prelude/src/main/kotlin/arrow/extension.kt
@@ -1,0 +1,16 @@
+package arrow
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+  AnnotationTarget.CLASS,
+  AnnotationTarget.LOCAL_VARIABLE,
+  AnnotationTarget.FUNCTION
+)
+@MustBeDocumented
+annotation class extension
+
+val given: Nothing
+  get() = TODO("Should have been replaced by Arrow Meta Compiler Plugin provided by [plugins { id 'io.arrow-kt.arrow' version 'x.x.x' }")
+
+fun <A> given(): A =
+  TODO("Should have been replaced by Arrow Meta Compiler Plugin provided by [plugins { id 'io.arrow-kt.arrow' version 'x.x.x' }]")

--- a/prelude/src/main/kotlin/arrow/synthetic.kt
+++ b/prelude/src/main/kotlin/arrow/synthetic.kt
@@ -1,0 +1,34 @@
+package arrow
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(
+  /** Class, interface or object, annotation class is also included */
+  AnnotationTarget.CLASS,
+  /** Annotation class only */
+  AnnotationTarget.ANNOTATION_CLASS,
+  /** Generic type parameter (unsupported yet) */
+  AnnotationTarget.TYPE_PARAMETER,
+  /** Property */
+  AnnotationTarget.PROPERTY,
+  /** Field, including property's backing field */
+  AnnotationTarget.FIELD,
+  /** Local variable */
+  AnnotationTarget.LOCAL_VARIABLE,
+  /** Value parameter of a function or a constructor */
+  AnnotationTarget.VALUE_PARAMETER,
+  /** Constructor only (primary or secondary) */
+  AnnotationTarget.CONSTRUCTOR,
+  /** Function (constructors are not included) */
+  AnnotationTarget.FUNCTION,
+  /** Property getter only */
+  AnnotationTarget.PROPERTY_GETTER,
+  /** Property setter only */
+  AnnotationTarget.PROPERTY_SETTER,
+  /** Type usage */
+  AnnotationTarget.TYPE,
+  /** File */
+  AnnotationTarget.FILE,
+  AnnotationTarget.TYPEALIAS
+)
+@MustBeDocumented
+annotation class synthetic


### PR DESCRIPTION
- Remove `arrow-core-data` dependency
- Replace `arrow-annotations` dependency by moving `extension` and `synthetic` to `arrow-meta-prelude`.