### PR TITLE
Handle 'return' correctly

### DIFF
--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/continuations/ContSeq.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/continuations/ContSeq.kt
@@ -125,6 +125,10 @@ fun <A> List<ContSeq<A>>.sequence(): ContSeq<List<A>> =
 inline fun doOnlyWhen(condition: Boolean, crossinline f: () -> ContSeq<Unit>): ContSeq<Unit> =
   if (condition) f() else ContSeq.unit
 
+/** Execute a side effect only when some condition holds. */
+inline fun <A> doOnlyWhen(condition: Boolean, value: A, crossinline f: () -> ContSeq<A>): ContSeq<A> =
+  if (condition) f() else cont { value }
+
 /**
  * [ContSyntax] exposes [abort] which allows for interruption of the computation,
  * meaning that when `abort` is encountered the `Cont` will be interrupted and will not yield a value.

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -153,8 +153,8 @@ fun bracketMutableVars(data: CheckData): ContSeq<Unit> = ContSeq {
  * Ways to return from a block.
  */
 sealed class Return
-object NoReturn: Return()
-data class ExplicitReturn(val returnPoint: String): Return()
+object NoReturn : Return()
+data class ExplicitReturn(val returnPoint: String) : Return()
 
 // 2.1: declarations
 // -----------------
@@ -227,7 +227,7 @@ private fun SolverState.checkExpressionConstraints(
           data.mutableVariables[name]?.let {
             checkMutableAssignment(expression, name, it.invariant, expression.right, data)
           }
-        } ?: cont { NoReturn }  // <- this case should not happen
+        } ?: cont { NoReturn } // <- this case should not happen
       } else {
         fallThrough(associatedVarName, expression, data)
       }
@@ -417,8 +417,8 @@ private fun SolverState.checkCallArguments(
             is ExplicitReturn -> cont { returnInfo.left() }
             else ->
               go(expressions.drop(1)).flatMap {
-                it.fold (
-                  { r -> cont { r.left() } },  // if we found a return, do it
+                it.fold(
+                  { r -> cont { r.left() } }, // if we found a return, do it
                   { restArgs -> cont { (listOf(name to argUniqueName) + restArgs).right() } }
                 )
               }
@@ -609,7 +609,7 @@ private fun SolverState.checkSimpleConditional(
       .flatMap { (returnAndCond, correspondingVars) ->
         val (returnInfo, cond) = returnAndCond
         when (returnInfo) {
-          is ExplicitReturn ->  // weird case: a return in a condition
+          is ExplicitReturn -> // weird case: a return in a condition
             cont { returnInfo }
           else ->
             continuationBracket.map {

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -67,7 +67,6 @@ class LiquidDataflowTests {
   }
 
   @Test
-  @Disabled // until 'return' works correctly
   fun `post-conditions and variables, 2`() {
     """
       ${imports()}


### PR DESCRIPTION
This PR fixes the handling of `return` nodes, which was incorrect until now, since it `abort`ed the whole computation from that point on. One important consequence was that post-conditions were *not* checked when appearing after a `return`, like in the following snippet:

```kotlin
fun f(x: Int): Int {
  return 2.post("greater than 0") { it > 0 }
}
```

In a technical side, this PR changes the signature of the checking functions from `ContSeq<Unit>` to `ContSeq<Return>`. This additional piece of information tells whether we simply got to the end of the block (`NoReturn`) or we were explicit (`ExplicitReturn`). In the latter case we also record an explicit label if it appears. The core of the handling is in:
- `checkReturnExpression`, where we handle the `ExplicitReturn` case and continue if it was "ours",
- `checkBlockExpression`, where we need to *not* continue with the next of the block if there was an explicit return in the current expression.

Unfortunately, there's some amount of accidental complexity in `checkCallArguments` and `checkSimpleConditional`. The reason is that Kotlin allows `return`s to appear everywhere, also within an argument or in a condition.

```kotlin
val f(x: Int): Int = f(return 2) // <- why not?
```

So there's some complicated handling to ensure that if when handling an argument a `return` is called, we stop the handling of the rest of arguments (we cannot just keep checking all of them, since we could obtain constraint which are not true). Same for conditions. **Help is more than welcome to refactor that terrible piece of code.**