### PR TITLE
Use different compiler ids for each plugin

### DIFF
--- a/gradle/projects.libs.versions.toml
+++ b/gradle/projects.libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 arrow = "1.0.0"
-arrowGradleConfig = "0.4.1"
+arrowGradleConfig = "0.5.2-alpha.6"
 assertj = "3.21.0"
 classgraph = "4.8.129"
 dokka = "1.5.31"

--- a/libs/gradle-plugin-commons/src/main/kotlin/arrow/meta/plugin/gradle/ArrowMetaGradlePlugin.kt
+++ b/libs/gradle-plugin-commons/src/main/kotlin/arrow/meta/plugin/gradle/ArrowMetaGradlePlugin.kt
@@ -25,11 +25,10 @@ public interface ArrowMetaGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
   public val dependencies: List<Triple<String, String, String>>
 
-  public val extensionName: String
-
   override fun apply(project: Project): Unit {
     val defaultPath = File("${project.buildDir}/generated/meta/").path
 
+    val extensionName = "arrow.meta.$pluginId"
     val extension = project.extensions.create(extensionName, ArrowMetaExtension::class.java)
     extension.generatedSrcOutputDir.convention(defaultPath)
 
@@ -78,7 +77,7 @@ public interface ArrowMetaGradlePlugin : KotlinCompilerPluginSupportPlugin {
     }
   }
 
-  override fun getCompilerPluginId(): String = "arrow.meta.plugin.compiler"
+  override fun getCompilerPluginId(): String = "arrow.meta.plugin.compiler.$pluginId"
 
   override fun isApplicable(kotlinCompilation: KotlinCompilation<*>): Boolean = true
 

--- a/plugins/analysis/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/AnalysisGradlePlugin.kt
+++ b/plugins/analysis/gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/AnalysisGradlePlugin.kt
@@ -4,8 +4,7 @@ public class AnalysisGradlePlugin : ArrowMetaGradlePlugin {
   override val groupId: String = "io.arrow-kt"
   override val artifactId: String = "arrow-analysis-kotlin-plugin"
   override val version: String = "1.5.31-SNAPSHOT"
-  override val pluginId: String = "io.arrow-kt.analysis"
-  override val extensionName: String = "arrowAnalysis"
+  override val pluginId: String = "analysis"
 
   override val dependencies: List<Triple<String, String, String>> =
     listOf(

--- a/plugins/optics/optics-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/OpticsGradlePlugin.kt
+++ b/plugins/optics/optics-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/OpticsGradlePlugin.kt
@@ -4,9 +4,8 @@ public class OpticsGradlePlugin : ArrowMetaGradlePlugin {
   override val groupId: String = "io.arrow-kt"
   override val artifactId: String = "arrow-optics-plugin"
   override val version: String = "1.5.31-SNAPSHOT"
-  override val pluginId: String = "io.arrow-kt.optics"
-  override val extensionName: String = "arrowOptics"
+  override val pluginId: String = "optics"
 
   override val dependencies: List<Triple<String, String, String>> =
-    listOf(Triple(groupId, "arrow-optics", "1.0.0"))
+    listOf(Triple(groupId, "arrow-optics", "1.0.1"))
 }

--- a/plugins/proofs/proofs-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ProofsGradlePlugin.kt
+++ b/plugins/proofs/proofs-gradle-plugin/src/main/kotlin/arrow/meta/plugin/gradle/ProofsGradlePlugin.kt
@@ -4,8 +4,7 @@ public class ProofsGradlePlugin : ArrowMetaGradlePlugin {
   override val groupId: String = "io.arrow-kt"
   override val artifactId: String = "arrow-proofs-plugin"
   override val version: String = "1.5.31-SNAPSHOT"
-  override val pluginId: String = "io.arrow-kt.proofs"
-  override val extensionName: String = "arrowProofs"
+  override val pluginId: String = "proofs"
 
   override val dependencies: List<Triple<String, String, String>> =
     listOf(


### PR DESCRIPTION
The goal is to be able to apply more than one plug-in in a project, which now fails with the error:

```
> Task :compileKotlin
'compileJava' task (current target is 17) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
e: Multiple values are not allowed for plugin option arrow.meta.plugin.compiler:generatedSrcOutputDir

Plugin "arrow.meta.plugin.compiler" usage:
  generatedSrcOutputDir arrow-meta-gen-src-output-dir
                             Directory to locate generated sources
```