### PR TITLE
Configuration: specific classpath for Ank validation

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -17,6 +17,14 @@ apply plugin: 'ank-gradle-plugin'
 dependencies {
     compile project(':idea-plugin')
     compile "junit:junit:4.13"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-compiler:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-scripting-compiler:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-scripting-compiler-impl:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-script-util:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-reflect:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-scripting-jvm:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-scripting-common:$KOTLIN_VERSION"
+    runtimeOnly "org.jetbrains.kotlin:kotlin-script-runtime:$KOTLIN_VERSION"
 }
 
 intellij {
@@ -26,31 +34,67 @@ intellij {
 
 task printcp {
     doLast {
-        println sourceSets.main.compileClasspath.each { println it }
-        println sourceSets.main.runtimeClasspath.each { println it }
+        println "compile classpath:"
+        sourceSets.main.compileClasspath.each { println it }
+        println "runtime classpath:"
+        sourceSets.main.runtimeClasspath.each { println it }
     }
 }
 
 ext {
     set("LOCAL_PATHS_FILE", "${projectDir}/localPaths.log")
     // Reason: required by ank; file must exist during Gradle configuration check
-    if ( !new File("$LOCAL_PATHS_FILE").exists() )  new File("$LOCAL_PATHS_FILE").createNewFile()
+    if ( !file("$LOCAL_PATHS_FILE").exists() )  file("$LOCAL_PATHS_FILE").createNewFile()
 }
 
 ank {
     source = file("${projectDir}/docs")
     target = file("${projectDir}/build/site")
-    classpath = sourceSets.main.runtimeClasspath + layout.files(new File("$LOCAL_PATHS_FILE").readLines())
+    classpath = layout.files(file("$LOCAL_PATHS_FILE").readLines())
 }
 
 task getLocalPaths {
     // Reason: local paths cannot be generated in Ank extension neither ext section
     doLast {
-        def libraries = ['kotlin-plugin.jar', 'platform-api.jar', 'platform-impl.jar', 'idea.jar', 'testFramework.jar']
-        def localPaths = libraries.collect{ library -> sourceSets.main.compileClasspath.find{ path -> path.name == "$library" } }
-        def localPathsFile = new File("$LOCAL_PATHS_FILE")
+
+        def librariesFromRuntime = [
+            "junit",
+            "kotlin-compiler-$KOTLIN_VERSION",
+            "kotlin-scripting-compiler-$KOTLIN_VERSION",
+            "kotlin-scripting-compiler-impl-$KOTLIN_VERSION",
+            "kotlin-script-util-$KOTLIN_VERSION",
+            "kotlin-reflect-$KOTLIN_VERSION",
+            "kotlin-stdlib-jdk7-$KOTLIN_VERSION",
+            "kotlin-scripting-jvm-$KOTLIN_VERSION",
+            "kotlin-scripting-common-$KOTLIN_VERSION",
+            "kotlin-script-runtime-$KOTLIN_VERSION",
+            "trove4j",
+            "kotlin-stdlib-common-$KOTLIN_VERSION",
+            "annotations-13.0",
+            "kotlinx-coroutines-core",
+            "kindedj",
+            "kotlin-stdlib-$KOTLIN_VERSION",
+            "arrow-ank-$ARROW_VERSION",
+            "idea-plugin-$VERSION_NAME",
+            "compiler-plugin-$VERSION_NAME-all",
+            "kotlin-stdlib-jdk8-$KOTLIN_VERSION",
+            "arrow-core-data-$ARROW_VERSION",
+            "arrow-fx-$ARROW_VERSION",
+            "arrow-annotations-$ARROW_VERSION",
+            "arrow-core-$ARROW_VERSION"
+        ]
+        def librariesFromCompilation = [
+            'kotlin-plugin.jar',
+            'platform-api.jar',
+            'platform-impl.jar',
+            'idea.jar',
+            'testFramework.jar'
+        ]
+        def localPaths = librariesFromRuntime.collect{ library -> sourceSets.main.runtimeClasspath.find{ path -> path.name.contains("$library") } }
+        localPaths.addAll(librariesFromCompilation.collect{ library -> sourceSets.main.compileClasspath.find{ path -> (path.name == "$library") } })
+        def localPathsFile = file("$LOCAL_PATHS_FILE")
         localPathsFile.write localPaths.join("\n")
-        layout.files(new File("$LOCAL_PATHS_FILE").readLines()).each { println it.path }
+        layout.files(file("$LOCAL_PATHS_FILE").readLines()).each { println it.path }
     }
 }
 


### PR DESCRIPTION
## Reason

Current errors when validating the documentation for `1.4.0-rc`. There is no clue to solve them.

If all the dependencies from compile classpath and runtime classpath (295 dependencies) are added then Ank raises a lot of errors from conflicts between them so the classpath for Ank validation includes:

* The whole runtime classpath: 31 dependencies; some of them with specific Kotlin version for Ank
* Specific dependencies from Intellij IDEA + Kotlin IDEA Plugin

## Changes

The classpath for Ank validation will include:

* Specific dependencies with the current Kotlin version: 24 dependencies
* Specific dependencies from Intellij IDEA + Kotlin IDEA Plugin

## Advantages

That control about dependencies for Ank validation is useful for upgrades because just the expected dependencies are considered.