### PR TITLE
[Analysis] Add more fallbacks to Kotlin analysis interpreter

### DIFF
--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/ast/KotlinInterpreter.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/ast/KotlinInterpreter.kt
@@ -42,7 +42,11 @@ fun <
     is ReceiverParameterDescriptor -> KotlinReceiverParameterDescriptor(this).repr()
     is LocalVariableDescriptor -> KotlinLocalVariableDescriptor(this).repr()
     is PackageFragmentDescriptor -> KotlinPackageFragmentDescriptor(this).repr()
+    // fallback cases: we sometimes find unknown descriptors
+    // and for those cases we need nothing else than what the
+    // abstract classes provide
     is FunctionDescriptor -> (object : KotlinFunctionDescriptor(this) {}).repr()
+    is VariableDescriptor -> (object : KotlinVariableDescriptor(this) {}).repr()
     else -> TODO("Missing impl for $this (${this.javaClass.name})")
   }
 

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinLocalVariableDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinLocalVariableDescriptor.kt
@@ -3,7 +3,7 @@ package arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.descriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.LocalVariableDescriptor
 
 class KotlinLocalVariableDescriptor(
-  val impl: org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
-) : LocalVariableDescriptor, KotlinVariableDescriptor {
+  override val impl: org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
+) : LocalVariableDescriptor, KotlinVariableDescriptor(impl) {
   override fun impl(): org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor = impl
 }

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinPropertyDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinPropertyDescriptor.kt
@@ -5,8 +5,10 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.PropertyDescriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.ast.model
 
-class KotlinPropertyDescriptor(val impl: org.jetbrains.kotlin.descriptors.PropertyDescriptor) :
-  PropertyDescriptor, KotlinVariableDescriptorWithAccessors, KotlinCallableMemberDescriptor {
+class KotlinPropertyDescriptor(
+  override val impl: org.jetbrains.kotlin.descriptors.PropertyDescriptor
+) :
+  PropertyDescriptor, KotlinVariableDescriptorWithAccessors(impl), KotlinCallableMemberDescriptor {
   override fun impl(): org.jetbrains.kotlin.descriptors.PropertyDescriptor = impl
   override val isSetterProjectedOut: Boolean
     get() = impl().isSetterProjectedOut

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinValueParameterDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinValueParameterDescriptor.kt
@@ -9,8 +9,8 @@ import org.jetbrains.kotlin.psi.KtParameter
 import org.jetbrains.kotlin.resolve.source.getPsi
 
 class KotlinValueParameterDescriptor(
-  val impl: org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
-) : ValueParameterDescriptor, KotlinVariableDescriptor, KotlinParameterDescriptor {
+  override val impl: org.jetbrains.kotlin.descriptors.ValueParameterDescriptor
+) : ValueParameterDescriptor, KotlinVariableDescriptor(impl), KotlinParameterDescriptor {
   override fun impl(): org.jetbrains.kotlin.descriptors.ValueParameterDescriptor = impl
   override val index: Int
     get() = impl().index

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinVariableDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinVariableDescriptor.kt
@@ -2,9 +2,12 @@ package arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.descriptor
 
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.VariableDescriptor
 
-fun interface KotlinVariableDescriptor : VariableDescriptor, KotlinValueDescriptor {
+abstract class KotlinVariableDescriptor(
+  open val impl: org.jetbrains.kotlin.descriptors.VariableDescriptor
+) : VariableDescriptor, KotlinValueDescriptor {
 
-  override fun impl(): org.jetbrains.kotlin.descriptors.VariableDescriptor
+  override fun impl(): org.jetbrains.kotlin.descriptors.VariableDescriptor = impl
+
   override val isVar: Boolean
     get() = impl().isVar
   override val isConst: Boolean

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinVariableDescriptorWithAccessors.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinVariableDescriptorWithAccessors.kt
@@ -4,10 +4,11 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.VariableDescriptorWithAccessors
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.ast.model
 
-fun interface KotlinVariableDescriptorWithAccessors :
-  VariableDescriptorWithAccessors, KotlinVariableDescriptor {
+abstract class KotlinVariableDescriptorWithAccessors(
+  override val impl: org.jetbrains.kotlin.descriptors.VariableDescriptorWithAccessors
+) : VariableDescriptorWithAccessors, KotlinVariableDescriptor(impl) {
 
-  override fun impl(): org.jetbrains.kotlin.descriptors.VariableDescriptorWithAccessors
+  override fun impl(): org.jetbrains.kotlin.descriptors.VariableDescriptorWithAccessors = impl
   override val getter: VariableAccessorDescriptor?
     get() = impl().getter?.model()
   override val isDelegated: Boolean


### PR DESCRIPTION
Sometimes the Kotlin compiler surprises us with more members of the `Descriptor` hiearchy. For most of them we do not really want to do something special, so I've reworked the `model` call to take care of those with a fallback implementation.

This has bitten me in particular while using the Analysis plug-in in an external project:

```
e: kotlin.NotImplementedError: An operation is not implemented: Missing impl for org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject@d1bb6a5 (org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject)
        at arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.ast.KotlinInterpreterKt.model(KotlinInterpreter.kt:46)
```