### PR TITLE
Use different MetaCliProcessors

### DIFF
--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/MetaCliProcessor.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/MetaCliProcessor.kt
@@ -13,7 +13,7 @@ object ArrowMetaConfigurationKeys {
     CompilerConfigurationKey<List<String>>("directory to locate sources")
 }
 
-class MetaCliProcessor : CommandLineProcessor {
+abstract class MetaCliProcessor(private val metaPluginId: String) : CommandLineProcessor {
 
   companion object {
     val ARROW_META_GENERATED_SRC_OUTPUT_DIR =
@@ -27,7 +27,7 @@ class MetaCliProcessor : CommandLineProcessor {
   }
 
   /** The Arrow Meta Compiler Plugin Id */
-  override val pluginId: String = "arrow.meta.plugin.compiler"
+  override val pluginId: String = "arrow.meta.plugin.compiler.$metaPluginId"
 
   override val pluginOptions: Collection<CliOption> = listOf(ARROW_META_GENERATED_SRC_OUTPUT_DIR)
 

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/analysis/DefaultElementScope.kt
@@ -493,7 +493,7 @@ fun getOrCreateBaseDirectory(configuration: CompilerConfiguration?): java.io.Fil
     configuration?.get(ArrowMetaConfigurationKeys.GENERATED_SRC_OUTPUT_DIR)?.firstOrNull()
       ?: System.getProperty("arrow.meta.generate.source.dir")
   checkNotNull(parentBuildPath) {
-    "Generated sources output dir is not found: ${ArrowMetaConfigurationKeys.GENERATED_SRC_OUTPUT_DIR}"
+    "Generated sources output dir is not found: ${configuration?.get(ArrowMetaConfigurationKeys.GENERATED_SRC_OUTPUT_DIR)} ${System.getProperty("arrow.meta.generate.source.dir")}"
   }
   val directory = java.io.File("$parentBuildPath")
   directory.mkdirs()

--- a/libs/arrow-meta/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/libs/arrow-meta/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,1 +1,0 @@
-arrow.meta.MetaCliProcessor

--- a/libs/gradle-plugin-commons/src/main/kotlin/arrow/meta/plugin/gradle/ArrowMetaGradlePlugin.kt
+++ b/libs/gradle-plugin-commons/src/main/kotlin/arrow/meta/plugin/gradle/ArrowMetaGradlePlugin.kt
@@ -25,11 +25,12 @@ public interface ArrowMetaGradlePlugin : KotlinCompilerPluginSupportPlugin {
 
   public val dependencies: List<Triple<String, String, String>>
 
+  private fun extensionName() = "arrow.meta.$pluginId"
+
   override fun apply(project: Project): Unit {
     val defaultPath = File("${project.buildDir}/generated/meta/").path
 
-    val extensionName = "arrow.meta.$pluginId"
-    val extension = project.extensions.create(extensionName, ArrowMetaExtension::class.java)
+    val extension = project.extensions.create(extensionName(), ArrowMetaExtension::class.java)
     extension.generatedSrcOutputDir.convention(defaultPath)
 
     val properties = Properties()
@@ -65,7 +66,7 @@ public interface ArrowMetaGradlePlugin : KotlinCompilerPluginSupportPlugin {
     kotlinCompilation: KotlinCompilation<*>
   ): Provider<List<SubpluginOption>> {
     val project = kotlinCompilation.target.project
-    val extension = project.extensions.getByType(ArrowMetaExtension::class.java)
+    val extension = project.extensions.getByName(extensionName()) as ArrowMetaExtension
     return project.provider {
       listOf(
         SubpluginOption(

--- a/plugins/analysis/example/build.gradle.kts
+++ b/plugins/analysis/example/build.gradle.kts
@@ -36,7 +36,7 @@ tasks.compileKotlinJvm {
   kotlinOptions {
     freeCompilerArgs = listOf(
       "-Xplugin=$rootDir/plugins/analysis/kotlin-plugin/build/libs/arrow-analysis-kotlin-plugin-1.5.31-SNAPSHOT.jar",
-      "-P", "plugin:arrow.meta.plugin.compiler:generatedSrcOutputDir=$buildDir/generated/meta"
+      "-P", "plugin:arrow.meta.plugin.compiler.analysis:generatedSrcOutputDir=$buildDir/generated/meta"
     )
   }
 }

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/AnalysisPlugin.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/AnalysisPlugin.kt
@@ -7,3 +7,5 @@ open class AnalysisPlugin : Meta {
   override fun intercept(ctx: CompilerContext): List<CliPlugin> =
     listOf("Arrow Analysis" { meta(analysisPhases()) })
 }
+
+class AnalysisMetaCliProcessor : MetaCliProcessor("analysis")

--- a/plugins/analysis/kotlin-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/plugins/analysis/kotlin-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,1 +1,1 @@
-arrow.meta.MetaCliProcessor
+arrow.meta.AnalysisMetaCliProcessor

--- a/plugins/analysis/laws/build.gradle.kts
+++ b/plugins/analysis/laws/build.gradle.kts
@@ -37,7 +37,7 @@ tasks.compileKotlinJvm {
     dependsOn(":arrow-analysis-kotlin-plugin:jar")
     freeCompilerArgs = listOf(
       "-Xplugin=$rootDir/plugins/analysis/kotlin-plugin/build/libs/arrow-analysis-kotlin-plugin-1.5.31-SNAPSHOT.jar",
-      "-P", "plugin:arrow.meta.plugin.compiler:generatedSrcOutputDir=$buildDir/generated/meta"
+      "-P", "plugin:arrow.meta.plugin.compiler.analysis:generatedSrcOutputDir=$buildDir/generated/meta"
     )
   }
 }

--- a/plugins/optics/optics-plugin/src/main/kotlin/arrow/meta/OpticsMetaPlugin.kt
+++ b/plugins/optics/optics-plugin/src/main/kotlin/arrow/meta/OpticsMetaPlugin.kt
@@ -15,3 +15,5 @@ open class OpticsMetaPlugin : Meta {
       optics
     )
 }
+
+class OpticsMetaCliProcessor : MetaCliProcessor("optics")

--- a/plugins/optics/optics-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/plugins/optics/optics-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+arrow.meta.OpticsMetaCliProcessor

--- a/plugins/proofs/proofs-plugin/src/main/kotlin/arrow/meta/ProofsMetaPlugin.kt
+++ b/plugins/proofs/proofs-plugin/src/main/kotlin/arrow/meta/ProofsMetaPlugin.kt
@@ -11,3 +11,5 @@ import arrow.meta.plugins.proofs.typeProofs
 open class ProofsMetaPlugin : Meta {
   override fun intercept(ctx: CompilerContext): List<CliPlugin> = listOf(typeProofs)
 }
+
+class ProofsMetaCliProcessor : MetaCliProcessor("proofs")

--- a/plugins/proofs/proofs-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+++ b/plugins/proofs/proofs-plugin/src/main/resources/META-INF/services/org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
@@ -1,0 +1,1 @@
+arrow.meta.ProofsMetaCliProcessor


### PR DESCRIPTION
I think this solves #926. The idea is that each plug-in should provide its own local configuration (which you can still override in a global fashion by setting the `arrow.meta.generated.src.folder` property). At least the plug-ins can now be applied without problems.