### PR TITLE
Update MPP configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,8 +30,7 @@ SUBPROJECT_MPP=gradle/subproject-mpp.gradle
 
 # Kotlin configuration
 kotlin.incremental=true
-# Reason: https://youtrack.jetbrains.com/issue/KT-46847
-# kotlin.stdlib.default.dependency=false
+kotlin.stdlib.default.dependency=false
 
 # Kotlin Test configuration
 #Parallelism needs to be set to 1 since the concurrent tests in arrow-effects become flaky otherwise

--- a/gradle/subproject-mpp.gradle
+++ b/gradle/subproject-mpp.gradle
@@ -2,12 +2,12 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+                compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:$KOTLIN_VERSION"
             }
         }
         commonTest {
             dependencies {
-                compileOnly "org.jetbrains.kotlin:kotlin-stdlib:$KOTLIN_VERSION"
+                compileOnly "org.jetbrains.kotlin:kotlin-stdlib-common:$KOTLIN_VERSION"
                 implementation "io.kotest:kotest-property:$KOTEST_VERSION"
                 implementation "io.kotest:kotest-assertions-core:$KOTEST_VERSION"
                 implementation "io.kotest:kotest-framework-api:$KOTEST_VERSION"
@@ -24,6 +24,16 @@ kotlin {
                 implementation "io.kotest:kotest-runner-junit5:$KOTEST_VERSION"
                 implementation "io.kotest:kotest-property:$KOTEST_VERSION"
                 implementation "io.kotest:kotest-assertions-core:$KOTEST_VERSION"
+            }
+        }
+        jsMain {
+            dependencies {
+                compileOnly "org.jetbrains.kotlin:kotlin-stdlib-js:$KOTLIN_VERSION"
+            }
+        }
+        jsTest {
+            dependencies {
+                compileOnly "org.jetbrains.kotlin:kotlin-stdlib-js:$KOTLIN_VERSION"
             }
         }
     }


### PR DESCRIPTION
To recover the use of `kotlin.stdlib.default.dependency` property