### PR TITLE
[Analysis] Subtyping

### DIFF
--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaDefaultErrorMessages.java
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaDefaultErrorMessages.java
@@ -29,6 +29,7 @@ public class MetaDefaultErrorMessages implements DefaultErrorMessages.Extension 
         MAP.put(InconsistentInvariants, "{0}", RenderString);
         MAP.put(UnsatInvariants, "{0}", RenderString);
         MAP.put(ErrorParsingPredicate, "{0}", RenderString);
+        MAP.put(LiskovProblem, "{0}", RenderString);
     }
 }
 

--- a/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaErrors.java
+++ b/plugins/liquid/refined-types-plugin/src/main/java/arrow/meta/plugins/liquid/errors/MetaErrors.java
@@ -16,6 +16,7 @@ public interface MetaErrors {
     DiagnosticFactory1<PsiElement, String> InconsistentInvariants = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> UnsatInvariants = DiagnosticFactory1.create(ERROR);
     DiagnosticFactory1<PsiElement, String> ErrorParsingPredicate = DiagnosticFactory1.create(ERROR);
+    DiagnosticFactory1<PsiElement, String> LiskovProblem = DiagnosticFactory1.create(ERROR);
 
     /**
      * needed to prevent NPE in

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/collect/ConstraintCollection.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/collect/ConstraintCollection.kt
@@ -28,9 +28,11 @@ import arrow.meta.plugins.liquid.smt.intMultiply
 import arrow.meta.plugins.liquid.smt.intPlus
 import arrow.meta.plugins.liquid.smt.isFieldCall
 import arrow.meta.plugins.liquid.smt.isSingleVariable
+import arrow.meta.plugins.liquid.smt.renameDeclarationConstraints
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.descriptors.CallableMemberDescriptor
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
@@ -97,12 +99,65 @@ internal fun SolverState.constraintsFromSolverState(resolvedCall: ResolvedCall<*
 
 /**
  * Looks up in the solver state previously collected constraints and
- * returns the constraints associated to this [descriptor] if any
+ * returns the constraints associated to this [descriptor],
+ * or any of the declaration it has overridden, if any
  */
 internal fun SolverState.constraintsFromSolverState(descriptor: DeclarationDescriptor): DeclarationConstraints? =
+  immediateConstraintsFromSolverState(descriptor) ?: overriddenConstraintsFromSolverState(descriptor)
+
+/**
+ * Looks up in the solver state previously collected constraints
+ * for the given [descriptor], but not for their possible parents
+ */
+internal fun SolverState.immediateConstraintsFromSolverState(descriptor: DeclarationDescriptor): DeclarationConstraints? =
   callableConstraints.firstOrNull {
     descriptor.fqNameSafe == it.descriptor.fqNameSafe
   }
+
+/**
+ * Looks up in the solver state previously collected constraints
+ * for every declaration the [descriptor] may have overridden
+ */
+internal fun SolverState.overriddenConstraintsFromSolverState(descriptor: DeclarationDescriptor): DeclarationConstraints? =
+  descriptor.overriddenDescriptors()?.mapNotNull { overriddenDescriptor ->
+    constraintsFromSolverState(overriddenDescriptor)
+  }?.map {
+    // rename the argument names and similar things
+    solver.renameConditions(it, descriptor)
+  }?.let { overriddenConstraints ->
+    // and finally put all the pre- and post-conditions together
+    DeclarationConstraints(
+      descriptor,
+      overriddenConstraints.flatMap { it.pre },
+      overriddenConstraints.flatMap { it.post })
+  }
+
+/**
+ * Rename the conditions from one descriptor
+ * to the names of another
+ */
+internal fun Solver.renameConditions(
+  constraints: DeclarationConstraints,
+  to: DeclarationDescriptor
+): DeclarationConstraints {
+  val fromParams = (constraints.descriptor as? CallableDescriptor)?.valueParameters?.map { it.name.asString() }
+  val toParams = (to as? CallableDescriptor)?.valueParameters?.map { it.name.asString() }
+  return if (fromParams != null && toParams != null) {
+    renameDeclarationConstraints(constraints, fromParams.zip(toParams).toMap())
+  } else {
+    constraints
+  }
+}
+
+/**
+ * Obtain the descriptors which have been overriden by a declaration,
+ * if they exist
+ */
+private fun DeclarationDescriptor.overriddenDescriptors(): Collection<DeclarationDescriptor>? =
+  when (this) {
+      is CallableMemberDescriptor -> this.overriddenDescriptors
+      else -> null
+    }
 
 /**
  * Collects constraints from all declarations and adds them to the solver state

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/collect/ConstraintCollection.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/collect/ConstraintCollection.kt
@@ -121,6 +121,8 @@ internal fun SolverState.immediateConstraintsFromSolverState(descriptor: Declara
 internal fun SolverState.overriddenConstraintsFromSolverState(descriptor: DeclarationDescriptor): DeclarationConstraints? =
   descriptor.overriddenDescriptors()?.mapNotNull { overriddenDescriptor ->
     constraintsFromSolverState(overriddenDescriptor)
+  }?.takeIf {
+    it.isNotEmpty()
   }?.map {
     // rename the argument names and similar things
     solver.renameConditions(it, descriptor)

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/errors/ErrorMessages.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/errors/ErrorMessages.kt
@@ -232,6 +232,18 @@ object ErrorMessages {
       "invariants are inconsistent: ${it.joinToString { it.dumpKotlinLike() }}"
   }
 
+  object Liskov {
+    internal fun KotlinPrinter.notWeakerPrecondition(constraint: NamedConstraint): String =
+      """|pre-condition `${constraint.msg}` is not weaker than those from overridden members
+         |  -> problematic constraint: `${constraint.formula.dumpKotlinLike()}`    `
+      """.trimMargin()
+
+    internal fun KotlinPrinter.notStrongerPostcondition(constraint: NamedConstraint): String =
+      """|post-condition `${constraint.msg}` from overridden member is not satisfied
+         |  -> problematic constraint: `${constraint.formula.dumpKotlinLike()}`    `
+      """.trimMargin()
+  }
+
   internal fun template(constraint: NamedConstraint, solver: Solver): String = solver.run {
     val showVariables = extractVariables(constraint.formula)
     val elements = showVariables.mapNotNull { mirroredElement(it.key) }

--- a/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/state/SolverInteraction.kt
+++ b/plugins/liquid/refined-types-plugin/src/main/kotlin/arrow/meta/plugins/liquid/phases/analysis/solver/state/SolverInteraction.kt
@@ -8,6 +8,8 @@ import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Inc
 import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Inconsistency.inconsistentCallPost
 import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Inconsistency.inconsistentConditions
 import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Inconsistency.inconsistentInvariants
+import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Liskov.notStrongerPostcondition
+import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Liskov.notWeakerPrecondition
 import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Unsatisfiability.unsatBodyPost
 import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Unsatisfiability.unsatCallPre
 import arrow.meta.plugins.liquid.phases.analysis.solver.errors.ErrorMessages.Unsatisfiability.unsatInvariants
@@ -213,6 +215,34 @@ internal fun SolverState.checkInvariant(
       val msg = unsatInvariants(expression, constraint, model)
       context.trace.report(
         MetaErrors.UnsatInvariants.on(expression.psiOrParent, msg)
+      )
+    }
+  }
+
+internal fun SolverState.checkLiskovWeakerPrecondition(
+  constraint: NamedConstraint,
+  context: DeclarationCheckerContext,
+  expression: KtElement
+): Boolean =
+  solver.run {
+    checkImplicationOf(constraint) { model ->
+      val msg = notWeakerPrecondition(constraint)
+      context.trace.report(
+        MetaErrors.LiskovProblem.on(expression.psiOrParent, msg)
+      )
+    }
+  }
+
+internal fun SolverState.checkLiskovStrongerPostcondition(
+  constraint: NamedConstraint,
+  context: DeclarationCheckerContext,
+  expression: KtElement
+): Boolean =
+  solver.run {
+    checkImplicationOf(constraint) { model ->
+      val msg = notStrongerPostcondition(constraint)
+      context.trace.report(
+        MetaErrors.LiskovProblem.on(expression.psiOrParent, msg)
       )
     }
   }

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -460,6 +460,65 @@ class LiquidDataflowTests {
       withoutPlugin = { compiles }
     )
   }
+
+  @Test
+  fun `subtyping, pre- and post-conditions are checked in overridden functions`() {
+    """
+      ${imports()}
+      open class A() {
+        open fun f(): Int = 2.post({ it > 0 }) { "greater than 0" }
+      }
+      
+      class B(): A() {
+        override fun f(): Int = 0
+      }
+      """(
+      withPlugin = { failsWith { it.contains("`f` fails to satisfy the post-condition") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  fun `subtyping, Liskov Substitution Principle, 1`() {
+    """
+      ${imports()}
+      open class A() {
+        open fun f(): Int = 2.post({ it > 0 }) { "greater than 0" }
+      }
+      
+      class B(): A() {
+        override fun f(): Int = 1.post({ it >= 0 }) { "non-negative" }
+      }
+      """(
+      withPlugin = { failsWith { it.contains("post-condition `greater than 0` from overridden member is not satisfied") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  fun `subtyping, Liskov Substitution Principle, 2`() {
+    """
+      ${imports()}
+      open class A() {
+        open fun f(x: Int): Int {
+          pre(x > 0) { "greater than 0" }
+          val y = x + 1
+          return y.post({ it > 0 }) { "greater than 0" }
+        }
+      }
+      
+      class B(): A() {
+        override fun f(x: Int): Int {
+          pre(x >= 0) { "greater or equal to 0" }
+          val y = x + 1000
+          return y.post({ it > 1 }) { "greater than 1" }
+        }
+      }
+      """(
+      withPlugin = { compiles },
+      withoutPlugin = { compiles }
+    )
+  }
 }
 
 private fun imports() =

--- a/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
+++ b/plugins/liquid/refined-types-plugin/src/test/kotlin/arrow/meta/plugins/liquid/LiquidDataflowTests.kt
@@ -519,6 +519,27 @@ class LiquidDataflowTests {
       withoutPlugin = { compiles }
     )
   }
+
+  @Test
+  fun `subtyping, Liskov Substitution Principle, interface`() {
+    """
+      ${imports()}
+      interface A {
+        fun f(): Int 
+        
+        @Law
+        fun f_Law(): Int =
+          f().post({ it > 0 }) { "greater than 0" }
+      }
+      
+      class B(): A {
+        override fun f(): Int = 0
+      }
+      """(
+      withPlugin = { failsWith { it.contains("declaration `f` fails to satisfy the post-condition") } },
+      withoutPlugin = { compiles }
+    )
+  }
 }
 
 private fun imports() =


### PR DESCRIPTION
This PR changes the analysis of declarations to go well with subtyping:
- check that the Liskov Substitution Principle is obeyed in overridden members
- look for constraints in overridden members if they cannot be found in the current one