### PR TITLE
Fix #728 - Filter compilation output during testing

### DIFF
--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
@@ -17,9 +17,12 @@ internal fun compile(data: CompilationData): Result =
     pluginClasspaths = data.compilerPlugins.map { classpathOf(it) }
     compilerPlugins = data.metaPlugins
     messageOutputStream = object : PrintStream(System.out) {
+      
+      private val kotlincErrorRegex = Regex("^e:") 
+      
       override fun write(buf: ByteArray, off: Int, len: Int) {
         val newLine = String(buf, off, len)
-          .run { replace(Regex("^e:"), "error found:") }
+          .run { replace(kotlincErrorRegex, "error found:") }
           .toByteArray()
 
         super.write(newLine, off, newLine.size)

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
@@ -27,10 +27,6 @@ internal fun compile(data: CompilationData): Result =
     }
   }.compile()
 
-private fun rewriteAndPrintOutput(lines: List<String>) {
-  println(lines.joinToString(System.lineSeparator()) { it.replace(Regex("^e:"), "error found:") })
-}
-
 private fun classpathOf(dependency: String): File {
   val regex = Regex(".*${dependency.replace(':', '-')}.*")
   val file = ClassGraph().classpathFiles.firstOrNull { classpath -> classpath.name.matches(regex) }

--- a/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
+++ b/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
@@ -6,21 +6,26 @@ import com.tschuchort.compiletesting.SourceFile
 import io.github.classgraph.ClassGraph
 import org.assertj.core.api.Assertions.assertThat
 import java.io.File
+import java.io.PrintStream
 
 internal const val DEFAULT_FILENAME = "Source.kt"
 
-internal fun compile(data: CompilationData): Result {
-  val outputFile = File.createTempFile("tmp", "log")
-  val compilationResult = KotlinCompilation().apply {
+internal fun compile(data: CompilationData): Result =
+  KotlinCompilation().apply {
     sources = data.sources.map { SourceFile.kotlin(it.filename, it.text.trimMargin()) }
     classpaths = data.dependencies.map { classpathOf(it) }
     pluginClasspaths = data.compilerPlugins.map { classpathOf(it) }
     compilerPlugins = data.metaPlugins
-    messageOutputStream = outputFile.outputStream()
+    messageOutputStream = object : PrintStream(System.out) {
+      override fun write(buf: ByteArray, off: Int, len: Int) {
+        val newLine = String(buf, off, len)
+          .run { replace(Regex("^e:"), "error found:") }
+          .toByteArray()
+
+        super.write(newLine, off, newLine.size)
+      }
+    }
   }.compile()
-  rewriteAndPrintOutput(outputFile.readLines())
-  return compilationResult
-}
 
 private fun rewriteAndPrintOutput(lines: List<String>) {
   println(lines.joinToString(System.lineSeparator()) { it.replace(Regex("^e:"), "error found:") })


### PR DESCRIPTION
Closes #728 thanks to the idea by @Starmel :tada: 

It filters the compilation output during testing when avoiding lines starting with "e:"