### PR TITLE
Allow different extension names for Meta plug-ins

### DIFF
--- a/libs/gradle-plugin-commons/src/main/kotlin/arrow/meta/plugin/gradle/ArrowMetaGradlePlugin.kt
+++ b/libs/gradle-plugin-commons/src/main/kotlin/arrow/meta/plugin/gradle/ArrowMetaGradlePlugin.kt
@@ -25,10 +25,12 @@ public interface ArrowMetaGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
   public val dependencies: List<Triple<String, String, String>>
 
+  public val extensionName: String
+
   override fun apply(project: Project): Unit {
     val defaultPath = File("${project.buildDir}/generated/meta/").path
 
-    val extension = project.extensions.create("arrowMeta", ArrowMetaExtension::class.java)
+    val extension = project.extensions.create(extensionName, ArrowMetaExtension::class.java)
     extension.generatedSrcOutputDir.convention(defaultPath)
 
     val properties = Properties()

--- a/plugins/analysis/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/AnalysisGradlePlugin.kt
+++ b/plugins/analysis/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/AnalysisGradlePlugin.kt
@@ -5,6 +5,7 @@ public class AnalysisGradlePlugin : ArrowMetaGradlePlugin {
   override val artifactId: String = "arrow-analysis-kotlin-plugin"
   override val version: String = "1.5.31-SNAPSHOT"
   override val pluginId: String = "io.arrow-kt.analysis"
+  override val extensionName: String = "arrowAnalysis"
 
   override val dependencies: List<Triple<String, String, String>> =
     listOf(

--- a/plugins/optics/optics-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/OpticsGradlePlugin.kt
+++ b/plugins/optics/optics-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/OpticsGradlePlugin.kt
@@ -5,6 +5,7 @@ public class OpticsGradlePlugin : ArrowMetaGradlePlugin {
   override val artifactId: String = "arrow-optics-plugin"
   override val version: String = "1.5.31-SNAPSHOT"
   override val pluginId: String = "io.arrow-kt.optics"
+  override val extensionName: String = "arrowOptics"
 
   override val dependencies: List<Triple<String, String, String>> =
     listOf(Triple(groupId, "arrow-optics", "1.0.0"))

--- a/plugins/proofs/proofs-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ProofsGradlePlugin.kt
+++ b/plugins/proofs/proofs-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ProofsGradlePlugin.kt
@@ -5,6 +5,7 @@ public class ProofsGradlePlugin : ArrowMetaGradlePlugin {
   override val artifactId: String = "arrow-proofs-plugin"
   override val version: String = "1.5.31-SNAPSHOT"
   override val pluginId: String = "io.arrow-kt.proofs"
+  override val extensionName: String = "arrowProofs"
 
   override val dependencies: List<Triple<String, String, String>> =
     listOf(


### PR DESCRIPTION
This is needed to apply several compiler plug-ins over the same project.