### PR TITLE
Fix publish and run IDE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,6 @@ task buildMeta {
 task publishMeta {
   dependsOn ':compiler-plugin:publishToMavenLocal'
   dependsOn ':gradle-plugin:publishToMavenLocal'
-  dependsOn ':idea-plugin:publishToMavenLocal'
   dependsOn ':meta-test:publishToMavenLocal'
   dependsOn ':prelude:publishToMavenLocal'
 }
@@ -101,9 +100,11 @@ task publishAndRunIde {
   description = "Publishes and runs IDE on local workspace"
   dependsOn ':cleanMeta'
   dependsOn ':publishMeta'
+  dependsOn ':idea-plugin:buildPlugin'
   dependsOn ':idea-plugin:runIde'
   tasks.findByPath(':publishMeta').mustRunAfter ':cleanMeta'
-  tasks.findByPath(':idea-plugin:runIde').mustRunAfter ':publishMeta'
+  tasks.findByPath(':idea-plugin:buildPlugin').mustRunAfter ':publishMeta'
+  tasks.findByPath(':idea-plugin:runIde').mustRunAfter ':idea-plugin:buildPlugin'
 }
 
 task generateDoc(type:Exec) {

--- a/gradle/build-idea-plugin.gradle
+++ b/gradle/build-idea-plugin.gradle
@@ -14,7 +14,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "de.undercouch:gradle-download-task:4.0.4"
+    classpath "de.undercouch:gradle-download-task:4.1.1"
   }
 }
 
@@ -35,6 +35,7 @@ task downloadLibraries(type: Download) {
   )
   dest "${buildDir}/libs4Plugin"
   overwrite false
+  quiet true
 }
 
 task copyLibraries(type: Copy) {


### PR DESCRIPTION
This PR continues https://github.com/arrow-kt/arrow-meta/pull/740 in order to use the same artifacts that are published into repositories for local tests.