### PR TITLE
Remove playground for Arrow IDE Plugin examples

### DIFF
--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ApplicationSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/application/ApplicationSyntax.kt
@@ -40,14 +40,14 @@ interface ApplicationSyntax {
    * even though the service can be retrieved multiple times with [ServiceManager.getService] or [com.intellij.openapi.project.Project.getService] for project-level services.
    * It is impeccable that there is only one [instance] implementation for a given [service] to fulfill coherence in the ide.
    * The ide will throw an exception, if that premise is not met.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import org.jetbrains.kotlin.psi.KtNamedFunction
    *
    * interface MyService {
    *   fun printLn(f: KtNamedFunction): Unit
    * }
    * ```
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.invoke
@@ -119,7 +119,7 @@ interface ApplicationSyntax {
   /**
    * replaces an application [service] with [instance].
    * In this example this [Annotator] needs a different [instance] for `MyService` than what is currently provided - see our example in [addAppService].
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.invoke
@@ -185,7 +185,7 @@ interface ApplicationSyntax {
    * @param instance hijacks the existing instance [A] from the IDE and registers the new instance [A]. The hijacked instance is preserved, when [instance] returns null.
    * There are several use-cases like [org.jetbrains.kotlin.caches.resolve.KotlinCacheService] for project-level services.
    * The following example registers a logger for the KotlinCacheService by hijacking it's standard implementation from the kotlin plugin.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/action/AnActionSyntax.kt
@@ -33,7 +33,7 @@ interface AnActionSyntax : AnActionUtilitySyntax {
   /**
    * Registers the [action] with [actionId] as its identifier.
    * The [actionId] is solely used internally.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import com.intellij.openapi.wm.ToolWindowManager
    * import arrow.meta.ide.resources.ArrowIcons
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/color/ColorSettingsSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/color/ColorSettingsSyntax.kt
@@ -41,7 +41,7 @@ interface ColorSettingsSyntax {
   /**
    * This extension registers a [ColorSettingsPage].
    * Let's register `MetaColorSettings` with the [KotlinHighlighter] and an empty [additionalHighlightingTags].
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke
@@ -81,7 +81,7 @@ interface ColorSettingsSyntax {
    * ---
    * Adding `KeyWords`, `Interface` and `Named Arguments` as tags to [demoText] is not enough.
    * They have to be added to [additionalHighlightingTags] in order to be indexed, by the ide.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke
@@ -123,7 +123,7 @@ interface ColorSettingsSyntax {
    * [ColorSettingsPage] does not register tagged Tokens in [demoText] to the Language, for that we need other `Extensions`.
    * Nonetheless, we can register tokens to be highlighted, assuming we already provide an ide extension instance with these added tokens - mainly with a `Parser` and [Annotator].
    *
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke
@@ -164,7 +164,7 @@ interface ColorSettingsSyntax {
    *
    * We can achieve a similar visual representation with an empty instance [PlainSyntaxHighlighter] - which is the default for [highlighter].
    *
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/documentation/DocumentationSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/documentation/DocumentationSyntax.kt
@@ -18,7 +18,7 @@ interface DocumentationSyntax {
   /**
    * registers a [DocumentationProvider].
    * Users are now able to hover over descriptors and see the provided documentation.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/hints/HintingSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/hints/HintingSyntax.kt
@@ -62,7 +62,7 @@ interface HintingSyntax {
    * The following examples is a minimal version of the
    * [org.jetbrains.kotlin.idea.codeInsight.KotlinExpressionTypeProvider] and targets [KtFunction]s, who are expressed as expressions.
    *
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke
@@ -224,7 +224,7 @@ interface HintingSyntax {
    * registers a [KotlinTypeArgumentInfoHandlerBase]
    * This extension is used for [DeclarationDescriptor]'s, the `Owner` is [KtTypeArgumentList] and the `ActualType` is [KtTypeProjection].
    * The following example provides Hints for [ClassDescriptor] from [org.jetbrains.kotlin.idea.parameterInfo.KotlinClassTypeArgumentInfoHandler]:
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke
@@ -274,7 +274,7 @@ interface HintingSyntax {
    * registers a [KotlinParameterInfoWithCallHandlerBase]
    * This is used for [FunctionDescriptor]'s, the `Owner` is [ArgumentList] and the `ActualType` is [Argument]. Naturally, `Type` is a [FunctionDescriptor].
    * The following example is for [KtLambdaArgument]s from [org.jetbrains.kotlin.idea.parameterInfo.KotlinLambdaParameterInfoHandler]:
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/icon/IconProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/icon/IconProviderSyntax.kt
@@ -25,7 +25,7 @@ interface IconProviderSyntax {
   /**
    * registers an [IconProvider].
    * One minimal example from [KotlinIconProvider], may look like this:
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.invoke
@@ -66,7 +66,7 @@ interface IconProviderSyntax {
    * registers an [IconProvider]
    * `TransformIcon<A>` is an alias for `Pair<Icon, (psiElement: PsiElement, flag: Int) -> A?>`
    * If only one [IconProvider] is desired, we may use [addIcons] and create those `Pairs` with [icon].
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/inspection/InspectionSyntax.kt
@@ -41,7 +41,7 @@ interface InspectionSyntax : InspectionUtilitySyntax {
   /**
    * registers a Local ApplicableInspection and has [KtPsiFactory] in Scope to modify the element, project or editor at once within [applyTo].
    * The following example is a simplified purityPlugin, where every function that returns Unit has to be suspended. Otherwise the code can not be compiled.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.dsl.utils.intersectFunction

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/lineMarker/LineMarkerSyntax.kt
@@ -132,7 +132,7 @@ interface LineMarkerSyntax {
    * [addLineMarkerProvider] is a convenience extension, which registers the Leaf element of a composite PsiElement [A] e.g.: `KtClass`
    * and circumvents effort's to find the right PsiElement.
    * In addition, plugin developer's can compose sophisticated messages, as the whole scope of [A] can be exploited.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.resources.ArrowIcons

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/syntaxHighlighter/SyntaxHighlighterSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/editor/syntaxHighlighter/SyntaxHighlighterSyntax.kt
@@ -26,7 +26,7 @@ interface SyntaxHighlighterSyntax {
   /**
    * @param tokenHighlights specifies the generated tokens from the lexer that need to be highlighted
    * The following example registers a sample amount of the generated Tokens from the KotlinLexer.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/extensions/ExtensionProviderSyntax.kt
@@ -146,7 +146,7 @@ interface ExtensionProviderSyntax {
    * //sampleEnd
    * ```
    * Registering [MetaProvider] in `Meta` may look like this:
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.dsl.editor.lineMarker.LineMarkerSyntax

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/ui/dialogs/DialogSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/ui/dialogs/DialogSyntax.kt
@@ -26,7 +26,7 @@ import javax.swing.Icon
  */
 interface DialogSyntax {
   /**
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.invoke

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/ui/popups/PopupSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/ui/popups/PopupSyntax.kt
@@ -28,7 +28,7 @@ import javax.swing.event.HyperlinkEvent
  */
 interface PopupSyntax {
   /**
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.dsl.ui.popups.IdeListPopupItem

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/ui/toolwindow/ToolWindowSyntax.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/dsl/ui/toolwindow/ToolWindowSyntax.kt
@@ -34,7 +34,7 @@ interface ToolWindowSyntax {
    * registers an Action with the title [toolId] and [actionId].
    * When the user executes the latter a tool window with displayName [toolId] is activated or registered by absence.
    * The following example enables the internal `Fir Explorer`, whenever the current document is a kotlin file.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.resources.ArrowIcons
@@ -122,7 +122,7 @@ interface ToolWindowSyntax {
 
   /**
    * Adds a notification balloon to the Toolwindow and only disappears if the users clicks on it.
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.resources.ArrowIcons
@@ -230,7 +230,7 @@ interface ToolWindowSyntax {
   /**
    * constructs a [JPanel] with an [Editor] inside.
    *
-   * ```kotlin:ank:playground
+   * ```kotlin:ank
    * import arrow.meta.ide.IdePlugin
    * import arrow.meta.ide.MetaIde
    * import arrow.meta.ide.resources.ArrowIcons

--- a/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
+++ b/idea-plugin/src/main/kotlin/arrow/meta/ide/testing/env/IdeTestInterpreter.kt
@@ -56,7 +56,7 @@ fun <F : IdeSyntax, A> interpreter(ideTest: IdeTest<F, A>, ctx: F, fixture: Code
  * class MyIdePlugin : IdeSyntax
  * ```
  * a general schema looks like this:
- * ```kotlin:ank:playground
+ * ```kotlin:ank
  * import arrow.meta.ide.dsl.IdeSyntax
  * import arrow.meta.ide.testing.IdeTest
  * import arrow.meta.ide.testing.Source


### PR DESCRIPTION
`playground` Ank modifier is being used for Arrow IDE Plugin examples. However, it's not working now because it's necessary to provide more libraries (Meta and Kotlin IDE plugin).

This PR removes the use of that Ank modifier. 

## Screenshot

![Screenshot from 2020-08-05 15-25-47](https://user-images.githubusercontent.com/22792183/89419132-49d0a000-d731-11ea-9b23-4924abdc075d.png)
