### PR TITLE
[WIP] Add whitespace as separator for annotations

### DIFF
--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/classorobject/ClassOrObject.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/classorobject/ClassOrObject.kt
@@ -29,7 +29,7 @@ import org.jetbrains.kotlin.psi.psiUtil.modalityModifierType
 open class ClassOrObjectScope<out T : KtClassOrObject>(
   override val value: T,
   override val descriptor: ClassDescriptor?,
-  val `@annotations`: ScopedList<KtAnnotationEntry> = ScopedList(value.annotationEntries),
+  val `@annotations`: ScopedList<KtAnnotationEntry> = ScopedList(value.annotationEntries, separator = " "),
   val modality: Name? = value.modalityModifierType()?.value?.let(Name::identifier),
   val superTypes: ScopedList<KtSuperTypeListEntry> =
     ScopedList(

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/classorobject/ClassOrObject.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/classorobject/ClassOrObject.kt
@@ -29,7 +29,8 @@ import org.jetbrains.kotlin.psi.psiUtil.modalityModifierType
 open class ClassOrObjectScope<out T : KtClassOrObject>(
   override val value: T,
   override val descriptor: ClassDescriptor?,
-  val `@annotations`: ScopedList<KtAnnotationEntry> = ScopedList(value.annotationEntries, separator = " "),
+  val `@annotations`: ScopedList<KtAnnotationEntry> =
+    ScopedList(value.annotationEntries, separator = " "),
   val modality: Name? = value.modalityModifierType()?.value?.let(Name::identifier),
   val superTypes: ScopedList<KtSuperTypeListEntry> =
     ScopedList(

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/filebase/File.kt
@@ -45,7 +45,8 @@ import org.jetbrains.kotlin.psi.stubs.KotlinFileStub
  */
 class File(
   override val value: KtFile,
-  val `@annotations`: ScopedList<KtAnnotationEntry> = ScopedList(value.annotationEntries),
+  val `@annotations`: ScopedList<KtAnnotationEntry> =
+    ScopedList(value.annotationEntries, separator = " "),
   val name: String = value.name,
   val importList: Scope<KtImportList> =
     Scope(value.importList), // TODO KtImportList scope and quote template

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/modifierlistowner/ModifierList.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/modifierlistowner/ModifierList.kt
@@ -36,6 +36,6 @@ import org.jetbrains.kotlin.psi.psiUtil.visibilityModifier
 class ModifierList(
   override val value: KtModifierList?,
   val `@annotations`: ScopedList<KtAnnotationEntry> =
-    ScopedList(value?.annotationEntries.orEmpty()),
+    ScopedList(value?.annotationEntries.orEmpty(), separator = " "),
   val modifier: PsiElement? = value?.visibilityModifier()
 ) : Scope<KtModifierList>(value)

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/modifierlistowner/TypeReference.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/quotes/modifierlistowner/TypeReference.kt
@@ -38,7 +38,7 @@ class TypeReference(
   val typeElement: Scope<KtTypeElement>? =
     Scope(value?.typeElement), // TODO KtTypeElement scope and quote template
   val `@annotations`: ScopedList<KtAnnotationEntry> =
-    ScopedList(separator = " ", value = value?.annotationEntries.orEmpty())
+    ScopedList(value = value?.annotationEntries.orEmpty(), separator = " ")
 ) : Scope<KtTypeReference>(value) {
   override fun ElementScope.identity(): TypeReference = """$`@annotations`$typeElement""".type
 }

--- a/libs/arrow-meta/src/test/kotlin/arrow/meta/quotes/scope/templates/ClassBodyTest.kt
+++ b/libs/arrow-meta/src/test/kotlin/arrow/meta/quotes/scope/templates/ClassBodyTest.kt
@@ -58,7 +58,18 @@ class ClassBodyTest {
       | }
       | """.source
 
-    val classBodyExpressions = arrayOf(classBodyScopeTest, enumBodyScopeTest, objectBodyScopeTest)
+    private val annotationTest =
+      """
+      | //metadebug
+      | 
+      | @Deprecated("example") @Suppress("UNUSED_WARNINGS")
+      | class AnnotationTest {
+      |   public val x = 0
+      | }
+      """.source
+
+    val classBodyExpressions =
+      arrayOf(classBodyScopeTest, enumBodyScopeTest, objectBodyScopeTest, annotationTest)
   }
 
   @Test
@@ -74,6 +85,11 @@ class ClassBodyTest {
   @Test
   fun `Validate object body scope properties`() {
     validate(objectBodyScopeTest)
+  }
+
+  @Test
+  fun `Validate several annotations for class`() {
+    validate(annotationTest)
   }
 
   private fun validate(source: Code.Source) {


### PR DESCRIPTION
Fix for https://github.com/arrow-kt/arrow-meta/issues/893

Add a whitespace as a separator for `@annotations` in `ClassOrObject`