### PR TITLE
Update multiplatform configuration

### DIFF
--- a/arrow-refined-types/build.gradle
+++ b/arrow-refined-types/build.gradle
@@ -12,12 +12,9 @@ kotlin {
         commonTest {
             dependencies {
                 compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
-                implementation "io.kotest:kotest-runner-junit5:$KOTEST_VERSION"
                 implementation "io.kotest:kotest-property:$KOTEST_VERSION"
                 implementation "io.kotest:kotest-assertions-core:$KOTEST_VERSION"
-
-                // To avoid issues in the IDE
-                implementation "io.kotest:kotest-framework-api-jvm:$KOTEST_VERSION"
+                implementation "io.kotest:kotest-framework-api:$KOTEST_VERSION"
             }
         }
         jvmMain {
@@ -42,6 +39,10 @@ kotlin {
                 jvmTarget = "1.8"
             }
         }
+    }
+
+    js {
+        nodejs()
     }
 }
 

--- a/arrow-refined-types/build.gradle
+++ b/arrow-refined-types/build.gradle
@@ -42,6 +42,7 @@ kotlin {
     }
 
     js {
+        browser()
         nodejs()
     }
 }

--- a/arrow-refined-types/src/commonTest/kotlin/arrow/refinement.tests/RefinedArb.kt
+++ b/arrow-refined-types/src/commonTest/kotlin/arrow/refinement.tests/RefinedArb.kt
@@ -41,7 +41,7 @@ fun <A, B> checkLaw(
 }
 
 abstract class RefinedLaws<A>(arb: Arb<A>, vararg refined: Refined<A, *>) : StringSpec({
-  println("Running laws for ${refined.map { it::class.simpleName }.joinToString()}")
+  println("Running laws for ${refined.joinToString { it::class.toString() }}")
   refined.forEach {
     it::class.simpleName?.invoke { it.laws(arb)  }
   }

--- a/arrow-refined-types/src/commonTest/kotlin/arrow/refinement.tests/RefinedArb.kt
+++ b/arrow-refined-types/src/commonTest/kotlin/arrow/refinement.tests/RefinedArb.kt
@@ -41,8 +41,8 @@ fun <A, B> checkLaw(
 }
 
 abstract class RefinedLaws<A>(arb: Arb<A>, vararg refined: Refined<A, *>) : StringSpec({
-  println("Running laws for ${refined.map { it::class.qualifiedName }.joinToString()}")
+  println("Running laws for ${refined.map { it::class.simpleName }.joinToString()}")
   refined.forEach {
-    it::class.qualifiedName?.invoke { it.laws(arb)  }
+    it::class.simpleName?.invoke { it.laws(arb)  }
   }
 })

--- a/build.gradle
+++ b/build.gradle
@@ -1,22 +1,18 @@
+buildscript {
+  ext.set("PATH_APIDOCS", "${rootDir}/docs/docs/apidocs")
+}
+
 plugins {
-  id 'org.jetbrains.kotlin.jvm' version "$KOTLIN_VERSION"
+  id 'org.jetbrains.kotlin.jvm' version "$KOTLIN_VERSION" apply false
   id "org.jetbrains.dokka" version "$DOKKA_VERSION" apply false
 }
 
-def pathApiDocs = "${rootDir}/docs/docs/apidocs"
-
-configure(subprojects
-        - project("docs")
+configure(subprojects - project("docs")
 ) {
-  // Documentation
-  clean.doFirst {
-    delete pathApiDocs
-  }
-
   apply plugin: "org.jetbrains.dokka"
   dokka {
     outputFormat = 'jekyll'
-    outputDirectory = pathApiDocs
+    outputDirectory = PATH_APIDOCS
     configuration {
         includes = ['README.md']
     }
@@ -27,9 +23,9 @@ configure(subprojects
   version = VERSION_NAME
 }
 
-configure(subprojects
-        - project("docs")
-        - project("arrow-refined-types")
+configure(subprojects -
+        project("docs") -
+        project("arrow-refined-types")
 ) {
   afterEvaluate {
     jar {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -25,4 +25,8 @@ ank {
   classpath = sourceSets.main.runtimeClasspath
 }
 
+clean.doFirst {
+  delete PATH_APIDOCS
+}
+
 compileKotlin.kotlinOptions.freeCompilerArgs += ["-Xskip-runtime-version-check"]

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'kotlin'
+  id 'org.jetbrains.kotlin.jvm'
   id 'java-gradle-plugin'
   id 'com.gradle.plugin-publish' version "$GRADLE_PLUGIN_PUBLISH_VERSION"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,13 @@
 # Package definitions
 GROUP=io.arrow-kt
 VERSION_NAME=1.5.0-SNAPSHOT
+
 # Dependencies versions
 ARROW_VERSION=0.11.0
 KOTLIN_VERSION=1.5.0
 JVM_TARGET_VERSION=1.8
 KOTLIN_TEST_VERSION=3.4.2
-KOTEST_VERSION=4.5.0
+KOTEST_VERSION=4.6.0
 ASSERTJ_VERSION=3.13.2
 DOKKA_VERSION=0.10.0
 CLASS_GRAPH_VERSION=4.8.47
@@ -18,18 +19,24 @@ KOTLIN_HTML_VERSION=0.1.4
 JCABI_AETHER_VERSION=0.10.1
 ATOMICFU_VERSION=0.14.3
 AETHER_API_VERSION=1.13.1
+
 # Gradle options
 org.gradle.jvmargs=-Xmx4g
 org.gradle.parallel=true
+
 # Kotlin configuration
 kotlin.incremental=true
-kotlin.stdlib.default.dependency=false
+# Reason: https://youtrack.jetbrains.com/issue/KT-46847
+# kotlin.stdlib.default.dependency=false
+
 # Kotlin Test configuration
 #Parallelism needs to be set to 1 since the concurrent tests in arrow-effects become flaky otherwise
 kotlintest.parallelism=1
+
 # Publication
 RELEASE_REPOSITORY=https://oss.sonatype.org/service/local/staging/deploy/maven2/
 SNAPSHOT_REPOSITORY=https://oss.sonatype.org/content/repositories/snapshots/
+
 # Pomfile definitions
 POM_DESCRIPTION=Arrow Meta
 POM_URL=https://github.com/arrow-kt/arrow-meta/


### PR DESCRIPTION
- Add `js` target
- Update dependencies to make it work for both targets (IDE included)
- Small fix in tests to make them run for `js` target as well
- Remove `kotlin.stdlib.default.dependency=false` because of https://youtrack.jetbrains.com/issue/KT-46847
- Fix the application of Kotlin JVM plugin
- Extract and relocate code to be able to customize `clean` task