### PR TITLE
This test should pass or fail?

### DIFF
--- a/proofs-plugin/src/test/kotlin/arrow/meta/plugins/proofs/ResolutionTests.kt
+++ b/proofs-plugin/src/test/kotlin/arrow/meta/plugins/proofs/ResolutionTests.kt
@@ -59,6 +59,44 @@ class ResolutionTests {
     }
   }
 
+    @Test
+    fun `This test should pass or fail`() {
+        givenResolutionTest(
+            source =
+                """
+          
+        class RemoteDataSource {            
+            fun getUser(): String = "Javier"
+        }     
+
+        @Given     
+        fun givenRemoteDataSource(): RemoteDataSource = RemoteDataSource()   
+                    
+        interface GetUser {
+            operator fun invoke(): String
+        }
+        
+        @Given
+        class GetUserImpl(
+            private val remoteDataSource: RemoteDataSource = given(),
+        ) : GetUser {
+            override operator fun invoke(): String = remoteDataSource.getUser()
+        }
+        
+        @Given
+        class UserViewModel(
+            private val getUser: GetUser = given(),
+        ) {
+            fun loadUser(): String = getUser()
+        }                            
+        
+        val viewModel: UserViewModel = given()
+        val name = viewModel.loadUser()
+                
+      """
+        ) { allOf("name".source.evalsTo("Javier")) }
+    }
+
   @Test
   fun `@Given internal orphan override`() {
     givenResolutionTest(


### PR DESCRIPTION
Without adding `@Given` to parameters type inside a constructor, the test passes, should it fail?

```
@Given
class GetUserImpl(
	// should be `private val remoteDataSource: @Given RemoteDataSource = given()`?
    private val remoteDataSource: RemoteDataSource = given(),
) : GetUser {
    override operator fun invoke(): String = remoteDataSource.getUser()
}
```