### PR TITLE
Fixes GivenTests

### DIFF
--- a/compiler-plugin/src/main/kotlin/arrow/meta/log/Log.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/log/Log.kt
@@ -10,9 +10,9 @@ sealed class Log {
 operator fun <A> Log.invoke(
   tag: A.() -> String,
   f: () -> A
-): A = f()
-  // if (this is Log.Verbose) {
-  //   val (time, result) = measureTimeMillisWithResult(f)
-  //   println("${tag(result)} : [${time}ms]")
-  //   result
-  // } else f()
+): A =
+  if (this is Log.Verbose) {
+    val (time, result) = measureTimeMillisWithResult(f)
+    println("${tag(result)} : [${time}ms]")
+    result
+  } else f()

--- a/compiler-plugin/src/main/kotlin/arrow/meta/log/Log.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/log/Log.kt
@@ -10,9 +10,9 @@ sealed class Log {
 operator fun <A> Log.invoke(
   tag: A.() -> String,
   f: () -> A
-): A =
-  if (this is Log.Verbose) {
-    val (time, result) = measureTimeMillisWithResult(f)
-    println("${tag(result)} : [${time}ms]")
-    result
-  } else f()
+): A = f()
+  // if (this is Log.Verbose) {
+  //   val (time, result) = measureTimeMillisWithResult(f)
+  //   println("${tag(result)} : [${time}ms]")
+  //   result
+  // } else f()

--- a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/ir/ProofsIrCodegen.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/ir/ProofsIrCodegen.kt
@@ -163,7 +163,6 @@ class ProofsIrCodegen(
       val upperBound = givenTypeParamUpperBound.givenUpperBound
       if (upperBound != null) insertGivenCall(givenTypeParamUpperBound, expression)
       else insertExtensionSyntaxCall(expression)
-      println("After:\n${ir2string(expression)}")
       expression
     }
 

--- a/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/resolve/GivenUpperBound.kt
+++ b/compiler-plugin/src/main/kotlin/arrow/meta/plugins/proofs/phases/resolve/GivenUpperBound.kt
@@ -1,44 +1,36 @@
 package arrow.meta.plugins.proofs.phases.resolve
 
+import arrow.meta.phases.codegen.ir.substitutedValueParameters
 import arrow.meta.phases.resolve.intersection
+import arrow.meta.plugins.proofs.phases.ArrowGivenProof
 import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
-import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.ir.expressions.IrCall
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.typeUtil.isNothing
 
 data class GivenUpperBound(
-  val givenValueParameters: List<ValueParameterDescriptor>,
-  val givenUpperBound: KotlinType?
+  val givenValueParameters: List<Pair<ValueParameterDescriptor, KotlinType>>,
+  val givenUpperBound: KotlinType?,
 ) {
   companion object {
-
-    val givenAnnotationName: FqName = FqName("arrow.Given")
-
     val Empty: GivenUpperBound =
       GivenUpperBound(
         givenValueParameters = emptyList(),
         givenUpperBound = null
       )
 
-    operator fun invoke(callableMemberDescriptor: CallableMemberDescriptor): GivenUpperBound {
-      val givenValueParameters = callableMemberDescriptor.valueParameters
-        .mapNotNull {
-          if (it.type.annotations.findAnnotation(givenAnnotationName) != null)
-            it
-          else null
-        }
-      return if (givenValueParameters.isEmpty()) Empty
-      else {
-        val intersection = givenValueParameters.fold(callableMemberDescriptor.builtIns.nothingType as KotlinType) { a, b ->
-          if (a.isNothing()) b.type
-          else a.intersection(b.type)
-        }
-        GivenUpperBound(givenValueParameters, intersection)
-      }
-    }
-
+    operator fun invoke(f: CallableMemberDescriptor, call: IrCall): GivenUpperBound =
+      f.substitutedValueParameters(call)
+        .filter { it.first.type.annotations.hasAnnotation(ArrowGivenProof) }
+        .takeIf { it.isNotEmpty() }
+        ?.run {
+          GivenUpperBound(this, fold(f.builtIns.nothingType as KotlinType) { a, (_, b) ->
+            if (a.isNothing()) b
+            else a.intersection(b)
+          })
+        } ?: Empty
   }
 }
 


### PR DESCRIPTION
Resolves the GivenProof resolution, which caused the failing GivenTests.

Prior to 1.3.71 there was a member `descriptor`, which would return the resolved call at the call-site. It has been removed ever since in this [PR](https://github.com/JetBrains/kotlin/commit/ed79ab68abb0969c725e2c0b7d377866f41ac070#diff-5d9c42c2e76ac014d97644460546e5af). 
This PR resolves the Kotlintype for type parameters so that calculating the upper bound resolves with the concrete type at call-site and not the generic type parameter, which is found in the ValueparameterDescriptor.