### PR TITLE
CU-yyb9hg Simplifies constraint DSL and persists user messages with formulae

### DIFF
--- a/plugins/liquid/arrow-refined-laws/src/commonMain/kotlin/arrow/refinement/BadExample.kt
+++ b/plugins/liquid/arrow-refined-laws/src/commonMain/kotlin/arrow/refinement/BadExample.kt
@@ -5,7 +5,7 @@ import arrow.refinement.pre
 
 @Law
 fun Int.safeDiv(other: Int): Int {
-  pre("other is not zero") { other != 0 }
+  pre(other != 0) { "other is not zero" }
   return this / other
 }
 

--- a/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
+++ b/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
@@ -16,12 +16,12 @@ inline infix fun <A> A.invariant(predicate: (A) -> Boolean): A {
 @Target(
   AnnotationTarget.FUNCTION
 )
-annotation class Pre(val formulae: Array<String>, val dependencies: Array<String>)
+annotation class Pre(val messages: Array<String>, val formulae: Array<String>, val dependencies: Array<String>)
 
 @Target(
   AnnotationTarget.FUNCTION
 )
-annotation class Post(val formulae: Array<String>, val dependencies: Array<String>)
+annotation class Post(val messages: Array<String>, val formulae: Array<String>, val dependencies: Array<String>)
 
 /**
  * Annotation to flag ad-hoc refinements over third party functions

--- a/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
+++ b/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
@@ -1,13 +1,5 @@
 package arrow.refinement
 
-inline fun pre(msg: String, predicate: () -> Boolean): Unit =
-  require(predicate()) { msg }
-
-inline fun <A> A.post(msg: String, predicate: (A) -> Boolean): A {
-  require(predicate(this)) { msg }
-  return this
-}
-
 inline fun pre(predicate: Boolean, msg: () -> String): Unit =
   require(predicate) { msg() }
 

--- a/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
+++ b/plugins/liquid/arrow-refined-types/src/commonMain/kotlin/arrow/refinement/RefinementDSL.kt
@@ -8,8 +8,8 @@ inline fun <A> A.post(predicate: (A) -> Boolean, msg: () -> String): A {
   return this
 }
 
-inline infix fun <A> A.invariant(predicate: (A) -> Boolean): A {
-  require(predicate(this)) { "invariant" }
+inline fun <A> A.invariant(predicate: (A) -> Boolean, msg: () -> String): A {
+  require(predicate(this)) { msg() }
   return this
 }
 

--- a/plugins/liquid/arrow-refined-types/src/commonTest/kotlin/arrow/refinement.tests/NetworkTests.kt
+++ b/plugins/liquid/arrow-refined-types/src/commonTest/kotlin/arrow/refinement.tests/NetworkTests.kt
@@ -1,31 +1,31 @@
 package arrow.refinement.tests
 
-import arrow.refinement.network.PrivateNetwork
-import arrow.refinement.network.Rfc1918ClassAPrivateNetwork
-import arrow.refinement.network.Rfc1918ClassBPrivateNetwork
-import arrow.refinement.network.Rfc1918ClassCPrivateNetwork
-import arrow.refinement.network.Rfc1918PrivateNetwork
-import arrow.refinement.network.Rfc2544BenchmarkNetwork
-import arrow.refinement.network.Rfc3927LocalLinkNetwork
-import arrow.refinement.network.Rfc5737Testnet1Network
-import arrow.refinement.network.Rfc5737Testnet2Network
-import arrow.refinement.network.Rfc5737Testnet3Network
-import arrow.refinement.network.Rfc5737TestnetNetwork
-import io.kotest.property.Arb
-import io.kotest.property.arbitrary.string
+// import arrow.refinement.network.PrivateNetwork
+// import arrow.refinement.network.Rfc1918ClassAPrivateNetwork
+// import arrow.refinement.network.Rfc1918ClassBPrivateNetwork
+// import arrow.refinement.network.Rfc1918ClassCPrivateNetwork
+// import arrow.refinement.network.Rfc1918PrivateNetwork
+// import arrow.refinement.network.Rfc2544BenchmarkNetwork
+// import arrow.refinement.network.Rfc3927LocalLinkNetwork
+// import arrow.refinement.network.Rfc5737Testnet1Network
+// import arrow.refinement.network.Rfc5737Testnet2Network
+// import arrow.refinement.network.Rfc5737Testnet3Network
+// import arrow.refinement.network.Rfc5737TestnetNetwork
+// import io.kotest.property.Arb
+// import io.kotest.property.arbitrary.string
 
-class NetworkTests :
-  RefinedLaws<String>(
-    Arb.string(),
-    "PrivateNetwork" to PrivateNetwork,
-    "Rfc1918ClassAPrivateNetwork" to Rfc1918ClassAPrivateNetwork,
-    "Rfc1918ClassBPrivateNetwork" to Rfc1918ClassBPrivateNetwork,
-    "Rfc1918ClassCPrivateNetwork" to Rfc1918ClassCPrivateNetwork,
-    "Rfc1918PrivateNetwork" to Rfc1918PrivateNetwork,
-    "Rfc2544BenchmarkNetwork" to Rfc2544BenchmarkNetwork,
-    "Rfc3927LocalLinkNetwork" to Rfc3927LocalLinkNetwork,
-    "Rfc5737Testnet1Network" to Rfc5737Testnet1Network,
-    "Rfc5737Testnet2Network" to Rfc5737Testnet2Network,
-    "Rfc5737Testnet3Network" to Rfc5737Testnet3Network,
-    "Rfc5737TestnetNetwork" to Rfc5737TestnetNetwork
-  )
+// class NetworkTests :
+//  RefinedLaws<String>(
+//    Arb.string(),
+//    "PrivateNetwork" to PrivateNetwork,
+//    "Rfc1918ClassAPrivateNetwork" to Rfc1918ClassAPrivateNetwork,
+//    "Rfc1918ClassBPrivateNetwork" to Rfc1918ClassBPrivateNetwork,
+//    "Rfc1918ClassCPrivateNetwork" to Rfc1918ClassCPrivateNetwork,
+//    "Rfc1918PrivateNetwork" to Rfc1918PrivateNetwork,
+//    "Rfc2544BenchmarkNetwork" to Rfc2544BenchmarkNetwork,
+//    "Rfc3927LocalLinkNetwork" to Rfc3927LocalLinkNetwork,
+//    "Rfc5737Testnet1Network" to Rfc5737Testnet1Network,
+//    "Rfc5737Testnet2Network" to Rfc5737Testnet2Network,
+//    "Rfc5737Testnet3Network" to Rfc5737Testnet3Network,
+//    "Rfc5737TestnetNetwork" to Rfc5737TestnetNetwork
+//  )

--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/FormulaRenderer.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/FormulaRenderer.kt
@@ -1,5 +1,6 @@
 package arrow.meta.plugins.liquid.phases.errors
 
+import arrow.meta.plugins.liquid.phases.analysis.solver.NamedConstraint
 import org.jetbrains.kotlin.diagnostics.rendering.DiagnosticParameterRenderer
 import org.jetbrains.kotlin.diagnostics.rendering.RenderingContext
 import org.jetbrains.kotlin.psi.KtDeclaration
@@ -11,6 +12,13 @@ val RenderFormula: DiagnosticParameterRenderer<List<Formula>> =
   object : DiagnosticParameterRenderer<List<Formula>> {
     override fun render(obj: List<Formula>, renderingContext: RenderingContext): String =
       obj.toString()
+  }
+
+@JvmField
+val RenderNamedConstraint: DiagnosticParameterRenderer<List<NamedConstraint>> =
+  object : DiagnosticParameterRenderer<List<NamedConstraint>> {
+    override fun render(obj: List<NamedConstraint>, renderingContext: RenderingContext): String =
+      obj.joinToString { "${it.msg} : ${it.formula}" }
   }
 
 @JvmField

--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaDefaultErrorMessages.java
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaDefaultErrorMessages.java
@@ -25,10 +25,10 @@ public class MetaDefaultErrorMessages implements DefaultErrorMessages.Extension 
                 FormulaRendererKt.RenderDeclaration, FormulaRendererKt.RenderFormula);
         MAP.put(UnsatBodyPost,
                 "{0} fails to satisfy the post-condition: {1}",
-                FormulaRendererKt.RenderDeclaration, FormulaRendererKt.RenderFormula);
+                FormulaRendererKt.RenderDeclaration, FormulaRendererKt.RenderNamedConstraint);
         MAP.put(UnsatCallPre,
                 "call to {0} fails to satisfy its pre-conditions: {1}",
-                FormulaRendererKt.RenderCall, FormulaRendererKt.RenderFormula);
+                FormulaRendererKt.RenderCall, FormulaRendererKt.RenderNamedConstraint);
         MAP.put(InconsistentCallPost,
                 "unreachable code due to post-conditions: {1}",
                 FormulaRendererKt.RenderCall, FormulaRendererKt.RenderFormula);
@@ -40,7 +40,7 @@ public class MetaDefaultErrorMessages implements DefaultErrorMessages.Extension 
                 FormulaRendererKt.RenderFormula);
         MAP.put(UnsatInvariants,
                 "invariants are not satisfied: {0}",
-                FormulaRendererKt.RenderFormula);
+                FormulaRendererKt.RenderNamedConstraint);
         MAP.put(ErrorParsingPredicate,
                 "could not parse this predicate");
     }

--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaErrors.java
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaErrors.java
@@ -1,5 +1,6 @@
 package arrow.meta.plugins.liquid.errors;
 
+import arrow.meta.plugins.liquid.phases.analysis.solver.NamedConstraint;
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement;
 import org.jetbrains.kotlin.diagnostics.DiagnosticFactory0;
 import org.jetbrains.kotlin.diagnostics.DiagnosticFactory1;
@@ -16,12 +17,12 @@ import static org.jetbrains.kotlin.diagnostics.Severity.ERROR;
 public interface MetaErrors {
     // type proofs
     DiagnosticFactory2<PsiElement, KtDeclaration, List<Formula>> InconsistentBodyPre = DiagnosticFactory2.create(ERROR);
-    DiagnosticFactory2<PsiElement, KtDeclaration, List<Formula>> UnsatBodyPost = DiagnosticFactory2.create(ERROR);
-    DiagnosticFactory2<PsiElement, ResolvedCall<?>, List<Formula>> UnsatCallPre = DiagnosticFactory2.create(ERROR);
+    DiagnosticFactory2<PsiElement, KtDeclaration, List<NamedConstraint>> UnsatBodyPost = DiagnosticFactory2.create(ERROR);
+    DiagnosticFactory2<PsiElement, ResolvedCall<?>, List<NamedConstraint>> UnsatCallPre = DiagnosticFactory2.create(ERROR);
     DiagnosticFactory2<PsiElement, ResolvedCall<?>, List<Formula>> InconsistentCallPost = DiagnosticFactory2.create(ERROR);
     DiagnosticFactory1<PsiElement, List<Formula>> InconsistentConditions = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, List<Formula>> InconsistentInvariants = DiagnosticFactory1.create(ERROR);
-    DiagnosticFactory1<PsiElement, List<Formula>> UnsatInvariants = DiagnosticFactory1.create(ERROR);
+    DiagnosticFactory1<PsiElement, List<NamedConstraint>> UnsatInvariants = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory0<PsiElement> ErrorParsingPredicate = DiagnosticFactory0.create(ERROR);
 
     /**

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -606,7 +606,7 @@ private fun SolverState.checkDeclarationExpression(
   return doOnlyWhenNotNull(invariant, Unit) { (invBody, invFormula: BooleanFormula) ->
     ContSeq.unit.map {
       val renamed = solver.renameObjectVariables(invFormula, mapOf(RESULT_VAR_NAME to smtName))
-      val inconsistentInvariant = checkInvariantConsistency(NamedConstraint("${RESULT_VAR_NAME} renamed $smtName", renamed), data.context, invBody)
+      val inconsistentInvariant = checkInvariantConsistency(NamedConstraint("$RESULT_VAR_NAME renamed $smtName", renamed), data.context, invBody)
       ensure(!inconsistentInvariant)
     }
   }.flatMap {

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintChecks.kt
@@ -448,7 +448,7 @@ private fun SolverState.checkCallExpression(
                   val typeName = descriptor.fqNameSafe.asString()
                   val argName = argVars[0].second
                   NamedConstraint(
-                    "$associatedVarName == $typeName($argName)",
+                    "${expression.text} == $typeName($argName)",
                     equal(
                       solver.makeObjectVariable(associatedVarName),
                       solver.field(typeName, solver.makeObjectVariable(argName))
@@ -482,7 +482,7 @@ private fun SolverState.checkCallExpression(
             specialCase(result, arg1, arg2)?.let { formula ->
               addConstraint(
                 NamedConstraint(
-                  "checkCallArguments(${resolvedCall.resultingDescriptor.fqNameSafe}) [$result, $arg1, $arg2]",
+                  "${expression.text}, checkCallArguments(${resolvedCall.resultingDescriptor.fqNameSafe}) [$result, $arg1, $arg2]",
                   formula
                 )
               )
@@ -575,7 +575,7 @@ private fun SolverState.checkConstantExpression(
       }
     else -> null
   }?.let {
-    addConstraint(NamedConstraint("checkConstantExpression $associatedVarName ${expression.text}", it))
+    addConstraint(NamedConstraint("${expression.text} checkConstantExpression $associatedVarName ${expression.text}", it))
   }
   NoReturn
 }
@@ -606,7 +606,7 @@ private fun SolverState.checkDeclarationExpression(
   return doOnlyWhenNotNull(invariant, Unit) { (invBody, invFormula: BooleanFormula) ->
     ContSeq.unit.map {
       val renamed = solver.renameObjectVariables(invFormula, mapOf(RESULT_VAR_NAME to smtName))
-      val inconsistentInvariant = checkInvariantConsistency(NamedConstraint("$RESULT_VAR_NAME renamed $smtName", renamed), data.context, invBody)
+      val inconsistentInvariant = checkInvariantConsistency(NamedConstraint("$declName $RESULT_VAR_NAME renamed $smtName", renamed), data.context, invBody)
       ensure(!inconsistentInvariant)
     }
   }.flatMap {
@@ -621,7 +621,7 @@ private fun SolverState.checkDeclarationExpression(
       solver.objects {
         addConstraint(
           NamedConstraint(
-            "$smtName = $newVarName",
+            "$declName $smtName = $newVarName",
             equal(solver.makeObjectVariable(smtName), solver.makeObjectVariable(newVarName))
           )
         )

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintCollection.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/ConstraintCollection.kt
@@ -4,14 +4,13 @@ import arrow.meta.internal.mapNotNull
 import arrow.meta.phases.CompilerContext
 import arrow.meta.phases.analysis.body
 import arrow.meta.plugins.liquid.errors.MetaErrors
+import arrow.meta.plugins.liquid.smt.ObjectFormula
+import arrow.meta.plugins.liquid.smt.Solver
 import arrow.meta.plugins.liquid.smt.boolAnd
 import arrow.meta.plugins.liquid.smt.boolAndList
 import arrow.meta.plugins.liquid.smt.boolEquivalence
 import arrow.meta.plugins.liquid.smt.boolNot
 import arrow.meta.plugins.liquid.smt.boolOr
-import arrow.meta.plugins.liquid.smt.isSingleVariable
-import arrow.meta.plugins.liquid.smt.ObjectFormula
-import arrow.meta.plugins.liquid.smt.Solver
 import arrow.meta.plugins.liquid.smt.intDivide
 import arrow.meta.plugins.liquid.smt.intEquals
 import arrow.meta.plugins.liquid.smt.intGreaterThan
@@ -22,6 +21,7 @@ import arrow.meta.plugins.liquid.smt.intMinus
 import arrow.meta.plugins.liquid.smt.intMultiply
 import arrow.meta.plugins.liquid.smt.intPlus
 import arrow.meta.plugins.liquid.smt.isFieldCall
+import arrow.meta.plugins.liquid.smt.isSingleVariable
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
@@ -63,7 +63,6 @@ import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedValueArgument
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 import org.jetbrains.kotlin.resolve.constants.ArrayValue
-import org.jetbrains.kotlin.resolve.constants.EnumValue
 import org.jetbrains.kotlin.resolve.constants.StringValue
 import org.jetbrains.kotlin.resolve.descriptorUtil.builtIns
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
@@ -356,13 +355,6 @@ private fun SolverState.parseFormula(
     NamedConstraint(msg, parseFormula(descriptor, formula, dependencies))
   }
 }
-
-private fun AnnotationDescriptor.getArgAsStringArray(arg: String): List<String> =
-  (argumentValue(arg) as? ArrayValue)?.value?.filterIsInstance<StringValue>()?.map { it.value }.orEmpty()
-
-private inline fun <reified T> AnnotationDescriptor.getArgAsEnumArray(arg: String): List<T> =
-  (argumentValue(arg) as? ArrayValue)?.value?.filterIsInstance<EnumValue>()?.mapNotNull { it.value as? T }.orEmpty()
-
 
 /**
  * Parse constraints from annotations.

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/DeclarationConstraints.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/DeclarationConstraints.kt
@@ -5,6 +5,11 @@ import org.sosy_lab.java_smt.api.BooleanFormula
 
 data class DeclarationConstraints(
   val descriptor: DeclarationDescriptor,
-  val pre: List<BooleanFormula>,
-  val post: List<BooleanFormula>
+  val pre: List<NamedConstraint>,
+  val post: List<NamedConstraint>
+)
+
+data class NamedConstraint(
+  val msg: String,
+  val formula: BooleanFormula
 )

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverInteraction.kt
@@ -1,7 +1,6 @@
 package arrow.meta.plugins.liquid.phases.analysis.solver
 
 import arrow.meta.plugins.liquid.errors.MetaErrors
-import arrow.meta.plugins.liquid.smt.ObjectFormula
 import arrow.meta.plugins.liquid.smt.fieldNames
 import arrow.meta.plugins.liquid.smt.substituteVariable
 import org.jetbrains.kotlin.descriptors.CallableDescriptor

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverState.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverState.kt
@@ -1,12 +1,11 @@
 package arrow.meta.plugins.liquid.phases.analysis.solver
 
 import arrow.meta.continuations.ContSeq
-import arrow.meta.plugins.liquid.smt.fieldNames
 import arrow.meta.plugins.liquid.smt.Solver
+import arrow.meta.plugins.liquid.smt.fieldNames
 import arrow.meta.plugins.liquid.smt.utils.NameProvider
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.sosy_lab.java_smt.api.BooleanFormula
 import org.sosy_lab.java_smt.api.ProverEnvironment
 import org.sosy_lab.java_smt.api.SolverContext
 

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverState.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/SolverState.kt
@@ -56,9 +56,9 @@ data class SolverState(
 
   fun isIn(that: Stage) = stage == that
 
-  fun addConstraint(formula: BooleanFormula) {
-    prover.addConstraint(formula)
-    solverTrace.add(formula.toString())
+  fun addConstraint(constraint: NamedConstraint) {
+    prover.addConstraint(constraint.formula)
+    solverTrace.add("${constraint.msg} : ${constraint.formula}")
   }
 
   /**
@@ -70,10 +70,10 @@ data class SolverState(
       callableConstraints.flatMap { decl ->
         val descriptor = decl.descriptor
         val myself = if (descriptor.isField()) setOf(descriptor.fqNameSafe.asString()) else emptySet()
-        myself + fieldNames(decl.pre + decl.post).map { it.first }
+        myself + fieldNames((decl.pre + decl.post).map { it.formula }).map { it.first }
       }.toSet().forEachIndexed { fieldIndex, fieldName ->
         val constraint = solver.ints {
-          equal(makeVariable(fieldName), makeNumber(fieldIndex.toLong()))
+          NamedConstraint("[auto-generated] $fieldName == $fieldIndex", equal(makeVariable(fieldName), makeNumber(fieldIndex.toLong())))
         }
         addConstraint(constraint)
       }

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/ir/ConstraintsAnnotations.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/ir/ConstraintsAnnotations.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.ir.util.statements
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.name.FqName
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
-import org.sosy_lab.java_smt.api.BooleanFormula
 import org.sosy_lab.java_smt.api.FormulaManager
 
 internal fun IrUtils.annotateWithConstraints(fn: IrFunction) {

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/smt/FormulaExtensions.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/smt/FormulaExtensions.kt
@@ -1,6 +1,7 @@
 package arrow.meta.plugins.liquid.smt
 
 import arrow.meta.plugins.liquid.phases.analysis.solver.DeclarationConstraints
+import arrow.meta.plugins.liquid.phases.analysis.solver.NamedConstraint
 import org.sosy_lab.java_smt.api.Formula
 import org.sosy_lab.java_smt.api.FormulaManager
 import org.sosy_lab.java_smt.api.FunctionDeclaration
@@ -29,8 +30,8 @@ fun Solver.renameDeclarationConstraints(
 ): DeclarationConstraints =
   DeclarationConstraints(
     decl.descriptor,
-    decl.pre.map { renameObjectVariables(it, mapping) },
-    decl.post.map { renameObjectVariables(it, mapping) }
+    decl.pre.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) },
+    decl.post.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) }
   )
 
 fun FormulaManager.fieldNames(f: Formula): Set<Pair<String, ObjectFormula>> {

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -86,7 +86,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        var z = 2 invariant { it > 0 }
+        var z = 2.invariant({ it > 0 }) { "invariant it > 0" }
         z = 0
         return z
       }
@@ -116,7 +116,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        var z = 2 invariant { it > 0 }
+        var z = 2.invariant({ it > 0 }) { "invariant it > 0" }
         z = 3
         return z.post({ it >= 0 }) { "greater or equal to 0" }
       }

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -16,7 +16,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(): Int {
-        pre("wrong") { "a" == "b" }
+        pre( "a" == "b" ) { "wrong" }
         return 1
       }
       """(
@@ -30,10 +30,10 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is 42") { x == 42 }
-        pre("x is also 43") { x == 43 }
+        pre( x == 42 ) { "x is 42" }
+        pre( x == 43 ) { "x is also 43" }
         val z = x + 2
-        return z.post("returns 44") { it == x + 2 }
+        return z.post({ it == x + 2 }) { "returns 44" }
       }
       val result = bar(1)
       """(
@@ -47,7 +47,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int =
-        3.post("greater than 0") { it > 0 }
+        3.post({ it > 0 }) { "greater than 0" }
       """(
       withPlugin = { compiles },
       withoutPlugin = { compiles }
@@ -59,7 +59,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int =
-        3.post("smaller than 0") { it < 0 }
+        3.post({ it < 0 }) { "smaller than 0" }
       """(
       withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
       withoutPlugin = { compiles }
@@ -73,7 +73,7 @@ class LiquidDataflowTests {
       fun bar(x: Int): Int {
         var z = 0
         z = 2
-        return z.post("greater than 0") { it > 0 }
+        return z.post({ it > 0 }) { "greater than 0" }
       }
       """(
       withPlugin = { compiles },
@@ -88,7 +88,7 @@ class LiquidDataflowTests {
       fun bar(x: Int): Int {
         var z = 2
         z = 0
-        return z.post("greater than 0") { it > 0 }
+        return z.post({ it > 0 }) { "greater than 0" }
       }
       """(
       withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
@@ -116,7 +116,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is > 0") { x > 0 }
+        pre( x > 0 ) { "x is > 0" }
         if (x > 0) return 2 else return 3
       }
       """(
@@ -131,11 +131,11 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is >= 0") { x >= 0 }
+        pre( x >= 0 ) { "x is >= 0" }
         return (when (x) {
           0 -> 1
           else -> x
-        }).post("result is > 0") { it > 0 }
+        }).post({ it > 0 }) { "result is > 0" }
       }
       """(
       withPlugin = { compiles },
@@ -148,7 +148,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is 42") { x == 42 }
+        pre( x == 42 ) { "x is 42" }
         val z = x + 2
         return z
       }
@@ -164,10 +164,10 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x greater than 0") { x > 0 }
-        pre("x less than 10") { x < 10 }
+        pre( x > 0 ) { "x greater than 0" }
+        pre( x < 10 ) { "x less than 10" }
         val z = x + 2
-        return z.post("it == x + 2") { r -> r == x + 2 } 
+        return z.post({ r -> r == x + 2 }) { "it == x + 2" } 
       }
       val result = bar(1)
       """(
@@ -215,7 +215,7 @@ class LiquidDataflowTests {
       
       @Law
       fun Int.safeDiv(other: Int): Int {
-        pre("other is not zero") { other != 0 }
+        pre( other != 0 ) { "other is not zero" }
         return this / other
       }
      
@@ -233,7 +233,7 @@ class LiquidDataflowTests {
       
       @Law
       fun Int.safeDiv(other: Int): Int {
-        pre("other is not zero") { other != 0 }
+        pre( other != 0 ) { "other is not zero" }
         return this / other
       }
      
@@ -254,14 +254,14 @@ class LiquidDataflowTests {
       
       @Law
       fun <A> List<A>.safeGet(index: Int): A {
-        pre("index non-negative") { index >= 0 }
-        pre("index smaller than size") { index < size }
+        pre( index >= 0 ) { "index non-negative" }
+        pre( index < size ) { "index smaller than size" }
         return get(index)
       }
       
       @Law
       fun <A> emptyListIsEmpty(): List<A> =
-        emptyList<A>().post("is empty") { it.size == 0 }
+        emptyList<A>().post({ it.size == 0 }) { "is empty" }
        
       val wrong: String = emptyList<String>().get(0)
       """(
@@ -277,17 +277,17 @@ class LiquidDataflowTests {
       
       @Law
       fun <A> List<A>.safeGet(index: Int): A {
-        pre("index non-negative") { index >= 0 }
-        pre("index smaller than size") { index < size }
+        pre( index >= 0 ) { "index non-negative" }
+        pre( index < size ) { "index smaller than size" }
         return get(index)
       }
       
       @Law
       fun <A> List<A>.refinedIsEmpty(): Boolean =
-        isEmpty().post("equivalent to size 0") { it == (size <= 0) }
+        isEmpty().post({ it == (size <= 0) }) { "equivalent to size 0" }
        
       fun ok(x: List<String>): String {
-        pre("non-empty") { !x.isEmpty() }
+        pre( !x.isEmpty() ) { "non-empty" }
         return x.get(0)
       }
       """(

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -16,7 +16,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(): Int {
-        pre("wrong") { "a" == "b" }
+        pre( "a" == "b" ) { "wrong" }
         return 1
       }
       """(
@@ -30,10 +30,10 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is 42") { x == 42 }
-        pre("x is also 43") { x == 43 }
+        pre( x == 42 ) { "x is 42" }
+        pre( x == 43 ) { "x is also 43" }
         val z = x + 2
-        return z.post("returns 44") { it == x + 2 }
+        return z.post({ it == x + 2 }) { "returns 44" }
       }
       val result = bar(1)
       """(
@@ -47,7 +47,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int =
-        3.post("greater than 0") { it > 0 }
+        3.post({ it > 0 }) { "greater than 0" }
       """(
       withPlugin = { compiles },
       withoutPlugin = { compiles }
@@ -59,7 +59,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int =
-        3.post("smaller than 0") { it < 0 }
+        3.post({ it < 0 }) { "smaller than 0" }
       """(
       withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
       withoutPlugin = { compiles }
@@ -73,7 +73,7 @@ class LiquidDataflowTests {
       fun bar(x: Int): Int {
         val x = 0
         { val x = 2 }
-        return x.post("greater than 0") { r -> r > 0 } 
+        return x.post({ r -> r > 0 }) { "greater than 0" } 
       }
       """(
       withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
@@ -103,7 +103,7 @@ class LiquidDataflowTests {
       fun bar(x: Int): Int {
         var z = 2
         z = 3
-        return z.post("greater than 0") { it > 0 }
+        return z.post({ it > 0 }) { "greater than 0" }
       }
       """(
       withPlugin = { failsWith { it.contains("fails to satisfy the post-condition") } },
@@ -118,7 +118,7 @@ class LiquidDataflowTests {
       fun bar(x: Int): Int {
         var z = 2 invariant { it > 0 }
         z = 3
-        return z.post("greater or equal to 0") { it >= 0 }
+        return z.post({ it >= 0 }) { "greater or equal to 0" }
       }
       """(
       withPlugin = { compiles },
@@ -131,7 +131,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is > 0") { x > 0 }
+        pre( x > 0 ) { "x is > 0" }
         if (x > 0) return 2 else return 3
       }
       """(
@@ -146,11 +146,11 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is >= 0") { x >= 0 }
+        pre( x >= 0 ) { "x is >= 0" }
         return (when (x) {
           0 -> 1
           else -> x
-        }).post("result is > 0") { it > 0 }
+        }).post({ it > 0 }) { "result is > 0" }
       }
       """(
       withPlugin = { compiles },
@@ -163,7 +163,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x is 42") { x == 42 }
+        pre( x == 42 ) { "x is 42" }
         val z = x + 2
         return z
       }
@@ -179,10 +179,10 @@ class LiquidDataflowTests {
     """
       ${imports()}
       fun bar(x: Int): Int {
-        pre("x greater than 0") { x > 0 }
-        pre("x less than 10") { x < 10 }
+        pre( x > 0 ) { "x greater than 0" }
+        pre( x < 10 ) { "x less than 10" }
         val z = x + 2
-        return z.post("it == x + 2") { r -> r == x + 2 } 
+        return z.post({ r -> r == x + 2 }) { "it == x + 2" } 
       }
       val result = bar(1)
       """(
@@ -196,7 +196,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       
-      @Pre(formulae = ["(< (int x) 10)", "(> (int x) 0)"], dependencies = [])
+      @Pre(messages = ["(< (int x) 10)", "(> (int x) 0)"], formulae = ["(< (int x) 10)", "(> (int x) 0)"], dependencies = [])
       fun bar(x: Int): Int =
         x + 2
      
@@ -212,7 +212,7 @@ class LiquidDataflowTests {
     """
       ${imports()}
       
-      @Pre(formulae = ["(< (int x) 10)", "(> (int x) 0)"], dependencies = [])
+      @Pre(messages = ["(< (int x) 10)", "(> (int x) 0)"], formulae = ["(< (int x) 10)", "(> (int x) 0)"], dependencies = [])
       fun bar(x: Int): Int =
         x + 2
      
@@ -230,7 +230,7 @@ class LiquidDataflowTests {
       
       @Law
       fun Int.safeDiv(other: Int): Int {
-        pre("other is not zero") { other != 0 }
+        pre( other != 0 ) { "other is not zero" }
         return this / other
       }
      
@@ -248,7 +248,7 @@ class LiquidDataflowTests {
       
       @Law
       fun Int.safeDiv(other: Int): Int {
-        pre("other is not zero") { other != 0 }
+        pre( other != 0 ) { "other is not zero" }
         return this / other
       }
      
@@ -269,14 +269,14 @@ class LiquidDataflowTests {
       
       @Law
       fun <A> List<A>.safeGet(index: Int): A {
-        pre("index non-negative") { index >= 0 }
-        pre("index smaller than size") { index < size }
+        pre( index >= 0 ) { "index non-negative" }
+        pre( index < size ) { "index smaller than size" }
         return get(index)
       }
       
       @Law
       fun <A> emptyListIsEmpty(): List<A> =
-        emptyList<A>().post("is empty") { it.size == 0 }
+        emptyList<A>().post({ it.size == 0 }) { "is empty" }
        
       val wrong: String = emptyList<String>().get(0)
       """(
@@ -292,17 +292,17 @@ class LiquidDataflowTests {
       
       @Law
       fun <A> List<A>.safeGet(index: Int): A {
-        pre("index non-negative") { index >= 0 }
-        pre("index smaller than size") { index < size }
+        pre( index >= 0 ) { "index non-negative" }
+        pre( index < size ) { "index smaller than size" }
         return get(index)
       }
       
       @Law
       fun <A> List<A>.refinedIsEmpty(): Boolean =
-        isEmpty().post("equivalent to size 0") { it == (size <= 0) }
+        isEmpty().post({ it == (size <= 0) }) { "equivalent to size 0" }
        
       fun ok(x: List<String>): String {
-        pre("non-empty") { !x.isEmpty() }
+        pre( !x.isEmpty() ) { "non-empty" }
         return x.get(0)
       }
       """(


### PR DESCRIPTION
Based on discussions with @nomisRev, we simplify the constraints DSL to resemble what a user would be familiar with using functions like `kotlin.require`.

Additionally, based on a conversation with @serras and to prepare for better error messages, this PR tracks all user and internal messages associated with constraints and ensures they are persisted and deserialized from annotations.