### PR TITLE
[Analysis] Fix problems with fields

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Declarations.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Declarations.kt
@@ -193,7 +193,8 @@ private fun SolverState.introduceImplicitProperties(
                 field(propertyDescriptor, solver.thisVariable)
               )
             }
-          )
+          ),
+          context
         )
       }
   }
@@ -297,13 +298,13 @@ private fun SolverState.checkLiskovConditions(
     // pre-conditions should be weaker,
     // so the immediate ones should be implied by the overridden ones
     val liskovPreOk = bracket {
-      overriddenConstraints.pre.forEach { addConstraint(it) }
+      overriddenConstraints.pre.forEach { addConstraint(it, context) }
       immediateConstraints.pre.all { checkLiskovWeakerPrecondition(it, context, declaration) }
     }
     // post-conditions should be stronger,
     // so the overridden ones should be implied by the immediate ones
     val liskovPostOk = bracket {
-      immediateConstraints.post.forEach { addConstraint(it) }
+      immediateConstraints.post.forEach { addConstraint(it, context) }
       overriddenConstraints.post.all { checkLiskovStrongerPostcondition(it, context, declaration) }
     }
     // check that both things are OK

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Parameters.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Parameters.kt
@@ -19,7 +19,7 @@ internal fun SolverState.initialParameters(
   val things = listOfNotNull(thisParam) + valueParams + listOfNotNull(result)
   return things.mapNotNull { param ->
     param.type?.let { ty ->
-      typeInvariants(context, ty, param.smtName).forEach { addConstraint(it) }
+      typeInvariants(context, ty, param.smtName).forEach { addConstraint(it, context) }
     }
     param.element?.let { element -> VarInfo(param.name, param.smtName, element) }
   }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/state/SolverInteraction.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/state/SolverInteraction.kt
@@ -46,8 +46,8 @@ internal fun SolverState.addAndCheckConsistency(
   context: ResolutionContext,
   message: (unsatCore: List<BooleanFormula>) -> Unit
 ): Boolean {
-  constraints.forEach { addConstraint(it) }
-  additionalFieldConstraints(constraints, context).forEach { addConstraint(it) }
+  constraints.forEach { addConstraint(it, context) }
+  additionalFieldConstraints(constraints, context).forEach { addConstraint(it, context) }
   return checkInconsistency(message)
 }
 
@@ -57,9 +57,9 @@ internal fun SolverState.checkImplicationOf(
   message: (model: Model) -> Unit
 ): Boolean = bracket {
   solver.booleans {
-    addConstraint(NamedConstraint("!(${constraint.msg})", not(constraint.formula)))
+    addConstraint(NamedConstraint("!(${constraint.msg})", not(constraint.formula)), context)
   }
-  additionalFieldConstraints(listOf(constraint), context).forEach { addConstraint(it) }
+  additionalFieldConstraints(listOf(constraint), context).forEach { addConstraint(it, context) }
   val unsat = prover.isUnsat
   if (!unsat) {
     message(prover.model)

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/state/SolverState.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/state/SolverState.kt
@@ -13,6 +13,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.collect.model.NamedCon
 import arrow.meta.plugins.analysis.phases.analysis.solver.search.typeInvariants
 import arrow.meta.plugins.analysis.smt.ObjectFormula
 import arrow.meta.plugins.analysis.smt.Solver
+import arrow.meta.plugins.analysis.smt.fieldNames
 import arrow.meta.plugins.analysis.smt.utils.FieldProvider
 import arrow.meta.plugins.analysis.smt.utils.NameProvider
 import arrow.meta.plugins.analysis.smt.utils.ReferencedElement
@@ -35,7 +36,7 @@ data class SolverState(
 
   private var parseErrors = false
 
-  fun signalParseErrors(): Unit {
+  fun signalParseErrors() {
     parseErrors = true
   }
 
@@ -66,13 +67,15 @@ data class SolverState(
         solverTrace.add("POP (scoped)")
       }
 
-  fun addConstraint(constraint: NamedConstraint) {
+  fun addConstraint(constraint: NamedConstraint, context: ResolutionContext) {
     prover.addConstraint(constraint.formula)
+    // introduce the field names
+    solver.formulaManager.fieldNames(constraint.formula).map { (fieldName, _) ->
+      context.descriptorFor(FqName(fieldName)).getOrNull(0)?.let { descriptor ->
+        fieldProvider.introduce(descriptor)
+      }
+    }
     solverTrace.add("${constraint.msg} : ${constraint.formula}")
-  }
-
-  fun addConstraintWithoutTrace(constraint: NamedConstraint) {
-    prover.addConstraint(constraint.formula)
   }
 
   fun newName(context: ResolutionContext, prefix: String, element: Element?): String =
@@ -88,7 +91,7 @@ data class SolverState(
     val info = element?.let { ReferencedElement(it, reference, type) }
     val newName = names.recordNewName(prefix, info)
     if (type != null && !type.isNullable()) {
-      typeInvariants(context, type, newName).forEach { addConstraint(it) }
+      typeInvariants(context, type, newName).forEach { addConstraint(it, context) }
     }
     return newName
   }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/utils/FieldProvider.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/utils/FieldProvider.kt
@@ -9,7 +9,7 @@ import org.sosy_lab.java_smt.api.ProverEnvironment
 class FieldProvider(
   private val solver: Solver,
   private val prover: ProverEnvironment,
-  private val basicFields: MutableMap<String, Long>,
+  internal val basicFields: MutableMap<String, Long>,
   private var current: Long
 ) {
 

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -769,6 +769,33 @@ class AnalysisTests {
   }
 
   @Test
+  fun `isEmpty is size == 0, on map`() {
+    """
+      ${imports()}
+      
+      @Law
+      inline fun <E> List<E>.getLaw(index: Int): E {
+        pre(index >= 0 && index < size) { "index within bounds" }
+        return get(index)
+      }
+      
+      @Law
+      inline fun <E> Collection<E>.isEmptyLaw(): Boolean =
+        isEmpty().post({ it == (size <= 0) }) { "empty when size is 0" }
+      
+      data class Order(val entries: List<Entry>)
+      data class Entry(val id: String, val amount: Int)
+      
+      fun Order.containsSingleValue() =
+        if (entries.isEmpty()) false
+        else entries.all { entry -> entry.id == entries[0].id }
+      """(
+      withPlugin = { compilesNoUnreachable },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
   fun `nullability, predicate with null, 1`() {
     """
       ${imports()}


### PR DESCRIPTION
I ran into a bug while working on the back-end example; it turned out that the numbering for fields was not correctly initialized at all spots. This was the result of one of the optimizations we applied, of not introducing field names until required; however some places were missing. I've added the check now to `addConstraint`, which is the single point of constraint addition in the system.