### PR TITLE
Configuration: remove Bintray et al.

### DIFF
--- a/.github/workflows/publish_artifacts.yml
+++ b/.github/workflows/publish_artifacts.yml
@@ -61,8 +61,10 @@ jobs:
         fi
     - name: Publish artifacts
       env:
-        BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-        BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
+        SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
+        SONATYPE_PWD: ${{ secrets.SONATYPE_PWD }}
+        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_signingKey }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_signingPassword }}
       run: |
         echo "NOTE: docs has its own publication workflows"
         echo "Uploading artifacts..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Λrrow Meta
 
-[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Fcompiler-plugin%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/compiler-plugin/)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=0576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.sonatype.org%2Fservice%2Flocal%2Frepositories%2Fsnapshots%2Fcontent%2Fio%2Farrow-kt%2Fcompiler-plugin%2Fmaven-metadata.xml)](https://oss.sonatype.org/service/local/repositories/snapshots/content/io/arrow-kt/compiler-plugin/)
 [![Publish artifacts](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Artifacts/badge.svg)](https://github.com/arrow-kt/arrow-meta/actions?query=workflow%3A%22Publish+Artifacts%22)
 [![Publish documentation](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Documentation/badge.svg)](https://github.com/arrow-kt/arrow-meta/actions?query=workflow%3A%22Publish+Documentation%22)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)

--- a/build.gradle
+++ b/build.gradle
@@ -25,16 +25,9 @@ allprojects {
   }
 
   repositories {
-    maven { url "https://kotlin.bintray.com/kotlinx" }
-    maven {
-      url "https://dl.bintray.com/arrow-kt/arrow-kt/"
-      content {
-        includeGroup "io.arrow-kt"
-      }
-    }
     mavenCentral()
-    jcenter()
-    maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+    jcenter() // TODO: Replace the use of org.celtric.kotlin:kotlin-html by kotlinx.html
   }
 }
 

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -1,8 +1,4 @@
 buildscript {
-  repositories {
-    mavenCentral()
-    maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
-  }
   dependencies {
     classpath "io.arrow-kt:arrow-ank-gradle:$ARROW_VERSION"
   }
@@ -104,3 +100,7 @@ task getLocalPaths {
 }
 
 compileKotlin.kotlinOptions.freeCompilerArgs += ["-Xskip-runtime-version-check"]
+
+afterEvaluate {
+    tasks.findByPath(':docs:runAnk').dependsOn ':idea-plugin:jar'
+}

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -5,7 +5,7 @@ permalink: /
 video: WKR384ZeBgk
 ---
 
-[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=%230576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.jfrog.org%2Fartifactory%2Foss-snapshot-local%2Fio%2Farrow-kt%2Fcompiler-plugin%2Fmaven-metadata.xml)](https://oss.jfrog.org/artifactory/oss-snapshot-local/io/arrow-kt/compiler-plugin/)
+[![Latest snapshot](https://img.shields.io/maven-metadata/v?color=0576b6&label=latest%20snapshot&metadataUrl=https%3A%2F%2Foss.sonatype.org%2Fservice%2Flocal%2Frepositories%2Fsnapshots%2Fcontent%2Fio%2Farrow-kt%2Fcompiler-plugin%2Fmaven-metadata.xml)](https://oss.sonatype.org/service/local/repositories/snapshots/content/io/arrow-kt/compiler-plugin/)
 [![Publish artifacts](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Artifacts/badge.svg)](https://github.com/arrow-kt/arrow-meta/actions?query=workflow%3A%22Publish+Artifacts%22)
 [![Publish documentation](https://github.com/arrow-kt/arrow-meta/workflows/Publish%20Documentation/badge.svg)](https://github.com/arrow-kt/arrow-meta/actions?query=workflow%3A%22Publish+Documentation%22)
 [![Kotlin version badge](https://img.shields.io/badge/kotlin-1.3-blue.svg)](https://kotlinlang.org/docs/reference/whatsnew13.html)

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -22,7 +22,7 @@ If using a SNAPSHOT version, it must be included with the legacy plugin applicat
 ```
 buildscript {
     repositories {
-        maven { url "https://oss.jfrog.org/artifactory/oss-snapshot-local/" }
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
     }
     dependencies {
         classpath "io.arrow-kt:gradle-plugin:<snapshot-version>"
@@ -90,7 +90,7 @@ dependencies {
 }
 
 repositories {
-    maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
+    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
 }
 
 // Since Intellij Gradle Plugin 0.5

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,17 +1,8 @@
 plugins {
+  id 'kotlin'
   id 'java-gradle-plugin'
   id 'com.gradle.plugin-publish' version "$GRADLE_PLUGIN_PUBLISH_VERSION"
 }
-
-repositories {
-  maven { url "https://kotlin.bintray.com/kotlinx" }
-  maven { url "https://dl.bintray.com/arrow-kt/arrow-kt/" }
-  maven { url 'https://oss.jfrog.org/artifactory/oss-snapshot-local/' }
-  mavenCentral()
-  jcenter()
-}
-
-apply plugin: 'kotlin'
 
 group = 'io.arrow-kt'
 version = VERSION_NAME

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,7 +20,6 @@ CLASS_GRAPH_VERSION=4.8.47
 JUNIT_VERSION=5.7.0
 KOTLIN_COMPILE_TESTING=1.2.11
 SHADOW_JAR_VERSION=5.0.0
-BINTRAY_VERSION=1.8.4
 OPENAPI_VERSION=7.0.3
 GRADLE_PLUGIN_PUBLISH_VERSION=0.11.0
 INTELLIJ_GRADLE_PLUGIN_VERSION=0.4.21
@@ -40,8 +39,8 @@ kotlin.incremental=true
 #Parallelism needs to be set to 1 since the concurrent tests in arrow-effects become flaky otherwise
 kotlintest.parallelism=1
 # Publication
-RELEASE_REPOSITORY=https://api.bintray.com/maven/arrow-kt/arrow-kt/arrow
-SNAPSHOT_REPOSITORY=https://oss.jfrog.org/artifactory/oss-snapshot-local
+RELEASE_REPOSITORY=https://oss.sonatype.org/service/local/staging/deploy/maven2/
+SNAPSHOT_REPOSITORY=https://oss.sonatype.org/content/repositories/snapshots/
 # Pomfile definitions
 POM_DESCRIPTION=Arrow Meta
 POM_URL=https://github.com/arrow-kt/arrow-meta/


### PR DESCRIPTION
## Previous steps

- Change in `arrow` repository: https://github.com/arrow-kt/arrow/pull/2371
- Create new secrets:
  * `SONATYPE_USER`
  * `SONATYPE_PWD`
  * `ORG_GRADLE_PROJECT_signingKey`
  * `ORG_GRADLE_PROJECT_signingPassword`

## Changes

- Replace OSS JFrog snapshots repository by Sonatype OSSRH snapshots repository.
- Replace Bintray repository by Sonatype OSSRH releases repository (a staging repository is created before).
- Update badges.
- Update documentation.

## Next steps

- Remove Bintray secrets.
- Notify the new SNAPSHOTS repository.
- Remove `1.4.10-SNAPSHOT` from OSS JFrog to avoid misunderstandings.
- Update `arrow-meta-examples`.