### PR TITLE
Upgrade to Arrow 0.11.0

### DIFF
--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -71,6 +71,5 @@ shadowJar {
 test {
     testLogging.showStandardStreams = true
     systemProperty "CURRENT_VERSION", "$VERSION_NAME"
-    systemProperty "ARROW_VERSION", "$ARROW_VERSION"
     jvmArgs '-Dkotlin.compiler.execution.strategy="in-process"'
 }

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -81,6 +81,7 @@ task getLocalPaths {
             "kotlin-stdlib-jdk8-$KOTLIN_VERSION",
             "arrow-core-data-$ARROW_VERSION",
             "arrow-fx-$ARROW_VERSION",
+            "arrow-fx-coroutines-$ARROW_VERSION",
             "arrow-annotations-$ARROW_VERSION",
             "arrow-core-$ARROW_VERSION"
         ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 GROUP=io.arrow-kt
 VERSION_NAME=1.4.10-SNAPSHOT
 # Dependencies versions
-ARROW_VERSION=0.10.5
+ARROW_VERSION=0.11.0
 #
 # WARNING!
 #   It's not possible to downgrade the version of a bundled plugin in Intellij IDEA.


### PR DESCRIPTION
It's only used for documentation (Arrow Ank) so far.