### PR TITLE
IDE Plugin: allow update when SNAPSHOT

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -72,11 +72,12 @@ jobs:
       run: |
         ARTIFACT_ID=$(grep "<id>" idea-plugin/src/main/resources/META-INF/plugin.xml | cut -d'>' -f2 | cut -d'<' -f1)
         ARTIFACT_VERSION=${{ steps.properties.outputs.actual-version }}
+        ARTIFACT_VERSION_EXT=$(if [[ "$ARTIFACT_VERSION" == *-SNAPSHOT ]]; then echo "-"$(date +%s); else echo ""; fi)
         REPOSITORY_TYPE=${{ steps.properties.outputs.repository-type }}
         mkdir -p idea-plugin/latest-${REPOSITORY_TYPE}
         mkdir idea-plugin/${ARTIFACT_VERSION}
         sed -i "s/%ARTIFACT_ID%/${ARTIFACT_ID}/g" .github/workflows/templates/updatePlugins.xml
-        sed -i "s/%ARTIFACT_VERSION%/${ARTIFACT_VERSION}/g" .github/workflows/templates/updatePlugins.xml
+        sed -i "s/%ARTIFACT_VERSION%/${ARTIFACT_VERSION}${ARTIFACT_VERSION_EXT}/g" .github/workflows/templates/updatePlugins.xml
         sed -i "s/%REPOSITORY_TYPE%/${REPOSITORY_TYPE}/g" .github/workflows/templates/updatePlugins.xml
         cp .github/workflows/templates/updatePlugins.xml idea-plugin/latest-${REPOSITORY_TYPE}/
         cp .github/workflows/templates/updatePlugins.xml idea-plugin/${ARTIFACT_VERSION}/

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -40,15 +40,17 @@ Arrow Meta IDE Plugin is compatible with the same versions as [Kotlin Plugin for
 
 When using the Arrow Meta Gradle Plugin from Intellij IDEA, there is a Gradle task available to install the Arrow Meta IDE Plugin.
 
-This message will appear with every Gradle task execution if Arrow Meta IDE Plugin is not installed, for instance, when running a `clean` task:
+This message will appear with every Gradle task execution if Arrow Meta IDE Plugin isn't installed, for instance, when running a `clean` task:
 
 ```
 > Configure project :
 Arrow Meta IDE Plugin is not installed!
-Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it.
+Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it (choose just one project when multi-project)
+Receive update notifications when adding this custom repository: https://meta.arrow-kt.io/idea-plugin/latest-<version-type>/updatePlugins.xml
+Guideline: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
 ```
 
-Go to `Arrow Meta` group for Gradle tasks and run `install-idea-plugin`:
+Go to `Arrow Meta` group for Gradle tasks (choose just one project when multi-project) and run `install-idea-plugin`:
 
 ```
 > Task :install-idea-plugin
@@ -58,6 +60,8 @@ Restart Intellij IDEA to finish the installation!
 
 It will be necessary to restart the IDE to finish the installation.
 
+Receive update notifications when adding the custom repository (URLs in the next section).
+
 ### Λrrow Meta IDE Plugin: installation from a custom plugin repository
 
 There are two custom plugin repositories according to the correspondent version:
@@ -65,7 +69,9 @@ There are two custom plugin repositories according to the correspondent version:
 * For the latest SNAPSHOT version: `https://meta.arrow-kt.io/idea-plugin/latest-snapshot/updatePlugins.xml`
 * For the latest RELEASE version: `https://meta.arrow-kt.io/idea-plugin/latest-release/updatePlugins.xml`
 
-Follow the steps about the use of [Custom plugin repositories](https://www.jetbrains.com/help/idea/managing-plugins.html#install_plugin_from_repo) to install the Arrow Meta IDE Plugin.
+Follow the steps about the use of [Custom plugin repositories](https://www.jetbrains.com/help/idea/managing-plugins.html#repos) to install the Arrow Meta IDE Plugin.
+
+If the IDE plugin was installed via the Gradle task, add the custom repository to receive update notifications.
 
 ### Λrrow Meta IDE Plugin: installation from Jetbrains Plugins Repository
 
@@ -87,10 +93,10 @@ repositories {
     maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
 }
 
-
+// Since Intellij Gradle Plugin 0.5
 intellij {
     ...
-    plugins = ["io.arrow-kt.arrow:${ARROW_META_VERSION}"]
+    plugins = ["io.arrow-kt.arrow"]
     pluginsRepo { custom("https://meta.arrow-kt.io/idea-plugin/latest-snapshot/updatePlugins.xml") }
 }
 ```

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -45,12 +45,12 @@ This message will appear with every Gradle task execution if Arrow Meta IDE Plug
 ```
 > Configure project :
 Arrow Meta IDE Plugin is not installed!
-Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it (choose just one project when multi-project)
+Run 'install-idea-plugin' Gradle task to install it (under 'Tasks -> arrow meta' in Gradle tool window; choose just one project when multi-project)
 Receive update notifications when adding this custom repository: https://meta.arrow-kt.io/idea-plugin/latest-<version-type>/updatePlugins.xml
 Guideline: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
 ```
 
-Go to `Arrow Meta` group for Gradle tasks (choose just one project when multi-project) and run `install-idea-plugin`:
+Go to 'Tasks -> arrow meta' in Gradle tool window (choose just one project when multi-project) and run `install-idea-plugin`:
 
 ```
 > Task :install-idea-plugin

--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
@@ -42,17 +42,21 @@ class ArrowGradlePlugin : Plugin<Project> {
         it.kotlinOptions.freeCompilerArgs += "-Xplugin=${classpathOf("compiler-plugin:$compilerPluginVersion")}"
       }
     }
-    val installIdeaPluginTask = project.tasks.register("install-idea-plugin", InstallIdeaPlugin::class.java)
-    installIdeaPluginTask.configure { task ->
-      task.group = "Arrow Meta"
-      task.description = "Installs the correspondent Arrow Meta IDE Plugin if it's not already installed."
+    project.tasks.register("install-idea-plugin", InstallIdeaPlugin::class.java) {
+      it.group = "Arrow Meta"
+      it.description = "Installs the correspondent Arrow Meta IDE Plugin if it's not already installed."
     }
     when {
-      inIdea() && pluginsDirExists() && !ideaPluginExists() -> {
-        println("Arrow Meta IDE Plugin is not installed!")
-        println("Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it.")
-      }
+      inIdea() && pluginsDirExists() && !ideaPluginExists() -> { printMessageForInstallation(compilerPluginVersion) }
     }
+  }
+
+  private fun printMessageForInstallation(compilerPluginVersion: String): Unit {
+    val versionType = when { compilerPluginVersion.endsWith("SNAPSHOT") -> "snapshot" else -> "release" }
+    println("Arrow Meta IDE Plugin is not installed!")
+    println("Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it (choose just one project when multi-project)")
+    println("Receive update notifications when adding this custom repository: https://meta.arrow-kt.io/idea-plugin/latest-$versionType/updatePlugins.xml")
+    println("Guideline: https://www.jetbrains.com/help/idea/managing-plugins.html#repos")
   }
 
   private fun classpathOf(dependency: String): File {

--- a/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
+++ b/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ArrowGradlePlugin.kt
@@ -54,7 +54,7 @@ class ArrowGradlePlugin : Plugin<Project> {
   private fun printMessageForInstallation(compilerPluginVersion: String): Unit {
     val versionType = when { compilerPluginVersion.endsWith("SNAPSHOT") -> "snapshot" else -> "release" }
     println("Arrow Meta IDE Plugin is not installed!")
-    println("Run 'install-idea-plugin' Gradle task under 'Arrow Meta' group to install it (choose just one project when multi-project)")
+    println("Run 'install-idea-plugin' Gradle task to install it (under 'Tasks -> arrow meta' in Gradle tool window; choose just one project when multi-project)")
     println("Receive update notifications when adding this custom repository: https://meta.arrow-kt.io/idea-plugin/latest-$versionType/updatePlugins.xml")
     println("Guideline: https://www.jetbrains.com/help/idea/managing-plugins.html#repos")
   }


### PR DESCRIPTION
**Fixes this issue**: when installing Arrow Meta IDE Plugin SNAPSHOT version, the IDE doesn't show notifications to update the plugin.

**Changes**:
* Fix deployment of custom repository
* Update messages from the Arrow Meta Gradle plugin
* Update setup documentation
* Tiny code improvements