### PR TITLE
[Analysis] Two small things

### DIFF
--- a/gradle/projects.libs.versions.toml
+++ b/gradle/projects.libs.versions.toml
@@ -28,6 +28,7 @@ intellijOpenApi = { module = "com.intellij:openapi", version.ref = "intellijOpen
 javaAssist = { module = "org.javassist:javassist", version.ref = "javaAssist" }
 javaSmt = { module = "org.sosy-lab:java-smt", version.ref = "javaSmt" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
 kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable" }
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable" }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/context/elements/StringTemplateExpression.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/context/elements/StringTemplateExpression.kt
@@ -1,0 +1,11 @@
+package arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements
+
+sealed interface StringTemplateEntry
+
+data class StringTemplateEntryString(val string: String) : StringTemplateEntry
+
+data class StringTemplateEntryExpression(val expression: Expression) : StringTemplateEntry
+
+interface StringTemplateExpression : Expression {
+  val entries: List<StringTemplateEntry>
+}

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/errors/ErrorIds.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/errors/ErrorIds.kt
@@ -186,6 +186,9 @@ sealed interface ErrorIds {
              }
            ```
         """.trimIndent()
+
+      override val level: SeverityLevel
+        get() = SeverityLevel.Warning
     },
     InconsistentCallPost {
       override val fullDescription: String
@@ -195,6 +198,9 @@ sealed interface ErrorIds {
           that this function could not be called at all. 
           _This is really uncommon in practice_.
         """.trimIndent()
+
+      override val level: SeverityLevel
+        get() = SeverityLevel.Warning
     },
     InconsistentInvariants {
       override val fullDescription: String

--- a/plugins/analysis/kotlin-plugin/build.gradle.kts
+++ b/plugins/analysis/kotlin-plugin/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
   testImplementation(libs.kotlin.stdlibJDK8)
   testImplementation(libs.junit)
+  testImplementation(libs.junitEngine)
   testImplementation(projects.arrowMetaTest)
   testRuntimeOnly(projects.arrowMeta)
   testRuntimeOnly(projects.arrowAnalysisTypes)

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/ast/KotlinInterpreter.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/ast/KotlinInterpreter.kt
@@ -77,7 +77,7 @@ fun <A : KtElement, B : Element> A.model(): B =
     is KtBlockExpression -> KotlinBlockExpression(this).repr()
     is KtStringTemplateExpression ->
       if (!this.hasInterpolation()) KotlinConstantStringExpression(this).repr()
-      else KotlinDefaultExpression(this).repr()
+      else KotlinStringTemplateExpression(this).repr()
     is KtReturnExpression -> KotlinReturnExpression(this).repr()
     is KtParenthesizedExpression -> KotlinParenthesizedExpression(this).repr()
     is KtFunctionLiteral -> KotlinFunctionLiteral(this).repr()

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/elements/KotlinElement.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/elements/KotlinElement.kt
@@ -11,6 +11,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.ast.model
 import org.jetbrains.kotlin.cli.common.messages.MessageUtil
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.kotlin.psi.psiUtil.parents
 import org.jetbrains.kotlin.resolve.BindingContextUtils
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
@@ -33,9 +34,12 @@ fun interface KotlinElement : Element {
     }
 
   override fun parents(): List<Element> =
-    impl().parents.filter { it !is KtFile }.filterIsInstance<KtElement>().toList().map {
-      it.model()
-    }
+    impl()
+      .parents
+      .filter { it !is KtFile && it !is KtStringTemplateEntry }
+      .filterIsInstance<KtElement>()
+      .toList()
+      .map { it.model() }
 
   override fun location(): CompilerMessageSourceLocation? =
     MessageUtil.psiElementToMessageLocation(impl().psiOrParent)?.let {

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/elements/KotlinStringTemplateExpression.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/elements/KotlinStringTemplateExpression.kt
@@ -1,0 +1,27 @@
+package arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.elements
+
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.StringTemplateEntry
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.StringTemplateEntryExpression
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.StringTemplateEntryString
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.StringTemplateExpression
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.ast.model
+import org.jetbrains.kotlin.psi.KtEscapeStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtLiteralStringTemplateEntry
+import org.jetbrains.kotlin.psi.KtStringTemplateEntryWithExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+
+class KotlinStringTemplateExpression(val impl: KtStringTemplateExpression) :
+  StringTemplateExpression, KotlinExpression {
+  override fun impl(): KtStringTemplateExpression = impl
+
+  override val entries: List<StringTemplateEntry> =
+    impl.entries.mapNotNull { entry ->
+      when (entry) {
+        is KtEscapeStringTemplateEntry -> StringTemplateEntryString(entry.unescapedValue)
+        is KtLiteralStringTemplateEntry -> StringTemplateEntryString(entry.text)
+        is KtStringTemplateEntryWithExpression ->
+          entry.expression?.let { e -> StringTemplateEntryExpression(e.model()) }
+        else -> null
+      }
+    }
+}

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -1462,6 +1462,23 @@ class AnalysisTests {
   }
 
   @Test
+  fun `string templates, fail`() {
+    """
+      ${imports()}
+      ${stringLaws()}
+      fun bar(name: String): Int {
+        pre( name.isNotEmpty() ) { "not empty name" }
+        return 2
+      }
+      // we don't know upfront the length of the expression
+      val result = bar("${'$'}{1 + 2}")
+      """(
+      withPlugin = { failsWith { it.contains("pre-condition `not empty name` is not satisfied") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
   fun `late initialization, without this`() {
     """
       ${imports()}


### PR DESCRIPTION
1. Support for string templates
2. Change the level of "unreachable code" to a warning in SARIF, to align it with the Kotlin and Java plug-ins

These are both required for the `backend-example` to work well