### PR TITLE
Add local copy of publication.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,10 +53,8 @@ subprojects { project ->
   }
 }
 
-configure(subprojects
-        - project("docs")
-) {
-  apply from: "https://raw.githubusercontent.com/arrow-kt/arrow/master/gradle/publication.gradle"
+configure(subprojects - project("docs")) {
+  apply from: "https://raw.githubusercontent.com/arrow-kt/arrow/master/arrow-libs/gradle/publication.gradle"
 }
 
 // To run tests for Arrow Meta IDEA Plugin


### PR DESCRIPTION
File content retrieved from the [last commit](https://github.com/arrow-kt/arrow/blob/cee775af92bac8e3b3f4bf06dbfd9784e782f359/gradle/publication.gradle) in arrow repository before the file was deleted.
Found by executing `git log --full-history -- ./gradle/publication.gradle` in arrow repository
Fix for https://github.com/arrow-kt/arrow-meta/issues/788