### PR TITLE
Support for mutable variables

### DIFF
--- a/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
+++ b/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
@@ -16,14 +16,10 @@ inline fun <A> A.post(predicate: (A) -> Boolean, msg: () -> String): A {
   return this
 }
 
-inline fun <A> invariant(msg: String, predicate: (A) -> Boolean, value: () -> A): A {
-  val x = value()
-  require(predicate(x)) { msg }
-  return x
+inline infix fun <A> A.invariant(predicate: (A) -> Boolean): A {
+  require(predicate(this)) { "invariant" }
+  return this
 }
-
-inline fun <A> A.invariant(msg: String, predicate: (A) -> Boolean): A =
-  invariant(msg, predicate) { this }
 
 @Target(
   AnnotationTarget.FUNCTION

--- a/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
+++ b/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
@@ -16,6 +16,15 @@ inline fun <A> A.post(predicate: (A) -> Boolean, msg: () -> String): A {
   return this
 }
 
+inline fun <A> invariant(msg: String, predicate: (A) -> Boolean, value: () -> A): A {
+  val x = value()
+  require(predicate(x)) { msg }
+  return x
+}
+
+inline fun <A> A.invariant(msg: String, predicate: (A) -> Boolean): A =
+  invariant(msg, predicate) { this }
+
 @Target(
   AnnotationTarget.FUNCTION
 )

--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaDefaultErrorMessages.java
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaDefaultErrorMessages.java
@@ -33,7 +33,10 @@ public class MetaDefaultErrorMessages implements DefaultErrorMessages.Extension 
                 "unreachable code due to post-conditions: {1}",
                 FormulaRendererKt.RenderCall, FormulaRendererKt.RenderFormula);
         MAP.put(InconsistentConditions,
-                "unreachable code due to conflicting conditions: {1}",
+                "unreachable code due to conflicting conditions: {0}",
+                FormulaRendererKt.RenderFormula);
+        MAP.put(UnsatInvariants,
+                "invariants are not satisfied: {0}",
                 FormulaRendererKt.RenderFormula);
     }
 }

--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaErrors.java
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaErrors.java
@@ -19,6 +19,7 @@ public interface MetaErrors {
     DiagnosticFactory2<PsiElement, ResolvedCall<?>, List<Formula>> UnsatCallPre = DiagnosticFactory2.create(ERROR);
     DiagnosticFactory2<PsiElement, ResolvedCall<?>, List<Formula>> InconsistentCallPost = DiagnosticFactory2.create(ERROR);
     DiagnosticFactory1<PsiElement, List<Formula>> InconsistentConditions = DiagnosticFactory1.create(ERROR);
+    DiagnosticFactory1<PsiElement, List<Formula>> UnsatInvariants = DiagnosticFactory1.create(ERROR);
 
     /**
      * needed to prevent NPE in

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -146,7 +146,6 @@ fun bracketMutableVars(data: CheckData): ContSeq<Unit> = ContSeq {
   data.mutableVariables.putAll(currentMap)
 }
 
-
 // 2.1: declarations
 // -----------------
 /**
@@ -336,7 +335,6 @@ private fun SolverState.checkCallExpression(
           specialCase(result, arg1, arg2)?.let { addConstraint(it) }
         }.void()
   }
-
 
 /**
  * Recursively perform check on arguments,

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -431,15 +431,13 @@ private fun SolverState.checkMutableAssignment(
   invariant: BooleanFormula?,
   body: KtExpression?,
   data: CheckData
-): ContSeq<Unit> =
-  bracketMutableVars(data).map {
-    val newName = names.newName(declName)
-    data.mutableVariables[declName] = MutableVarInfo(invariant, newName)
-    newName
-  }.flatMap { newName ->
-    val newInvariant = invariant?.let { solver.rename(it, mapOf(declName to newName)) }
-    checkDeclarationExpressionWorker(element, newName, newInvariant, body, data)
-  }
+): ContSeq<Unit> {
+  val newName = names.newName(declName)
+  val newInvariant = invariant?.let { solver.rename(it, mapOf(declName to newName)) }
+  return checkDeclarationExpressionWorker(element, newName, newInvariant, body, data)
+    .flatMap { bracketMutableVars(data) }
+    .map { data.mutableVariables[declName] = MutableVarInfo(invariant, newName) }
+}
 
 /**
  * Checks the possible invariants of a declaration, and its body.

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -450,7 +450,7 @@ private fun SolverState.checkDeclarationExpressionWorker(
   data: CheckData
 ): ContSeq<Unit> =
   checkExpressionConstraints(declName, body, data).map {
-    checkInvariant(invariant, data.context, element)
+    invariant?.let { checkInvariant(it, data.context, element) }
   }
 
 private fun SolverState.obtainInvariant(
@@ -459,10 +459,7 @@ private fun SolverState.obtainInvariant(
 ): BooleanFormula? {
   val resolvedCall = expression?.getResolvedCall(data.context.trace.bindingContext)
   return if (resolvedCall != null && resolvedCall.invariantCall()) {
-    val thePredicate = resolvedCall.allArgumentExpressions().find {
-      it.first == "predicate"
-    }?.third
-    thePredicate?.let {
+    resolvedCall.arg("predicate")?.let {
       val formulae = solver.argsFormulae(data.context.trace.bindingContext, it)
       formulae[0] as? BooleanFormula
     }

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -78,56 +78,56 @@ internal const val RESULT_VAR_NAME = "${'$'}result"
  * check this [declaration] body constraints
  */
 internal fun CompilerContext.checkDeclarationConstraints(
-  context: DeclarationCheckerContext,
-  declaration: KtDeclaration,
-  descriptor: DeclarationDescriptor
+    context: DeclarationCheckerContext,
+    declaration: KtDeclaration,
+    descriptor: DeclarationDescriptor
 ) {
-  val solverState = get<SolverState>(SolverState.key(context.moduleDescriptor))
-  val constraints = solverState?.constraintsFromSolverState(descriptor)
-  if (solverState != null && solverState.isIn(SolverState.Stage.Prove)) {
-    // choose a good name for the result
-    // should we change it for 'val' declarations?
-    val resultVarName = RESULT_VAR_NAME
-    // clear the solverTrace (for debugging purposes only)
-    solverState.solverTrace.clear()
-    // now go on and check the body
-    declaration.stableBody()?.let { body ->
-      solverState.checkDeclarationWithBody(
-        constraints, context,
-        resultVarName, declaration, body
-      ).drain()
+    val solverState = get<SolverState>(SolverState.key(context.moduleDescriptor))
+    val constraints = solverState?.constraintsFromSolverState(descriptor)
+    if (solverState != null && solverState.isIn(SolverState.Stage.Prove)) {
+        // choose a good name for the result
+        // should we change it for 'val' declarations?
+        val resultVarName = RESULT_VAR_NAME
+        // clear the solverTrace (for debugging purposes only)
+        solverState.solverTrace.clear()
+        // now go on and check the body
+        declaration.stableBody()?.let { body ->
+            solverState.checkDeclarationWithBody(
+                constraints, context,
+                resultVarName, declaration, body
+            ).drain()
+        }
     }
-  }
 }
 
 // 2.0: data for the checks
 // ------------------------
 
 data class CheckData(
-  val context: DeclarationCheckerContext,
-  val returnPoints: ReturnPoints,
-  val mutableVariables: Map<String, MutableVarInfo>
+    val context: DeclarationCheckerContext,
+    val returnPoints: ReturnPoints,
+    val mutableVariables: Map<String, MutableVarInfo>
 ) {
-  fun addReturnPoint(returnPoint: String, variableName: String) =
-    CheckData(context, returnPoints.add(returnPoint, variableName), mutableVariables)
+    fun addReturnPoint(returnPoint: String, variableName: String) =
+        CheckData(context, returnPoints.add(returnPoint, variableName), mutableVariables)
 }
 
 /**
  * Maps return points to the SMT variables representing that place.
  */
 data class ReturnPoints(
-  val topMostReturnPointVariableName: String,
-  val namedReturnPointVariableNames: Map<String, String>
+    val topMostReturnPointVariableName: String,
+    val namedReturnPointVariableNames: Map<String, String>
 ) {
 
-  // fun replaceTopMost(newVariableName: String) =
-  //   ReturnPoints(newVariableName, namedReturnPointVariableNames)
+    // fun replaceTopMost(newVariableName: String) =
+    //   ReturnPoints(newVariableName, namedReturnPointVariableNames)
 
-  fun add(returnPoint: String, variableName: String) =
-    ReturnPoints(
-      topMostReturnPointVariableName,
-      namedReturnPointVariableNames + (returnPoint to variableName)
-    )
+    fun add(returnPoint: String, variableName: String) =
+        ReturnPoints(
+            topMostReturnPointVariableName,
+            namedReturnPointVariableNames + (returnPoint to variableName)
+        )
 }
 
 /**
@@ -136,8 +136,8 @@ data class ReturnPoints(
  * - the "current" internal name for it
  */
 data class MutableVarInfo(
-  val invariant: BooleanFormula?,
-  val currentName: String
+    val invariant: BooleanFormula?,
+    val currentName: String
 )
 
 // 2.1: declarations
@@ -150,23 +150,23 @@ data class MutableVarInfo(
  * - whether the post-condition really holds.
  */
 private fun SolverState.checkDeclarationWithBody(
-  constraints: DeclarationConstraints?,
-  context: DeclarationCheckerContext,
-  resultVarName: String,
-  declaration: KtDeclaration,
-  body: KtExpression?
+    constraints: DeclarationConstraints?,
+    context: DeclarationCheckerContext,
+    resultVarName: String,
+    declaration: KtDeclaration,
+    body: KtExpression?
 ): ContSeq<Unit> =
-  continuationBracket.andThen {
-    val inconsistentPreconditions =
-      checkPreconditionsInconsistencies(constraints, context, declaration)
-    ensure<Unit>(!inconsistentPreconditions)
-    goOn()
-  }.flatMap {
-    val data = CheckData(context, ReturnPoints(resultVarName, emptyMap()), emptyMap())
-    checkExpressionConstraints(resultVarName, body, data)
-  }.andThenSideEffect {
-    checkPostConditionsImplication(constraints, context, declaration)
-  }
+    continuationBracket.andThen {
+        val inconsistentPreconditions =
+            checkPreconditionsInconsistencies(constraints, context, declaration)
+        ensure<Unit>(!inconsistentPreconditions)
+        goOn()
+    }.flatMap {
+        val data = CheckData(context, ReturnPoints(resultVarName, emptyMap()), emptyMap())
+        checkExpressionConstraints(resultVarName, body, data)
+    }.andThenSideEffect {
+        checkPostConditionsImplication(constraints, context, declaration)
+    }
 
 // 2.2: expressions
 // ----------------
@@ -176,50 +176,50 @@ private fun SolverState.checkDeclarationWithBody(
  * recursively checks an [expression] set of constraints
  */
 private fun SolverState.checkExpressionConstraints(
-  associatedVarName: String,
-  expression: KtExpression?,
-  data: CheckData
+    associatedVarName: String,
+    expression: KtExpression?,
+    data: CheckData
 ): ContSeq<Unit> =
-  when (expression) {
-    is KtParenthesizedExpression ->
-      checkExpressionConstraints(associatedVarName, expression.expression, data)
-    is KtBlockExpression ->
-      checkBlockExpression(associatedVarName, expression.statements, data)
-    is KtReturnExpression ->
-      checkReturnConstraints(expression, data)
-    is KtConstantExpression ->
-      checkConstantExpression(associatedVarName, expression)
-    is KtSimpleNameExpression ->
-      checkNameExpression(associatedVarName, expression)
-    is KtLabeledExpression ->
-      checkExpressionConstraints(
-        associatedVarName, expression.baseExpression,
-        // add the return point to the list and recur
-        data.addReturnPoint(expression.name!!, associatedVarName)
-      )
-    is KtDeclaration ->
-      checkDeclarationExpression(expression, data)
-    is KtIfExpression ->
-      checkSimpleConditional(associatedVarName, expression.computeSimpleConditions(), data)
-    is KtWhenExpression ->
-      if (expression.subjectExpression != null) {
-        doNothing // TODO: handle `when` with subject
-      } else {
-        checkSimpleConditional(associatedVarName, expression.computeSimpleConditions(), data)
-      }
-    else -> {
-      // fall-through case
-      // try to treat it as a function call (for +, -, and so on)
-      val resolvedCall = expression?.getResolvedCall(data.context.trace.bindingContext)
-      doOnlyWhen(resolvedCall != null) {
-        checkCallExpression(associatedVarName, expression!!, resolvedCall!!, data)
-      }
+    when (expression) {
+        is KtParenthesizedExpression ->
+            checkExpressionConstraints(associatedVarName, expression.expression, data)
+        is KtBlockExpression ->
+            checkBlockExpression(associatedVarName, expression.statements, data)
+        is KtReturnExpression ->
+            checkReturnConstraints(expression, data)
+        is KtConstantExpression ->
+            checkConstantExpression(associatedVarName, expression)
+        is KtSimpleNameExpression ->
+            checkNameExpression(associatedVarName, expression)
+        is KtLabeledExpression ->
+            checkExpressionConstraints(
+                associatedVarName, expression.baseExpression,
+                // add the return point to the list and recur
+                data.addReturnPoint(expression.name!!, associatedVarName)
+            )
+        is KtDeclaration ->
+            checkDeclarationExpression(expression, data)
+        is KtIfExpression ->
+            checkSimpleConditional(associatedVarName, expression.computeSimpleConditions(), data)
+        is KtWhenExpression ->
+            if (expression.subjectExpression != null) {
+                doNothing // TODO: handle `when` with subject
+            } else {
+                checkSimpleConditional(associatedVarName, expression.computeSimpleConditions(), data)
+            }
+        else -> {
+            // fall-through case
+            // try to treat it as a function call (for +, -, and so on)
+            val resolvedCall = expression?.getResolvedCall(data.context.trace.bindingContext)
+            doOnlyWhen(resolvedCall != null) {
+                checkCallExpression(associatedVarName, expression!!, resolvedCall!!, data)
+            }
+        }
     }
-  }
 
 private fun KtDeclaration.isVar(): Boolean = when (this) {
-  is KtVariableDeclaration -> this.isVar
-  else -> false
+    is KtVariableDeclaration -> this.isVar
+    else -> false
 }
 
 /**
@@ -228,23 +228,23 @@ private fun KtDeclaration.isVar(): Boolean = when (this) {
  * is the one assigned as the "return value" of the block.
  */
 private fun SolverState.checkBlockExpression(
-  associatedVarName: String,
-  expressions: List<KtExpression>,
-  data: CheckData
+    associatedVarName: String,
+    expressions: List<KtExpression>,
+    data: CheckData
 ): ContSeq<Unit> =
-  when (expressions.size) {
-    0 -> doNothing
-    1 -> // this is the last element, so it's the return value of the expression
-      checkExpressionConstraints(associatedVarName, expressions[0], data)
-    else -> {
-      val first = expressions[0]
-      val remainder = expressions.drop(1)
-      val inventedName = names.newName("stmt")
-      checkExpressionConstraints(inventedName, first, data).flatMap {
-        checkBlockExpression(associatedVarName, remainder, data)
-      }
+    when (expressions.size) {
+        0 -> doNothing
+        1 -> // this is the last element, so it's the return value of the expression
+            checkExpressionConstraints(associatedVarName, expressions[0], data)
+        else -> {
+            val first = expressions[0]
+            val remainder = expressions.drop(1)
+            val inventedName = names.newName("stmt")
+            checkExpressionConstraints(inventedName, first, data).flatMap {
+                checkBlockExpression(associatedVarName, remainder, data)
+            }
+        }
     }
-  }
 
 /**
  * Checks a 'return' or 'return@label' statement.
@@ -252,18 +252,18 @@ private fun SolverState.checkBlockExpression(
  * after a return there's nothing else to be checked.
  */
 private fun SolverState.checkReturnConstraints(
-  expression: KtReturnExpression,
-  data: CheckData
+    expression: KtReturnExpression,
+    data: CheckData
 ): ContSeq<Unit> {
-  // figure out the right variable to assign
-  // - if 'return@label', find the label in the recorded return points
-  // - otherwise, it should be the top-most one
-  val returnVarName = expression.getLabelName()?.let {
-    data.returnPoints.namedReturnPointVariableNames[it]
-  } ?: data.returnPoints.topMostReturnPointVariableName
-  // and now assign it
-  return checkExpressionConstraints(returnVarName, expression.returnedExpression, data)
-          .andThen { abort() } // Stop the computation after this
+    // figure out the right variable to assign
+    // - if 'return@label', find the label in the recorded return points
+    // - otherwise, it should be the top-most one
+    val returnVarName = expression.getLabelName()?.let {
+        data.returnPoints.namedReturnPointVariableNames[it]
+    } ?: data.returnPoints.topMostReturnPointVariableName
+    // and now assign it
+    return checkExpressionConstraints(returnVarName, expression.returnedExpression, data)
+        .andThen { abort() } // Stop the computation after this
 }
 
 /**
@@ -272,42 +272,42 @@ private fun SolverState.checkReturnConstraints(
  * starting from its arguments
  */
 private fun SolverState.checkCallExpression(
-  associatedVarName: String,
-  expression: KtExpression,
-  resolvedCall: ResolvedCall<out CallableDescriptor>,
-  data: CheckData
+    associatedVarName: String,
+    expression: KtExpression,
+    resolvedCall: ResolvedCall<out CallableDescriptor>,
+    data: CheckData
 ): ContSeq<Unit> =
-  when (val specialCase = specialCasingForResolvedCalls(resolvedCall)) {
-    null ->
-      checkCallArguments(resolvedCall, data)
-        .map { it.toMap() }
-        .andThen { argVars ->
-          val callConstraints = constraintsFromSolverState(resolvedCall)?.let {
-            val completeRenaming = argVars + (RESULT_VAR_NAME to associatedVarName)
-            solver.renameDeclarationConstraints(it, completeRenaming)
-          }
-          // check pre-conditions and post-conditions
-          checkCallPreConditionsImplication(callConstraints, data.context, expression, resolvedCall)
-          val inconsistentPostConditions =
-            checkCallPostConditionsInconsistencies(callConstraints, data.context, expression, resolvedCall)
-          // there's no point in continuing if we are in an inconsistent position
-          ensure(!inconsistentPostConditions)
-          goOn()
-        }
-    else ->
-      checkCallArguments(resolvedCall, data)
-        .andThen { argVars ->
-          val result =
-            if (expression.kotlinType(data.context.trace.bindingContext)?.isBoolean() == true)
-              solver.makeBooleanObjectVariable(associatedVarName)
-            else
-              solver.makeIntegerObjectVariable(associatedVarName)
-          val arg1 = solver.makeIntegerObjectVariable(argVars[0].second)
-          val arg2 = solver.makeIntegerObjectVariable(argVars[1].second)
-          specialCase(result, arg1, arg2)?.let { addConstraint(it) }
-          goOn()
-        }
-  }
+    when (val specialCase = specialCasingForResolvedCalls(resolvedCall)) {
+        null ->
+            checkCallArguments(resolvedCall, data)
+                .map { it.toMap() }
+                .andThen { argVars ->
+                    val callConstraints = constraintsFromSolverState(resolvedCall)?.let {
+                        val completeRenaming = argVars + (RESULT_VAR_NAME to associatedVarName)
+                        solver.renameDeclarationConstraints(it, completeRenaming)
+                    }
+                    // check pre-conditions and post-conditions
+                    checkCallPreConditionsImplication(callConstraints, data.context, expression, resolvedCall)
+                    val inconsistentPostConditions =
+                        checkCallPostConditionsInconsistencies(callConstraints, data.context, expression, resolvedCall)
+                    // there's no point in continuing if we are in an inconsistent position
+                    ensure(!inconsistentPostConditions)
+                    goOn()
+                }
+        else ->
+            checkCallArguments(resolvedCall, data)
+                .andThen { argVars ->
+                    val result =
+                        if (expression.kotlinType(data.context.trace.bindingContext)?.isBoolean() == true)
+                            solver.makeBooleanObjectVariable(associatedVarName)
+                        else
+                            solver.makeIntegerObjectVariable(associatedVarName)
+                    val arg1 = solver.makeIntegerObjectVariable(argVars[0].second)
+                    val arg2 = solver.makeIntegerObjectVariable(argVars[1].second)
+                    specialCase(result, arg1, arg2)?.let { addConstraint(it) }
+                    goOn()
+                }
+    }
 
 /**
  * Recursively perform check on arguments,
@@ -319,18 +319,18 @@ private fun SolverState.checkCallExpression(
  *   this creates a renaming for the original constraints
  */
 private fun SolverState.checkCallArguments(
-  resolvedCall: ResolvedCall<out CallableDescriptor>,
-  data: CheckData
+    resolvedCall: ResolvedCall<out CallableDescriptor>,
+    data: CheckData
 ): ContSeq<List<Pair<String, String>>> =
-  resolvedCall.allArgumentExpressions().map { (name, _, expr) ->
-      val argUniqueName =
-        if (expr != null && solver.isResultReference(expr, data.context.trace.bindingContext)) {
-          RESULT_VAR_NAME
-        } else {
-          names.newName(name)
-        }
-      checkExpressionConstraints(argUniqueName, expr, data)
-        .map { name to argUniqueName }
+    resolvedCall.allArgumentExpressions().map { (name, _, expr) ->
+        val argUniqueName =
+            if (expr != null && solver.isResultReference(expr, data.context.trace.bindingContext)) {
+                RESULT_VAR_NAME
+            } else {
+                names.newName(name)
+            }
+        checkExpressionConstraints(argUniqueName, expr, data)
+            .map { name to argUniqueName }
     }.sequence()
 
 /**
@@ -339,37 +339,37 @@ private fun SolverState.checkCallArguments(
  * [SolverState.prover] constraints.
  */
 private fun SolverState.checkConstantExpression(
-  associatedVarName: String,
-  expression: KtConstantExpression
+    associatedVarName: String,
+    expression: KtConstantExpression
 ): ContSeq<Unit> = sideEffect {
-  solver.formulae {
-    val mayBoolean = expression.text.toBooleanStrictOrNull()
-    val mayInteger = expression.text.toBigIntegerOrNull()
-    val mayRational = expression.text.toBigDecimalOrNull()
-    when {
-      mayBoolean == true ->
-        solver.makeBooleanObjectVariable(associatedVarName)
-      mayBoolean == false ->
-        solver.booleans { not(solver.makeBooleanObjectVariable(associatedVarName)) }
-      mayInteger != null ->
-        solver.ints {
-          equal(
-            solver.makeIntegerObjectVariable(associatedVarName),
-            makeNumber(mayInteger)
-          )
+    solver.formulae {
+        val mayBoolean = expression.text.toBooleanStrictOrNull()
+        val mayInteger = expression.text.toBigIntegerOrNull()
+        val mayRational = expression.text.toBigDecimalOrNull()
+        when {
+            mayBoolean == true ->
+                solver.makeBooleanObjectVariable(associatedVarName)
+            mayBoolean == false ->
+                solver.booleans { not(solver.makeBooleanObjectVariable(associatedVarName)) }
+            mayInteger != null ->
+                solver.ints {
+                    equal(
+                        solver.makeIntegerObjectVariable(associatedVarName),
+                        makeNumber(mayInteger)
+                    )
+                }
+            mayRational != null ->
+                solver.rationals {
+                    equal(
+                        solver.decimalValue(solver.makeObjectVariable(associatedVarName)),
+                        makeNumber(mayRational)
+                    )
+                }
+            else -> null
+        }?.let {
+            addConstraint(it)
         }
-      mayRational != null ->
-        solver.rationals {
-          equal(
-            solver.decimalValue(solver.makeObjectVariable(associatedVarName)),
-            makeNumber(mayRational)
-          )
-        }
-      else -> null
-    }?.let {
-      addConstraint(it)
     }
-  }
 }
 
 /**
@@ -377,38 +377,38 @@ private fun SolverState.checkConstantExpression(
  * equal to the value encoded in the named expression.
  */
 private fun SolverState.checkDeclarationExpression(
-  declaration: KtDeclaration,
-  data: CheckData
+    declaration: KtDeclaration,
+    data: CheckData
 ): ContSeq<Unit> {
-  val declName = when (declaration) {
-    // use the given name if available
-    is KtNamedDeclaration -> declaration.nameAsSafeName.asString()
-    else -> names.newName("decl")
-  }
-  val body = declaration.stableBody()
-  val invariant = obtainInvariant(body, data)
-  // TODO update declName and invariant with the variable names
-  return sideEffect {
-    invariant?.let { addConstraint(it) }
-  }.flatMap {
-    checkExpressionConstraints(declName, body, data)
-  }
+    val declName = when (declaration) {
+        // use the given name if available
+        is KtNamedDeclaration -> declaration.nameAsSafeName.asString()
+        else -> names.newName("decl")
+    }
+    val body = declaration.stableBody()
+    val invariant = obtainInvariant(body, data)
+    // TODO update declName and invariant with the variable names
+    return sideEffect {
+        invariant?.let { addConstraint(it) }
+    }.flatMap {
+        checkExpressionConstraints(declName, body, data)
+    }
 }
 
 private fun SolverState.obtainInvariant(
-  expression: KtExpression?,
-  data: CheckData
+    expression: KtExpression?,
+    data: CheckData
 ): BooleanFormula? {
-  val resolvedCall = expression?.getResolvedCall(data.context.trace.bindingContext)
-  return if (resolvedCall != null && resolvedCall.invariantCall()) {
-    resolvedCall.allArgumentExpressions().find {
-      it.first == "predicate"
-    }?.third?.let { theInvariant ->
-      TODO()
+    val resolvedCall = expression?.getResolvedCall(data.context.trace.bindingContext)
+    return if (resolvedCall != null && resolvedCall.invariantCall()) {
+        resolvedCall.allArgumentExpressions().find {
+            it.first == "predicate"
+        }?.third?.let { theInvariant ->
+            TODO()
+        }
+    } else {
+        null
     }
-  } else {
-    null
-  }
 }
 
 /**
@@ -417,14 +417,14 @@ private fun SolverState.obtainInvariant(
  * to the [SolverState.prover] constraints.
  */
 private fun SolverState.checkNameExpression(
-  associatedVarName: String,
-  expression: KtSimpleNameExpression
+    associatedVarName: String,
+    expression: KtSimpleNameExpression
 ): ContSeq<Unit> = sideEffect {
-  // FIX: add only things in scope
-  val referencedName = expression.getReferencedName().nameAsSafeName().asString()
-  solver.objects {
-    equal(solver.makeObjectVariable(associatedVarName), solver.makeObjectVariable(referencedName))
-  }.let { addConstraint(it) }
+    // FIX: add only things in scope
+    val referencedName = expression.getReferencedName().nameAsSafeName().asString()
+    solver.objects {
+        equal(solver.makeObjectVariable(associatedVarName), solver.makeObjectVariable(referencedName))
+    }.let { addConstraint(it) }
 }
 
 /**
@@ -433,60 +433,63 @@ private fun SolverState.checkNameExpression(
 data class Condition(val condition: KtExpression?, val body: KtExpression, val whole: KtElement)
 
 private fun KtExpression.computeSimpleConditions(): List<Condition> = when (this) {
-  is KtIfExpression ->
-    listOf(
-      Condition(condition!!, then!!, then!!),
-      Condition(null, `else`!!, `else`!!)
-    )
-  is KtWhenExpression ->
-    entries.flatMap { entry ->
-      if (entry.conditions.isEmpty()) {
-        listOf(Condition(null, entry.expression!!, entry))
-      } else {
-        entry.conditions.toList().mapNotNull { cond -> when (cond) {
-          is KtWhenConditionWithExpression ->
-            Condition(cond.expression!!, entry.expression!!, entry)
-          else -> null
-        } }
-      } }
-  else -> emptyList()
+    is KtIfExpression ->
+        listOf(
+            Condition(condition!!, then!!, then!!),
+            Condition(null, `else`!!, `else`!!)
+        )
+    is KtWhenExpression ->
+        entries.flatMap { entry ->
+            if (entry.conditions.isEmpty()) {
+                listOf(Condition(null, entry.expression!!, entry))
+            } else {
+                entry.conditions.toList().mapNotNull { cond ->
+                    when (cond) {
+                        is KtWhenConditionWithExpression ->
+                            Condition(cond.expression!!, entry.expression!!, entry)
+                        else -> null
+                    }
+                }
+            }
+        }
+    else -> emptyList()
 }
 
 /**
  * Check `if` and `when` expressions without subject.
  */
 private fun SolverState.checkSimpleConditional(
-  associatedVarName: String,
-  branches: List<Condition>,
-  data: CheckData
+    associatedVarName: String,
+    branches: List<Condition>,
+    data: CheckData
 ): ContSeq<Unit> =
-  branches.map { cond ->
-    val conditionVar = names.newName("cond")
-    // introduce the condition
-    (cond.condition?.let {
-      checkExpressionConstraints(conditionVar, it, data)
-    } ?: sideEffect {
-      // if we have no condition, it's equivalent to true
-      addConstraint(solver.makeBooleanObjectVariable(conditionVar))
-    }).map { Pair(cond, conditionVar) }
-  }.sequence().flatMap { conditionInformation ->
-    ContSeq {
-      yieldAll(yesNo(conditionInformation))
-    }.flatMap { (cond, correspondingVars) ->
-        continuationBracket
-          .andThen {
-            // assert the variables and check that we are consistent
-            val inconsistentEnvironment =
-              checkConditionsInconsistencies(correspondingVars, data.context, cond.whole)
-            // it only makes sense to continue if we are not consistent
-            guard<Unit>(!inconsistentEnvironment)
-            goOn()
-          }.flatMap {
-            // check the body
-            checkExpressionConstraints(associatedVarName, cond.body, data)
-          }
-      }
-  }
+    branches.map { cond ->
+        val conditionVar = names.newName("cond")
+        // introduce the condition
+        (cond.condition?.let {
+            checkExpressionConstraints(conditionVar, it, data)
+        } ?: sideEffect {
+            // if we have no condition, it's equivalent to true
+            addConstraint(solver.makeBooleanObjectVariable(conditionVar))
+        }).map { Pair(cond, conditionVar) }
+    }.sequence().flatMap { conditionInformation ->
+        ContSeq {
+            yieldAll(yesNo(conditionInformation))
+        }.flatMap { (cond, correspondingVars) ->
+            continuationBracket
+                .andThen {
+                    // assert the variables and check that we are consistent
+                    val inconsistentEnvironment =
+                        checkConditionsInconsistencies(correspondingVars, data.context, cond.whole)
+                    // it only makes sense to continue if we are not consistent
+                    guard<Unit>(!inconsistentEnvironment)
+                    goOn()
+                }.flatMap {
+                    // check the body
+                    checkExpressionConstraints(associatedVarName, cond.body, data)
+                }
+        }
+    }
 
 /**
  * Given a list of names for condition variables,
@@ -498,16 +501,18 @@ private fun SolverState.checkSimpleConditional(
  * - not a, not b, c
  */
 private fun <A> SolverState.yesNo(conditionVars: List<Pair<A, String>>): List<Pair<A, List<BooleanFormula>>> {
-  fun go(currents: List<Pair<A, String>>, acc: List<BooleanFormula>): List<Pair<A, List<BooleanFormula>>> =
-    if (currents.isEmpty()) {
-      emptyList()
-    } else { solver.booleans {
-      val varName = solver.makeBooleanObjectVariable(currents[0].second)
-      val nextValue = acc + listOf(varName)
-      val nextAcc = acc + listOf(not(varName))
-      listOf(Pair(currents[0].first, nextValue)) + go(currents.drop(1), nextAcc)
-    } }
-  return go(conditionVars, emptyList())
+    fun go(currents: List<Pair<A, String>>, acc: List<BooleanFormula>): List<Pair<A, List<BooleanFormula>>> =
+        if (currents.isEmpty()) {
+            emptyList()
+        } else {
+            solver.booleans {
+                val varName = solver.makeBooleanObjectVariable(currents[0].second)
+                val nextValue = acc + listOf(varName)
+                val nextAcc = acc + listOf(not(varName))
+                listOf(Pair(currents[0].first, nextValue)) + go(currents.drop(1), nextAcc)
+            }
+        }
+    return go(conditionVars, emptyList())
 }
 
 /**
@@ -516,8 +521,8 @@ private fun <A> SolverState.yesNo(conditionVars: List<Pair<A, String>>): List<Pa
  * That will recursively visit all body element as well and there we can match just in those we care.
  */
 private fun KtDeclaration.stableBody(): KtExpression? = when (this) {
-  is KtVariableDeclaration -> if (isVar) null else initializer
-  is KtDeclarationWithBody -> body()
-  is KtDeclarationWithInitializer -> initializer
-  else -> null
+    is KtVariableDeclaration -> if (isVar) null else initializer
+    is KtDeclarationWithBody -> body()
+    is KtDeclarationWithInitializer -> initializer
+    else -> null
 }

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintCollection.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintCollection.kt
@@ -311,6 +311,19 @@ private fun ResolvedCall<out CallableDescriptor>.preOrPostCall(): Boolean =
   preCall() || postCall()
 
 /**
+ * returns true if [this] resolved call is calling [arrow.refinement.invariant]
+ */
+internal fun ResolvedCall<out CallableDescriptor>.invariantCall(): Boolean =
+  resultingDescriptor.fqNameSafe == FqName("arrow.refinement.invariant")
+
+/**
+ * returns true if [this] resolved call is calling
+ * [arrow.refinement.pre] or [arrow.refinement.post] or [arrow.refinement.invariant]
+ */
+private fun ResolvedCall<out CallableDescriptor>.preOrPostOrInvariantCall(): Boolean =
+  preCall() || postCall() || invariantCall()
+
+/**
  * Translates a [resolvedCall] into an smt [BooleanFormula]
  * Ex.
  * ```kotlin
@@ -403,7 +416,7 @@ private fun Solver.argsFormulae(
   val results = arrayListOf<Formula>()
   val visitor = expressionRecursiveVisitor {
     val resolvedCall = it.getResolvedCall(bindingContext)
-    if (resolvedCall != null && !resolvedCall.preOrPostCall()) { // not match on the parent call
+    if (resolvedCall != null && !resolvedCall.preOrPostOrInvariantCall()) { // not match on the parent call
       val args = argsFormulae(resolvedCall, bindingContext)
       val descriptor = resolvedCall.resultingDescriptor
       val expressionFormula = formulaWithArgs(descriptor, args, resolvedCall)

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
@@ -130,3 +130,12 @@ internal fun SolverState.checkConditionsInconsistencies(
       MetaErrors.InconsistentConditions.on(expression.psiOrParent, unsatCore)
     )
   }
+
+internal fun SolverState.checkConditionsInconsistencies(
+  formula: BooleanFormula?,
+  context: DeclarationCheckerContext,
+  expression: KtElement
+): Boolean =
+  formula?.let {
+    checkConditionsInconsistencies(listOf(it), context, expression)
+  } ?: false

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
@@ -131,11 +131,15 @@ internal fun SolverState.checkConditionsInconsistencies(
     )
   }
 
-internal fun SolverState.checkConditionsInconsistencies(
+internal fun SolverState.checkInvariant(
   formula: BooleanFormula?,
   context: DeclarationCheckerContext,
   expression: KtElement
 ): Boolean =
-  formula?.let {
-    checkConditionsInconsistencies(listOf(it), context, expression)
-  } ?: false
+  formula?.let { formula ->
+    checkImplicationOf(formula) {
+      context.trace.report(
+        MetaErrors.UnsatInvariants.on(expression.psiOrParent, listOf(formula))
+      )
+    }
+  } ?: true

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
@@ -132,14 +132,12 @@ internal fun SolverState.checkConditionsInconsistencies(
   }
 
 internal fun SolverState.checkInvariant(
-  formula: BooleanFormula?,
+  formula: BooleanFormula,
   context: DeclarationCheckerContext,
   expression: KtElement
 ): Boolean =
-  formula?.let { formula ->
-    checkImplicationOf(formula) {
-      context.trace.report(
-        MetaErrors.UnsatInvariants.on(expression.psiOrParent, listOf(formula))
-      )
-    }
-  } ?: true
+  checkImplicationOf(formula) {
+    context.trace.report(
+      MetaErrors.UnsatInvariants.on(expression.psiOrParent, listOf(formula))
+    )
+  }

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -56,7 +56,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        var z = -1
+        var z = 0
         z = 2
         return z.post("greater than 0") { it > 0 }
       }
@@ -73,7 +73,7 @@ class LiquidDataflowTests {
       ${imports()}
       fun bar(x: Int): Int {
         var z = 2
-        z = -1
+        z = 0
         return z.post("greater than 0") { it > 0 }
       }
       """(

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -28,6 +28,61 @@ class LiquidDataflowTests {
   }
 
   @Test
+  fun `post-conditions are checked, 1`() {
+    """
+      ${imports()}
+      fun bar(x: Int): Int =
+        3.post("greater than 0") { it > 0 }
+      """(
+      withPlugin = { compiles },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  fun `post-conditions are checked, 2`() {
+    """
+      ${imports()}
+      fun bar(x: Int): Int =
+        3.post("smaller than 0") { it < 0 }
+      """(
+      withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  fun `post-conditions and variables, 1`() {
+    """
+      ${imports()}
+      fun bar(x: Int): Int {
+        var z = -1
+        z = 2
+        return z.post("greater than 0") { it > 0 }
+      }
+      """(
+      withPlugin = { compiles },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  @Disabled  // until 'return' works correctly
+  fun `post-conditions and variables, 2`() {
+    """
+      ${imports()}
+      fun bar(x: Int): Int {
+        var z = 2
+        z = -1
+        return z.post("greater than 0") { it > 0 }
+      }
+      """(
+      withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
   fun `unreachable code`() {
     """
       ${imports()}

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -67,7 +67,7 @@ class LiquidDataflowTests {
   }
 
   @Test
-  @Disabled  // until 'return' works correctly
+  @Disabled // until 'return' works correctly
   fun `post-conditions and variables, 2`() {
     """
       ${imports()}

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -83,6 +83,21 @@ class LiquidDataflowTests {
   }
 
   @Test
+  fun `invariants in variables`() {
+    """
+      ${imports()}
+      fun bar(x: Int): Int {
+        var z = 2 invariant { it > 0 }
+        z = 0
+        return z
+      }
+      """(
+      withPlugin = { failsWith { it.contains("invariants are not satisfied") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
   fun `unreachable code`() {
     """
       ${imports()}
@@ -223,6 +238,7 @@ private fun imports() =
   """
 package test
 
+import arrow.refinement.invariant
 import arrow.refinement.pre
 import arrow.refinement.post
 import arrow.refinement.Pre


### PR DESCRIPTION
This PR enables the analysis to work on `var` declarations and assignments. This is done by assigning fresh names to each new assignment of a variable; at a conceptual level the following code:

```kotlin
var x = 1
x = 2
return x
```

is "translated" into (but of course no translation takes place):

```kotlin
val x1 = 1
val x2 = 2
return x2
```