### PR TITLE
[Analysis] Improvements to formula dump

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/utils/FormulaToKotlin.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/utils/FormulaToKotlin.kt
@@ -22,53 +22,63 @@ internal class DefaultKotlinPrinter(
 
   override fun Formula.dumpKotlinLike(): String {
     val str = StringBuilder()
-    fmgr.visit(this, KotlinPrintVisitor(fmgr, str, nameProvider))
+    fmgr.visit(this, KotlinPrintVisitor(fmgr, str, nameProvider, false, false))
     return str.toString()
   }
 
-  private class KotlinPrintVisitor(
+  private data class KotlinPrintVisitor(
     private val fmgr: FormulaManager,
     private val out: StringBuilder,
-    private val nameProvider: NameProvider
+    private val nameProvider: NameProvider,
+    private val parensContext: Boolean,
+    private val negatedContext: Boolean
   ) : DefaultFormulaVisitor<Void?>() {
 
     override fun visitDefault(pF: Formula): Void? {
-      nameProvider.mirroredElement(pF.toString())?.let { out.append(it.element.text) }
-        ?: out.append(pF)
+      if (negatedContext) out.append('!')
+
+      val text = nameProvider.mirroredElement(pF.toString())?.element?.text ?: pF.toString()
+      val needsParens = (parensContext || negatedContext) && text.contains(' ')
+      if (needsParens) out.append('(')
+      out.append(text)
+      if (needsParens) out.append(')')
+
       return null
     }
 
     private enum class Render {
-      Unary,
+      Negation,
+      Postfix,
       Binary,
       Hidden,
       Field,
       Unsupported
     }
 
-    private fun FunctionDeclaration<*>.toKotlin(): Pair<Render, String> =
+    private fun FunctionDeclaration<*>.toKotlin(): Triple<Render, String, String?> =
       when (kind) {
-        FunctionDeclarationKind.AND -> Render.Binary to " && "
-        FunctionDeclarationKind.NOT -> Render.Unary to " ! "
-        FunctionDeclarationKind.OR -> Render.Binary to " || "
-        FunctionDeclarationKind.SUB -> Render.Binary to " - "
-        FunctionDeclarationKind.ADD -> Render.Binary to " + "
-        FunctionDeclarationKind.DIV -> Render.Binary to " / "
-        FunctionDeclarationKind.MUL -> Render.Binary to " * "
-        FunctionDeclarationKind.LT -> Render.Binary to " < "
-        FunctionDeclarationKind.LTE -> Render.Binary to " <= "
-        FunctionDeclarationKind.GT -> Render.Binary to " > "
-        FunctionDeclarationKind.GTE -> Render.Binary to " >= "
-        FunctionDeclarationKind.EQ -> Render.Binary to " == "
+        FunctionDeclarationKind.NOT -> Triple(Render.Negation, "!", null)
+        FunctionDeclarationKind.AND -> Triple(Render.Binary, "&&", null)
+        FunctionDeclarationKind.OR -> Triple(Render.Binary, "||", null)
+        FunctionDeclarationKind.SUB -> Triple(Render.Binary, "-", null)
+        FunctionDeclarationKind.ADD -> Triple(Render.Binary, "+", null)
+        FunctionDeclarationKind.DIV -> Triple(Render.Binary, "/", null)
+        FunctionDeclarationKind.MUL -> Triple(Render.Binary, "*", null)
+        FunctionDeclarationKind.LT -> Triple(Render.Binary, "<", ">=")
+        FunctionDeclarationKind.LTE -> Triple(Render.Binary, "<=", ">")
+        FunctionDeclarationKind.GT -> Triple(Render.Binary, ">", "<=")
+        FunctionDeclarationKind.GTE -> Triple(Render.Binary, ">=", "<")
+        FunctionDeclarationKind.EQ -> Triple(Render.Binary, "==", "!=")
         FunctionDeclarationKind.UF ->
           when (name) {
-            Solver.INT_VALUE_NAME -> Render.Hidden to ""
-            Solver.BOOL_VALUE_NAME -> Render.Hidden to ""
-            Solver.DECIMAL_VALUE_NAME -> Render.Hidden to ""
-            Solver.FIELD_FUNCTION_NAME -> Render.Field to name
-            else -> Render.Unsupported to "[unsupported UF: $name]"
+            Solver.INT_VALUE_NAME -> Triple(Render.Hidden, "", null)
+            Solver.BOOL_VALUE_NAME -> Triple(Render.Hidden, "", null)
+            Solver.DECIMAL_VALUE_NAME -> Triple(Render.Hidden, "", null)
+            Solver.FIELD_FUNCTION_NAME -> Triple(Render.Field, name, null)
+            Solver.IS_NULL_FUNCTION_NAME -> Triple(Render.Postfix, " == null", " != null")
+            else -> Triple(Render.Unsupported, "[unsupported UF: $name]", null)
           }
-        else -> Render.Unsupported to "[unsupported: $this]"
+        else -> Triple(Render.Unsupported, "[unsupported: $this]", null)
       }
 
     override fun visitFunction(
@@ -76,35 +86,42 @@ internal class DefaultKotlinPrinter(
       pArgs: List<Formula>,
       pFunctionDeclaration: FunctionDeclaration<*>
     ): Void? {
-      val (render, name) = pFunctionDeclaration.toKotlin()
-      val notUF = pFunctionDeclaration.kind != FunctionDeclarationKind.UF
-      if (notUF) {
-        out.append("(")
-      }
+      val (render, name, negatedName) = pFunctionDeclaration.toKotlin()
       when (render) {
-        Render.Unary -> {
-          out.append(name)
-          fmgr.visit(pArgs[0], this)
-        }
-        Render.Binary -> {
-          fmgr.visit(pArgs[0], this)
-          out.append(name)
-          fmgr.visit(pArgs[1], this)
-        }
-        Render.Unsupported -> {
+        Render.Hidden, Render.Unsupported -> {
           pArgs.forEach { arg -> fmgr.visit(arg, this) }
         }
-        Render.Hidden -> {
-          pArgs.forEach { arg -> fmgr.visit(arg, this) }
+        Render.Negation -> {
+          fmgr.visit(pArgs[0], this.copy(negatedContext = !negatedContext))
         }
-        Render.Field -> {
-          fmgr.visit(pArgs[1], this)
-          out.append(".")
-          out.append(pArgs[0].toString().substringAfterLast("."))
+        else -> {
+          val mustBeNegated = negatedContext && negatedName == null
+          val needsParens = parensContext || mustBeNegated
+          val nameToShow = if (negatedContext && negatedName != null) negatedName else name
+
+          if (mustBeNegated) out.append('!')
+          if (needsParens) out.append('(')
+          when (render) {
+            Render.Postfix -> {
+              fmgr.visit(pArgs[0], this.copy(parensContext = false, negatedContext = false))
+              out.append(nameToShow)
+            }
+            Render.Binary -> {
+              fmgr.visit(pArgs[0], this.copy(parensContext = true, negatedContext = false))
+              out.append(' ')
+              out.append(nameToShow)
+              out.append(' ')
+              fmgr.visit(pArgs[1], this.copy(parensContext = true, negatedContext = false))
+            }
+            Render.Field -> {
+              fmgr.visit(pArgs[1], this.copy(parensContext = false, negatedContext = false))
+              out.append(".")
+              out.append(pArgs[0].toString().substringAfterLast("."))
+            }
+            else -> {} // taken care of above
+          }
+          if (needsParens) out.append(')')
         }
-      }
-      if (notUF) {
-        out.append(")")
       }
       return null
     }

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -91,7 +91,7 @@ class AnalysisTests {
       """(
       withPlugin = {
         failsWith {
-          it.contains("declaration `bar` fails to satisfy the post-condition: (${'$'}result < 0)")
+          it.contains("declaration `bar` fails to satisfy the post-condition: ${'$'}result < 0")
         }
       },
       withoutPlugin = { compiles }
@@ -107,9 +107,8 @@ class AnalysisTests {
       """(
       withPlugin = {
         failsWith {
-          it.contains(
-            "declaration `bar` fails to satisfy the post-condition: (${'$'}result > 0)"
-          ) && it.contains("in branch: ( ! x > 0)")
+          it.contains("declaration `bar` fails to satisfy the post-condition: ${'$'}result > 0") &&
+            it.contains("in branch: !(x > 0)")
         }
       },
       withoutPlugin = { compiles }
@@ -152,7 +151,7 @@ class AnalysisTests {
       """(
       withPlugin = {
         failsWith {
-          it.contains("declaration `bar` fails to satisfy the post-condition: (${'$'}result > 0)")
+          it.contains("declaration `bar` fails to satisfy the post-condition: ${'$'}result > 0")
         }
       },
       withoutPlugin = { compiles }
@@ -186,7 +185,7 @@ class AnalysisTests {
       """(
       withPlugin = {
         failsWith {
-          it.contains("declaration `bar` fails to satisfy the post-condition: (${'$'}result > 0)")
+          it.contains("declaration `bar` fails to satisfy the post-condition: ${'$'}result > 0")
         }
       },
       withoutPlugin = { compiles }


### PR DESCRIPTION
This PR changes part of the logic for showing a formula back to a user, and fixes some corner cases:
- better handling of negation: whereas before we had `(! x > 0)` now we proper show `!(x > 0)`,
- special cases for negating equality or comparisons in formulae,
- better handling of parentheses,
- the `null` special function is now shown as in `x == null`