### PR TITLE
[Analysis] Better analysis for empty lists

### DIFF
--- a/gradle/projects.libs.versions.toml
+++ b/gradle/projects.libs.versions.toml
@@ -8,6 +8,7 @@ dokka = "1.6.0"
 intellijOpenApi = "7.0.3"
 javaAssist = "3.28.0-GA"
 junit = "5.8.2"
+junitLauncher = "1.8.2"
 kotlin = "1.6.0"
 kotest = "3.4.2"
 javaSmt = "3.11.0"
@@ -28,6 +29,7 @@ javaAssist = { module = "org.javassist:javassist", version.ref = "javaAssist" }
 javaSmt = { module = "org.sosy-lab:java-smt", version.ref = "javaSmt" }
 junit = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
 junitEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit" }
+junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitLauncher" }
 kotlin-annotationProcessingEmbeddable = { module = "org.jetbrains.kotlin:kotlin-annotation-processing-embeddable" }
 kotlin-compiler = { module = "org.jetbrains.kotlin:kotlin-compiler" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable" }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/DescriptorUtils.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/DescriptorUtils.kt
@@ -198,13 +198,13 @@ internal fun Solver.renameConditions(
   val toParams = (to as? CallableDescriptor)?.valueParameters?.map { it.name.value }
   return if (fromParams != null && toParams != null) {
     val renamed = renameDeclarationConstraints(constraints, fromParams.zip(toParams).toMap())
-    DeclarationConstraints(to, renamed.pre, renamed.post, renamed.doesNothingOnEmptyCollection)
+    DeclarationConstraints(to, renamed.pre, renamed.post, renamed.doNotLookAtArgumentsWhen)
   } else {
     DeclarationConstraints(
       to,
       constraints.pre,
       constraints.post,
-      constraints.doesNothingOnEmptyCollection
+      constraints.doNotLookAtArgumentsWhen
     )
   }
 }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/DescriptorUtils.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/DescriptorUtils.kt
@@ -198,8 +198,13 @@ internal fun Solver.renameConditions(
   val toParams = (to as? CallableDescriptor)?.valueParameters?.map { it.name.value }
   return if (fromParams != null && toParams != null) {
     val renamed = renameDeclarationConstraints(constraints, fromParams.zip(toParams).toMap())
-    DeclarationConstraints(to, renamed.pre, renamed.post)
+    DeclarationConstraints(to, renamed.pre, renamed.post, renamed.doesNothingOnEmptyCollection)
   } else {
-    DeclarationConstraints(to, constraints.pre, constraints.post)
+    DeclarationConstraints(
+      to,
+      constraints.pre,
+      constraints.post,
+      constraints.doesNothingOnEmptyCollection
+    )
   }
 }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ResolvedCallUtils.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ResolvedCallUtils.kt
@@ -16,7 +16,8 @@ enum class SpecialKind {
   Post,
   Invariant,
   TrustCall,
-  TrustBlock
+  TrustBlock,
+  NotLookArgs
 }
 
 internal val ResolvedCall.specialKind: SpecialKind?
@@ -33,6 +34,8 @@ internal val ResolvedCall.specialKind: SpecialKind?
         SpecialKind.TrustCall
       FqName("arrow.analysis.unsafeBlock"), FqName("arrow.analysis.RefinementDSLKt.unsafeBlock") ->
         SpecialKind.TrustBlock
+      FqName("arrow.analysis.doNotLookAtArgumentsWhen"),
+      FqName("arrow.analysis.RefinementDSLKt.doNotLookAtArgumentsWhen") -> SpecialKind.NotLookArgs
       else -> null
     }
 

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/context/descriptors/Annotated.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/context/descriptors/Annotated.kt
@@ -17,9 +17,9 @@ interface Annotated {
   val packageWithLawsAnnotation: AnnotationDescriptor?
     get() = annotations().findAnnotation(FqName("arrow.analysis.PackagesWithLaws"))
 
-  val hasDoesNothingOnEmptyCollectionAnnotation: Boolean
-    get() = annotations().hasAnnotation(FqName("arrow.analysis.DoesNothingOnEmptyCollection"))
+  val hasDoNotLookAtArgumentsAnnotation: Boolean
+    get() = annotations().hasAnnotation(FqName("arrow.analysis.DoNotLookAtArguments"))
 }
 
 val Annotated.hasInterestingAnnotation: Boolean
-  get() = hasPreOrPostAnnotation || hasPreOrPostAnnotation
+  get() = hasPreOrPostAnnotation || hasDoNotLookAtArgumentsAnnotation

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/context/descriptors/Annotated.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/context/descriptors/Annotated.kt
@@ -16,4 +16,10 @@ interface Annotated {
 
   val packageWithLawsAnnotation: AnnotationDescriptor?
     get() = annotations().findAnnotation(FqName("arrow.analysis.PackagesWithLaws"))
+
+  val hasDoesNothingOnEmptyCollectionAnnotation: Boolean
+    get() = annotations().hasAnnotation(FqName("arrow.analysis.DoesNothingOnEmptyCollection"))
 }
+
+val Annotated.hasInterestingAnnotation: Boolean
+  get() = hasPreOrPostAnnotation || hasPreOrPostAnnotation

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Expressions.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Expressions.kt
@@ -101,6 +101,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.search.primitiveConstr
 import arrow.meta.plugins.analysis.phases.analysis.solver.search.typeInvariants
 import arrow.meta.plugins.analysis.phases.analysis.solver.specialKind
 import arrow.meta.plugins.analysis.phases.analysis.solver.state.SolverState
+import arrow.meta.plugins.analysis.phases.analysis.solver.state.addAndCheckConsistency
 import arrow.meta.plugins.analysis.phases.analysis.solver.state.checkCallPostConditionsInconsistencies
 import arrow.meta.plugins.analysis.phases.analysis.solver.state.checkCallPreConditionsImplication
 import arrow.meta.plugins.analysis.phases.analysis.solver.state.checkConditionsInconsistencies
@@ -110,6 +111,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.valueArgumentExpressio
 import arrow.meta.plugins.analysis.smt.ObjectFormula
 import arrow.meta.plugins.analysis.smt.renameObjectVariables
 import arrow.meta.plugins.analysis.smt.substituteDeclarationConstraints
+import arrow.meta.plugins.analysis.smt.substituteObjectVariables
 import arrow.meta.plugins.analysis.types.PrimitiveType
 import arrow.meta.plugins.analysis.types.asFloatingLiteral
 import arrow.meta.plugins.analysis.types.asIntegerLiteral
@@ -371,7 +373,8 @@ private fun SolverState.checkCallExpression(
   val specialKind = resolvedCall.specialKind
   val specialControlFlow = controlFlowAnyFunction(data.context, resolvedCall)
   return when {
-    specialKind == SpecialKind.Pre -> // ignore calls to 'pre'
+    specialKind == SpecialKind.Pre ||
+      specialKind == SpecialKind.NotLookArgs -> // ignore calls to 'pre' or not looking at args
     data.noReturn {}
     specialKind == SpecialKind.Post -> // ignore post arguments
     checkExpressionConstraints(
@@ -544,27 +547,26 @@ internal fun SolverState.checkRegularFunctionCall(
   ) { dataAfterReceiver ->
     val callConstraints =
       getConstraintsFor(resolvedCall) ?: primitiveConstraints(data.context, resolvedCall)
-    val doesNothingOnEmptyCollection = callConstraints?.doesNothingOnEmptyCollection == true
+    val doNotLook = callConstraints?.doNotLookAtArgumentsWhen.orEmpty()
     ContSeq {
-      if (doesNothingOnEmptyCollection) yield(true)
+      if (doNotLook.isNotEmpty()) yield(true)
       yield(false)
     }
       .flatMap { r -> continuationBracket.map { r } }
-      .flatMap { doesNothingOnEmptyCollectionCase ->
-        if (doesNothingOnEmptyCollectionCase) {
-          // when it does nothing on empty collection, don't even look at arguments
-          // 1. introduce the fact that size is zero
-          receiverExpr?.type(data.context)?.getField("size")?.let { sizeField ->
-            addConstraint(
+      .flatMap { doNotLookCase ->
+        if (doNotLookCase) {
+          // case when we do not have to look at arguments
+          // 1. introduce the facts when we do not go
+          val renamedNotLook =
+            doNotLook.map { c ->
               NamedConstraint(
-                "size is zero",
-                solver.ints {
-                  equal(solver.intValue(field(sizeField, receiverName)), makeNumber(0))
-                }
-              ),
-              data.context
-            )
-          }
+                c.msg,
+                solver.substituteObjectVariables(c.formula, mapOf(THIS_VAR_NAME to receiverName))
+              )
+            }
+          addAndCheckConsistency(renamedNotLook, data.context) { /* do nothing on failure */}
+          val dataAfterNotLook =
+            dataAfterReceiver.addBranch(renamedNotLook.map(NamedConstraint::formula))
           // 2. introduce the postconditions
           checkCallableDescriptor(
             associatedVarName,
@@ -576,25 +578,29 @@ internal fun SolverState.checkRegularFunctionCall(
             receiverName,
             resolvedCall.getReturnType(),
             expression,
-            dataAfterReceiver
+            dataAfterNotLook
           )
         } else {
-          if (doesNothingOnEmptyCollection) {
-            // in this case we know more information
-            receiverExpr?.type(data.context)?.getField("size")?.let { sizeField ->
-              addConstraint(
-                NamedConstraint(
-                  "size is not zero",
-                  solver.ints {
-                    greaterThan(solver.intValue(field(sizeField, receiverName)), makeNumber(0))
-                  }
-                ),
-                data.context
-              )
-            }
-          }
+          // introduce the fact that we are looking at the arguments, if present
+          val dataAfterNotLook =
+            if (doNotLook.isNotEmpty()) {
+              val renamedNotLook =
+                doNotLook.map { c ->
+                  NamedConstraint(
+                    "! ${c.msg}",
+                    solver.not(
+                      solver.substituteObjectVariables(
+                        c.formula,
+                        mapOf(THIS_VAR_NAME to receiverName)
+                      )
+                    )
+                  )
+                }
+              addAndCheckConsistency(renamedNotLook, data.context) { /* do nothing on failure */}
+              dataAfterReceiver.addBranch(renamedNotLook.map(NamedConstraint::formula))
+            } else dataAfterReceiver
           // regular case, check the arguments and move on normally
-          checkCallArguments(resolvedCall, dataAfterReceiver).flatMap {
+          checkCallArguments(resolvedCall, dataAfterNotLook).flatMap {
             (returnOrContinue, dataAfterArgs) ->
             returnOrContinue.fold(
               { r -> cont { StateAfter(r, dataAfterArgs) } },

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FindDescriptor.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FindDescriptor.kt
@@ -35,6 +35,7 @@ internal fun SolverState.addConstraints(
   descriptor: DeclarationDescriptor,
   preConstraints: ArrayList<NamedConstraint>,
   postConstraints: ArrayList<NamedConstraint>,
+  doesNothingOnEmptyCollection: Boolean,
   bindingContext: ResolutionContext
 ) {
   val lawSubject =
@@ -45,12 +46,22 @@ internal fun SolverState.addConstraints(
   if (lawSubject != null) {
     val renamed =
       solver.renameConditions(
-        DeclarationConstraints(descriptor, preConstraints, postConstraints),
+        DeclarationConstraints(
+          descriptor,
+          preConstraints,
+          postConstraints,
+          doesNothingOnEmptyCollection
+        ),
         lawSubject.withAliasUnwrapped
       )
-    callableConstraints.add(renamed.descriptor, ArrayList(renamed.pre), ArrayList(renamed.post))
+    callableConstraints.add(
+      renamed.descriptor,
+      ArrayList(renamed.pre),
+      ArrayList(renamed.post),
+      doesNothingOnEmptyCollection
+    )
   }
-  callableConstraints.add(descriptor, preConstraints, postConstraints)
+  callableConstraints.add(descriptor, preConstraints, postConstraints, doesNothingOnEmptyCollection)
 }
 
 /** Finds the target of a particular law by looking up its [arrow.analysis.Subject] annotation */
@@ -140,9 +151,8 @@ private fun getReturnedExpressionWithoutPostcondition(
   function: Function,
   bindingContext: ResolutionContext
 ): ResolvedCall? {
-  val lastElement = function.body()?.lastBlockStatementOrThis()
   val lastElementWithoutReturn =
-    when (lastElement) {
+    when (val lastElement = function.body()?.lastBlockStatementOrThis()) {
       is ReturnExpression -> lastElement.returnedExpression
       else -> lastElement
     }
@@ -172,7 +182,8 @@ private fun getReturnedExpressionWithoutPostcondition(
 private fun MutableMap<FqName, MutableList<DeclarationConstraints>>.add(
   descriptor: DeclarationDescriptor,
   pre: ArrayList<NamedConstraint>,
-  post: ArrayList<NamedConstraint>
+  post: ArrayList<NamedConstraint>,
+  doesNothingOnEmptyCollection: Boolean
 ) {
   val fqName = descriptor.fqNameSafe
   // create a new one if not existent
@@ -180,10 +191,16 @@ private fun MutableMap<FqName, MutableList<DeclarationConstraints>>.add(
   val list = this[fqName]!!
   // see if there's any compatible
   when (val ix = list.indexOfFirst { it.descriptor.isCompatibleWith(descriptor) }) {
-    -1 -> list.add(DeclarationConstraints(descriptor, pre, post))
+    -1 -> list.add(DeclarationConstraints(descriptor, pre, post, doesNothingOnEmptyCollection))
     else -> {
       val previous = list[ix]
-      list[ix] = DeclarationConstraints(descriptor, previous.pre + pre, previous.post + post)
+      list[ix] =
+        DeclarationConstraints(
+          descriptor,
+          previous.pre + pre,
+          previous.post + post,
+          previous.doesNothingOnEmptyCollection || doesNothingOnEmptyCollection
+        )
     }
   }
 }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FromAnnotations.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FromAnnotations.kt
@@ -86,24 +86,20 @@ internal fun SolverState.addConstraintsFromAnnotations(
       when (ann.fqName) {
         FqName("arrow.analysis.Pre") -> "pre"
         FqName("arrow.analysis.Post") -> "post"
+        FqName("arrow.analysis.DoNotLookAtArguments") -> "doNotLookAtArgumentsWhen"
         else -> null
       }?.let { element -> parseFormula(element, ann, descriptor) }
     }
-  val doesNothingOnEmptyCollection = descriptor.hasDoesNothingOnEmptyCollectionAnnotation
   if (constraints.isNotEmpty()) {
     val preConstraints = arrayListOf<NamedConstraint>()
     val postConstraints = arrayListOf<NamedConstraint>()
+    val notLookConstraints = arrayListOf<NamedConstraint>()
     constraints.forEach { (call, formula) ->
       if (call == "pre") preConstraints.addAll(formula)
       if (call == "post") postConstraints.addAll(formula)
+      if (call == "doNotLookAtArgumentsWhen") notLookConstraints.addAll(formula)
     }
-    addConstraints(
-      descriptor,
-      preConstraints,
-      postConstraints,
-      doesNothingOnEmptyCollection,
-      bindingContext
-    )
+    addConstraints(descriptor, preConstraints, postConstraints, notLookConstraints, bindingContext)
   }
 }
 

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FromAnnotations.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FromAnnotations.kt
@@ -7,6 +7,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.CallableDescriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.DeclarationDescriptor
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.ModuleDescriptor
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.hasInterestingAnnotation
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.FqName
 import arrow.meta.plugins.analysis.phases.analysis.solver.collect.model.NamedConstraint
 import arrow.meta.plugins.analysis.phases.analysis.solver.gather
@@ -45,7 +46,7 @@ private fun SolverState.collectFromLocalDeclarations(
   localDeclarations: List<DeclarationDescriptor>,
   bindingTrace: ResolutionContext
 ) {
-  localDeclarations.flatMap { it.gather { it.hasPreOrPostAnnotation } }.forEach {
+  localDeclarations.flatMap { it.gather { it.hasInterestingAnnotation } }.forEach {
     addConstraintsFromAnnotations(it, bindingTrace)
   }
 }
@@ -58,7 +59,7 @@ private fun SolverState.collectFromClasspath(
     System.getProperty("ARROW_ANALYSIS_COLLECT_ENTIRE_CLASSPATH", "false").toBooleanStrictOrNull()
       ?: false
   if (collectEntireClasspath) {
-      module.gather(addSubPackages = true) { it.hasPreOrPostAnnotation }
+      module.gather(addSubPackages = true) { it.hasInterestingAnnotation }
     } else {
       // usual case: figure out the right packages from the hints
       val packagesWithLaws =
@@ -71,7 +72,7 @@ private fun SolverState.collectFromClasspath(
             it.packageWithLawsAnnotation?.argumentValueAsArrayOfString("packages").orEmpty()
           }
           .map { FqName(it) }
-      module.gather(packagesWithLaws, addSubPackages = false) { it.hasPreOrPostAnnotation }
+      module.gather(packagesWithLaws, addSubPackages = false) { it.hasInterestingAnnotation }
     }
     .forEach { addConstraintsFromAnnotations(it, bindingTrace) }
 }
@@ -88,6 +89,7 @@ internal fun SolverState.addConstraintsFromAnnotations(
         else -> null
       }?.let { element -> parseFormula(element, ann, descriptor) }
     }
+  val doesNothingOnEmptyCollection = descriptor.hasDoesNothingOnEmptyCollectionAnnotation
   if (constraints.isNotEmpty()) {
     val preConstraints = arrayListOf<NamedConstraint>()
     val postConstraints = arrayListOf<NamedConstraint>()
@@ -95,7 +97,13 @@ internal fun SolverState.addConstraintsFromAnnotations(
       if (call == "pre") preConstraints.addAll(formula)
       if (call == "post") postConstraints.addAll(formula)
     }
-    addConstraints(descriptor, preConstraints, postConstraints, bindingContext)
+    addConstraints(
+      descriptor,
+      preConstraints,
+      postConstraints,
+      doesNothingOnEmptyCollection,
+      bindingContext
+    )
   }
 }
 

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FromDSL.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/FromDSL.kt
@@ -61,6 +61,7 @@ public fun Declaration.collectConstraintsFromDSL(
         descriptor.constructors.single(),
         preConstraints,
         postConstraints,
+        doesNothingOnEmptyCollection = false,
         context
       )
     }
@@ -79,8 +80,18 @@ public fun Declaration.collectConstraintsFromDSL(
         constraintsFromFunctionLike(solverState, context, emptyList())
       else -> Pair(arrayListOf(), arrayListOf())
     }.let { (preConstraints, postConstraints) ->
-      if (preConstraints.isNotEmpty() || postConstraints.isNotEmpty()) {
-        solverState.addConstraints(descriptor, preConstraints, postConstraints, context)
+      val doesNothingOnEmptyCollection = descriptor.hasDoesNothingOnEmptyCollectionAnnotation
+      if (preConstraints.isNotEmpty() ||
+          postConstraints.isNotEmpty() ||
+          doesNothingOnEmptyCollection
+      ) {
+        solverState.addConstraints(
+          descriptor,
+          preConstraints,
+          postConstraints,
+          doesNothingOnEmptyCollection,
+          context
+        )
       }
     }
   }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/model/DeclarationConstraints.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/model/DeclarationConstraints.kt
@@ -5,5 +5,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptor
 data class DeclarationConstraints(
   val descriptor: DeclarationDescriptor,
   val pre: List<NamedConstraint>,
-  val post: List<NamedConstraint>
+  val post: List<NamedConstraint>,
+  /** special flag for functions like 'map' */
+  val doesNothingOnEmptyCollection: Boolean
 )

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/model/DeclarationConstraints.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/collect/model/DeclarationConstraints.kt
@@ -6,6 +6,5 @@ data class DeclarationConstraints(
   val descriptor: DeclarationDescriptor,
   val pre: List<NamedConstraint>,
   val post: List<NamedConstraint>,
-  /** special flag for functions like 'map' */
-  val doesNothingOnEmptyCollection: Boolean
+  val doNotLookAtArgumentsWhen: List<NamedConstraint>
 )

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/search/ConstraintSearch.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/search/ConstraintSearch.kt
@@ -1,6 +1,5 @@
 package arrow.meta.plugins.analysis.phases.analysis.solver.search
 
-import arrow.analysis.post
 import arrow.meta.plugins.analysis.phases.analysis.solver.RESULT_VAR_NAME
 import arrow.meta.plugins.analysis.phases.analysis.solver.THIS_VAR_NAME
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.ResolutionContext
@@ -54,7 +53,9 @@ internal fun SolverState.getImmediateConstraintsFor(
 ): DeclarationConstraints? =
   callableConstraints[descriptor.withAliasUnwrapped.fqNameSafe]
     ?.firstOrNull { d -> d.descriptor.isCompatibleWith(descriptor) }
-    ?.takeIf { d -> d.pre.isNotEmpty() || d.post.isNotEmpty() || d.doesNothingOnEmptyCollection }
+    ?.takeIf { d ->
+      d.pre.isNotEmpty() || d.post.isNotEmpty() || d.doNotLookAtArgumentsWhen.isNotEmpty()
+    }
 
 /**
  * The invariants are found in either:
@@ -173,7 +174,7 @@ internal fun SolverState.getOverriddenConstraintsFor(
         descriptor,
         overriddenConstraints.flatMap { it.pre },
         overriddenConstraints.flatMap { it.post },
-        overriddenConstraints.any { it.doesNothingOnEmptyCollection }
+        overriddenConstraints.flatMap { it.doNotLookAtArgumentsWhen }
       )
     }
 
@@ -235,7 +236,7 @@ internal fun SolverState.primitiveConstraints(
         else -> solver.objects { equal(solver.resultVariable, formula as ObjectFormula) }
       }?.let {
         val named = NamedConstraint("checkCallArguments(${descriptor.fqNameSafe})", it)
-        DeclarationConstraints(descriptor, emptyList(), listOf(named), false)
+        DeclarationConstraints(descriptor, emptyList(), listOf(named), emptyList())
       }
     }
   }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/search/ConstraintSearch.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/search/ConstraintSearch.kt
@@ -54,7 +54,7 @@ internal fun SolverState.getImmediateConstraintsFor(
 ): DeclarationConstraints? =
   callableConstraints[descriptor.withAliasUnwrapped.fqNameSafe]
     ?.firstOrNull { d -> d.descriptor.isCompatibleWith(descriptor) }
-    ?.takeIf { d -> d.pre.isNotEmpty() || d.post.isNotEmpty() }
+    ?.takeIf { d -> d.pre.isNotEmpty() || d.post.isNotEmpty() || d.doesNothingOnEmptyCollection }
 
 /**
  * The invariants are found in either:
@@ -172,7 +172,8 @@ internal fun SolverState.getOverriddenConstraintsFor(
       DeclarationConstraints(
         descriptor,
         overriddenConstraints.flatMap { it.pre },
-        overriddenConstraints.flatMap { it.post }
+        overriddenConstraints.flatMap { it.post },
+        overriddenConstraints.any { it.doesNothingOnEmptyCollection }
       )
     }
 
@@ -234,7 +235,7 @@ internal fun SolverState.primitiveConstraints(
         else -> solver.objects { equal(solver.resultVariable, formula as ObjectFormula) }
       }?.let {
         val named = NamedConstraint("checkCallArguments(${descriptor.fqNameSafe})", it)
-        DeclarationConstraints(descriptor, emptyList(), listOf(named))
+        DeclarationConstraints(descriptor, emptyList(), listOf(named), false)
       }
     }
   }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/FormulaExtensions.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/FormulaExtensions.kt
@@ -37,7 +37,8 @@ fun Solver.renameDeclarationConstraints(
   DeclarationConstraints(
     decl.descriptor,
     decl.pre.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) },
-    decl.post.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) }
+    decl.post.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) },
+    decl.doesNothingOnEmptyCollection
   )
 
 fun Solver.substituteDeclarationConstraints(
@@ -47,7 +48,8 @@ fun Solver.substituteDeclarationConstraints(
   DeclarationConstraints(
     decl.descriptor,
     decl.pre.map { NamedConstraint(it.msg, substituteObjectVariables(it.formula, mapping)) },
-    decl.post.map { NamedConstraint(it.msg, substituteObjectVariables(it.formula, mapping)) }
+    decl.post.map { NamedConstraint(it.msg, substituteObjectVariables(it.formula, mapping)) },
+    decl.doesNothingOnEmptyCollection
   )
 
 fun FormulaManager.fieldNames(f: Formula): Set<Pair<String, ObjectFormula>> {

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/FormulaExtensions.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/FormulaExtensions.kt
@@ -33,24 +33,28 @@ internal fun <T : Formula> Solver.substituteObjectVariables(
 fun Solver.renameDeclarationConstraints(
   decl: DeclarationConstraints,
   mapping: Map<String, String>
-): DeclarationConstraints =
-  DeclarationConstraints(
+): DeclarationConstraints {
+  fun go(c: NamedConstraint) = NamedConstraint(c.msg, renameObjectVariables(c.formula, mapping))
+  return DeclarationConstraints(
     decl.descriptor,
-    decl.pre.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) },
-    decl.post.map { NamedConstraint(it.msg, renameObjectVariables(it.formula, mapping)) },
-    decl.doesNothingOnEmptyCollection
+    decl.pre.map(::go),
+    decl.post.map(::go),
+    decl.doNotLookAtArgumentsWhen.map(::go)
   )
+}
 
 fun Solver.substituteDeclarationConstraints(
   decl: DeclarationConstraints,
   mapping: Map<String, ObjectFormula>
-): DeclarationConstraints =
-  DeclarationConstraints(
+): DeclarationConstraints {
+  fun go(c: NamedConstraint) = NamedConstraint(c.msg, substituteObjectVariables(c.formula, mapping))
+  return DeclarationConstraints(
     decl.descriptor,
-    decl.pre.map { NamedConstraint(it.msg, substituteObjectVariables(it.formula, mapping)) },
-    decl.post.map { NamedConstraint(it.msg, substituteObjectVariables(it.formula, mapping)) },
-    decl.doesNothingOnEmptyCollection
+    decl.pre.map(::go),
+    decl.post.map(::go),
+    decl.doNotLookAtArgumentsWhen.map(::go)
   )
+}
 
 fun FormulaManager.fieldNames(f: Formula): Set<Pair<String, ObjectFormula>> {
   val names = mutableSetOf<Pair<String, ObjectFormula>>()

--- a/plugins/analysis/example/src/commonMain/kotlin/arrow/analysis/BadExample.kt
+++ b/plugins/analysis/example/src/commonMain/kotlin/arrow/analysis/BadExample.kt
@@ -85,3 +85,5 @@ fun <A> List<A>.count(): Int {
   }
   return count.post({ it >= 0 }) { "result >= 0" }
 }
+
+fun <A> List<A>.isSingle() = all { it == first() }

--- a/plugins/analysis/java-plugin/src/main/kotlin/arrow/meta/plugins/analysis/java/ast/JavaResolutionContext.kt
+++ b/plugins/analysis/java-plugin/src/main/kotlin/arrow/meta/plugins/analysis/java/ast/JavaResolutionContext.kt
@@ -60,7 +60,9 @@ public class JavaResolutionContext(
               if (calleeText == "pre" ||
                   calleeText.endsWith(".pre") ||
                   calleeText == "post" ||
-                  calleeText.endsWith(".post")
+                  calleeText.endsWith(".post") ||
+                  calleeText == "doNotLookAtArgumentsWhen" ||
+                  calleeText.endsWith(".doNotLookAtArgumentsWhen")
               )
                 elements.add(node.model(ctx))
             }

--- a/plugins/analysis/kotlin-plugin/build.gradle.kts
+++ b/plugins/analysis/kotlin-plugin/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
   testImplementation(libs.kotlin.stdlibJDK8)
   testImplementation(libs.junit)
   testImplementation(libs.junitEngine)
+  testImplementation(libs.junitPlatformLauncher)
   testImplementation(projects.arrowMetaTest)
   testRuntimeOnly(projects.arrowMeta)
   testRuntimeOnly(projects.arrowAnalysisTypes)

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/KotlinResolutionContext.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/KotlinResolutionContext.kt
@@ -83,7 +83,8 @@ class KotlinResolutionContext(
     val visitor = callExpressionRecursiveVisitor {
       if (it.calleeExpression?.text == "pre" ||
           it.calleeExpression?.text == "post" ||
-          it.calleeExpression?.text == "require"
+          it.calleeExpression?.text == "require" ||
+          it.calleeExpression?.text == "doNotLookAtArgumentsWhen"
       ) {
         results.add(it)
       }

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/ir/ConstraintsAnnotations.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/ir/ConstraintsAnnotations.kt
@@ -45,6 +45,11 @@ internal fun IrUtils.annotateWithConstraints(solverState: SolverState, fn: IrFun
         postAnnotation(declarationConstraints.post, solverState.solver.formulaManager)?.let {
           fn.addAnnotation(it)
         }
+        notLookAnnotation(
+          declarationConstraints.doNotLookAtArgumentsWhen,
+          solverState.solver.formulaManager
+        )
+          ?.let { fn.addAnnotation(it) }
         if (model.isALaw()) {
           getIrReturnedExpressionWithoutPostcondition(fn)?.let { fnDescriptor ->
             lawSubjectAnnotation(fnDescriptor.withAliasUnwrapped)?.let { fn.addAnnotation(it) }
@@ -112,6 +117,17 @@ private fun IrUtils.postAnnotation(
 ): IrConstructorCall? =
   annotationFromClassId(
     ClassId.fromString("arrow/analysis/Post"),
+    formulae.map { it.msg },
+    formulae.map { it.formula.toString() },
+    formulae.flatMap { manager.fieldNames(it.formula).map { fld -> fld.first }.toSet() }
+  )
+
+private fun IrUtils.notLookAnnotation(
+  formulae: List<NamedConstraint>,
+  manager: FormulaManager
+): IrConstructorCall? =
+  annotationFromClassId(
+    ClassId.fromString("arrow/analysis/DoNotLookAtArguments"),
     formulae.map { it.msg },
     formulae.map { it.formula.toString() },
     formulae.flatMap { manager.fieldNames(it.formula).map { fld -> fld.first }.toSet() }

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -1607,8 +1607,9 @@ class AnalysisTests {
       ${imports()}
       ${collectionListLaws()}
       
-      @Law @DoesNothingOnEmptyCollection
+      @Law
       inline fun <E> List<E>.allLaw(predicate: (x: E) -> Boolean): Boolean {
+        doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
         return all(predicate)
       } 
       
@@ -1636,7 +1637,7 @@ import arrow.analysis.Post
 import arrow.analysis.Law
 import arrow.analysis.Laws
 import arrow.analysis.Subject
-import arrow.analysis.DoesNothingOnEmptyCollection
+import arrow.analysis.doNotLookAtArgumentsWhen
 import arrow.analysis.unsafeBlock
 import arrow.analysis.unsafeCall
 
@@ -1666,6 +1667,9 @@ object ListLaws {
     pre(size >= 1) { "not empty" }
     return first()
   }
+  @Law
+  inline fun <E> List<E>.isEmptyLaw(): Boolean =
+    isEmpty().post({ it == (size <= 0) }) { "empty list has size 0" }
 }
 """
 

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -1586,6 +1586,39 @@ class AnalysisTests {
       withoutPlugin = { compiles }
     )
   }
+
+  @Test
+  fun `do nothing on empty lists, without annotation`() {
+    """
+      ${imports()}
+      ${collectionListLaws()}
+      
+      fun List<Int>.containsSingleElement() =
+        this.all { n -> n == first() }
+      """(
+      withPlugin = { failsWith { it.contains("pre-condition `not empty` is not satisfied") } },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  fun `do nothing on empty lists, with annotation`() {
+    """
+      ${imports()}
+      ${collectionListLaws()}
+      
+      @Law @DoesNothingOnEmptyCollection
+      inline fun <E> List<E>.allLaw(predicate: (x: E) -> Boolean): Boolean {
+        return all(predicate)
+      } 
+      
+      fun List<Int>.containsSingleElement() =
+        this.all { n -> n == first() }
+      """(
+      withPlugin = { compilesNoUnreachable },
+      withoutPlugin = { compiles }
+    )
+  }
 }
 
 private val AssertSyntax.compilesNoUnreachable: Assert.SingleAssert
@@ -1603,6 +1636,7 @@ import arrow.analysis.Post
 import arrow.analysis.Law
 import arrow.analysis.Laws
 import arrow.analysis.Subject
+import arrow.analysis.DoesNothingOnEmptyCollection
 import arrow.analysis.unsafeBlock
 import arrow.analysis.unsafeCall
 

--- a/plugins/analysis/laws/src/commonMain/kotlin/arrow/analysis/laws/kotlin/Collections.kt
+++ b/plugins/analysis/laws/src/commonMain/kotlin/arrow/analysis/laws/kotlin/Collections.kt
@@ -3,9 +3,9 @@
 
 package arrow.analysis.laws.kotlin
 
-import arrow.analysis.DoesNothingOnEmptyCollection
 import arrow.analysis.Law
 import arrow.analysis.Laws
+import arrow.analysis.doNotLookAtArgumentsWhen
 import arrow.analysis.post
 import arrow.analysis.pre
 
@@ -22,9 +22,10 @@ object CollectionLaws {
   inline fun <E> Collection<E>.countLaw(): Int =
     count().post({ it == this.size }) { "count is size" }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> Collection<E>.countLaw(predicate: (E) -> Boolean): Int =
-    count(predicate).post({ it <= this.size }) { "count bounded by size" }
+  inline fun <E> Collection<E>.countLaw(predicate: (E) -> Boolean): Int {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return count(predicate).post({ it <= this.size }) { "count bounded by size" }
+  }
 
   @Law
   inline fun <E> Collection<E>.isEmptyLaw(): Boolean =
@@ -103,17 +104,19 @@ object CollectionLaws {
       "bounds for lastIndexOf"
     }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> Collection<E>.indexOfFirstLaw(predicate: (x: E) -> Boolean): Int =
-    indexOfFirst(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
+  inline fun <E> Collection<E>.indexOfFirstLaw(predicate: (x: E) -> Boolean): Int {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return indexOfFirst(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfFirst"
     }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> Collection<E>.indexOfLastLaw(predicate: (x: E) -> Boolean): Int =
-    indexOfLast(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
+  inline fun <E> Collection<E>.indexOfLastLaw(predicate: (x: E) -> Boolean): Int {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return indexOfLast(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfLast"
     }
+  }
 
   @Law
   inline fun <T> Collection<T>.randomLaw(): T {
@@ -131,30 +134,34 @@ object CollectionLaws {
       "size remains after unzip"
     }
   @Law
-  inline fun <T, R> Collection<T>.zipLaw(other: Collection<R>): List<Pair<T, R>> =
-    zip(other).post({ it.size <= this.size && it.size <= other.size }) {
+  inline fun <T, R> Collection<T>.zipLaw(other: Collection<R>): List<Pair<T, R>> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return zip(other).post({ it.size <= this.size && it.size <= other.size }) {
       "size bounded by the smallest"
     }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
   inline fun <T, R, V> Collection<T>.zipLaw(
     other: Collection<R>,
     transform: (a: T, b: R) -> V
-  ): List<V> =
-    zip(other, transform).post({ it.size <= this.size && it.size <= other.size }) {
+  ): List<V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return zip(other, transform).post({ it.size <= this.size && it.size <= other.size }) {
       "size bounded by the smallest"
     }
+  }
   @Law
   inline fun <T> Collection<T>.zipWithNextLaw(): List<Pair<T, T>> =
-    zipWithNext().post({ if (this.size == 0) (it.size == 0) else (it.size == this.size - 1) }) {
+    zipWithNext().post({ if (this.size < 2) (it.size == 0) else (it.size == this.size - 1) }) {
       "size is one less"
     }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <T, V> Collection<T>.zipWithNextLaw(transform: (a: T, b: T) -> V): List<V> =
-    zipWithNext(transform).post({
-      if (this.size == 0) (it.size == 0) else (it.size == this.size - 1)
+  inline fun <T, V> Collection<T>.zipWithNextLaw(transform: (a: T, b: T) -> V): List<V> {
+    doNotLookAtArgumentsWhen(size < 2) { "empty lists have no elements" }
+    return zipWithNext(transform).post({
+      if (this.size < 2) (it.size == 0) else (it.size == this.size - 1)
     }) { "size bounded by the smallest" }
+  }
 
   // operations which remove things
   @Law
@@ -171,23 +178,24 @@ object CollectionLaws {
   }
 
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> Collection<E>.filterLaw(predicate: (E) -> Boolean): List<E> =
-    filter(predicate).post({ it.size <= this.size }) { "bounds after filter" }
+  inline fun <E> Collection<E>.filterLaw(predicate: (E) -> Boolean): List<E> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filter(predicate).post({ it.size <= this.size }) { "bounds after filter" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> Collection<E>.filterNotLaw(predicate: (E) -> Boolean): List<E> =
-    filterNot(predicate).post({ it.size <= this.size }) { "bounds after filter" }
+  inline fun <E> Collection<E>.filterNotLaw(predicate: (E) -> Boolean): List<E> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filterNot(predicate).post({ it.size <= this.size }) { "bounds after filter" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E?>.filterNotNullLaw(): List<E> =
     filterNotNull().post({ it.size <= this.size }) { "bounds after filter" }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> Collection<E>.filterIndexedLaw(predicate: (Int, E) -> Boolean): List<E> =
-    filterIndexed(predicate).post({ it.size <= this.size }) { "bounds after filter" }
+  inline fun <E> Collection<E>.filterIndexedLaw(predicate: (Int, E) -> Boolean): List<E> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filterIndexed(predicate).post({ it.size <= this.size }) { "bounds after filter" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
   inline fun <reified R> Collection<*>.filterIsInstanceLaw(): List<R> =
     filterIsInstance<R>().post({ it.size <= this.size }) { "bounds after filter" }
 
@@ -195,9 +203,10 @@ object CollectionLaws {
   inline fun <E> Collection<E>.distinctLaw(): List<E> =
     distinct().post({ it.size <= this.size }) { "size bounded by original " }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <T, K> Collection<T>.distinctByLaw(selector: (T) -> K): List<T> =
-    distinctBy(selector).post({ it.size <= this.size }) { "size bounded by original " }
+  inline fun <T, K> Collection<T>.distinctByLaw(selector: (T) -> K): List<T> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return distinctBy(selector).post({ it.size <= this.size }) { "size bounded by original " }
+  }
 
   @Law
   inline fun <E> Collection<E>.plusLaw(element: E): List<E> =
@@ -230,16 +239,21 @@ object CollectionLaws {
   inline fun <E : Comparable<E>> Collection<E>.sortedDescendingLaw(): List<E> =
     sortedDescending().post({ it.size == this.size }) { "size remains after sorting" }
   @Law
-  @DoesNothingOnEmptyCollection
   inline fun <T, R : Comparable<R>> Collection<T>.sortedByLaw(
     crossinline selector: (T) -> R?
-  ): List<T> = sortedBy(selector).post({ it.size == this.size }) { "size remains after sorting" }
+  ): List<T> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return sortedBy(selector).post({ it.size == this.size }) { "size remains after sorting" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
   inline fun <T, R : Comparable<R>> Collection<T>.sortedByDescendingLaw(
     crossinline selector: (T) -> R?
-  ): List<T> =
-    sortedByDescending(selector).post({ it.size == this.size }) { "size remains after sorting" }
+  ): List<T> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return sortedByDescending(selector).post({ it.size == this.size }) {
+      "size remains after sorting"
+    }
+  }
   @Law
   inline fun <T> Collection<T>.sortedWithLaw(comparator: Comparator<in T>): List<T> =
     sortedWith(comparator).post({ it.size == this.size }) { "size remains after sorting" }
@@ -249,22 +263,28 @@ object CollectionLaws {
     shuffled().post({ it.size == this.size }) { "size remains after shuffle" }
 
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <A, B> Collection<A>.mapLaw(transform: (A) -> B): List<B> =
-    map(transform).post({ it.size == this.size }) { "size remains after map" }
+  inline fun <A, B> Collection<A>.mapLaw(transform: (A) -> B): List<B> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return map(transform).post({ it.size == this.size }) { "size remains after map" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <A, B> Collection<A>.mapIndexedLaw(transform: (Int, A) -> B): List<B> =
-    mapIndexed(transform).post({ it.size == this.size }) { "size remains after map" }
+  inline fun <A, B> Collection<A>.mapIndexedLaw(transform: (Int, A) -> B): List<B> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return mapIndexed(transform).post({ it.size == this.size }) { "size remains after map" }
+  }
 
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <A, B> Collection<A>.mapNotNullLaw(transform: (A) -> B?): List<B> =
-    mapNotNull(transform).post({ it.size <= this.size }) { "size bounded by original" }
+  inline fun <A, B> Collection<A>.mapNotNullLaw(transform: (A) -> B?): List<B> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return mapNotNull(transform).post({ it.size <= this.size }) { "size bounded by original" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <A, B> Collection<A>.mapIndexedNotNullLaw(transform: (Int, A) -> B?): List<B> =
-    mapIndexedNotNull(transform).post({ it.size == this.size }) { "size bounded by original" }
+  inline fun <A, B> Collection<A>.mapIndexedNotNullLaw(transform: (Int, A) -> B?): List<B> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return mapIndexedNotNull(transform).post({ it.size == this.size }) {
+      "size bounded by original"
+    }
+  }
 
   // operations between several collections
   @Law
@@ -322,7 +342,6 @@ object ListLaws {
     return last()
   }
   @Law
-  @DoesNothingOnEmptyCollection
   inline fun <E> List<E>.lastLaw(predicate: (x: E) -> Boolean): E {
     pre(size >= 1) { "not empty" }
     return last(predicate)
@@ -354,17 +373,19 @@ object ListLaws {
   inline fun <E> List<E>.lastIndexLaw(): Int =
     lastIndex.post({ it == size - 1 }) { "last index is size - 1" }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> List<E>.indexOfFirstLaw(predicate: (x: E) -> Boolean): Int =
-    indexOfFirst(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
+  inline fun <E> List<E>.indexOfFirstLaw(predicate: (x: E) -> Boolean): Int {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return indexOfFirst(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfFirst"
     }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <E> List<E>.indexOfLastLaw(predicate: (x: E) -> Boolean): Int =
-    indexOfLast(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
+  inline fun <E> List<E>.indexOfLastLaw(predicate: (x: E) -> Boolean): Int {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return indexOfLast(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfLast"
     }
+  }
 
   @Law
   inline fun <E> emptyListLaw(): List<E> =
@@ -525,30 +546,36 @@ object MapLaws {
     mutableMapOf(*elements).post({ it.size <= elements.size }) { "literal size" }
 
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <K, V, R> Map<out K, V>.mapValuesLaw(transform: (Map.Entry<K, V>) -> R): Map<K, R> =
-    mapValues(transform).post({ it.size == this.size }) { "size remains after mapValues" }
+  inline fun <K, V, R> Map<out K, V>.mapValuesLaw(transform: (Map.Entry<K, V>) -> R): Map<K, R> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return mapValues(transform).post({ it.size == this.size }) { "size remains after mapValues" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <K, V, R> Map<out K, V>.mapKeysLaw(transform: (Map.Entry<K, V>) -> R): Map<R, V> =
-    mapKeys(transform).post({ it.size <= this.size }) { "size bounded after mapKeys" }
+  inline fun <K, V, R> Map<out K, V>.mapKeysLaw(transform: (Map.Entry<K, V>) -> R): Map<R, V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return mapKeys(transform).post({ it.size <= this.size }) { "size bounded after mapKeys" }
+  }
 
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <K, V> Map<out K, V>.filterLaw(predicate: (Map.Entry<K, V>) -> Boolean): Map<K, V> =
-    filter(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  inline fun <K, V> Map<out K, V>.filterLaw(predicate: (Map.Entry<K, V>) -> Boolean): Map<K, V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filter(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <K, V> Map<out K, V>.filterNotLaw(predicate: (Map.Entry<K, V>) -> Boolean): Map<K, V> =
-    filterNot(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  inline fun <K, V> Map<out K, V>.filterNotLaw(predicate: (Map.Entry<K, V>) -> Boolean): Map<K, V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filterNot(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <K, V> Map<out K, V>.filterValuesLaw(predicate: (V) -> Boolean): Map<K, V> =
-    filterValues(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  inline fun <K, V> Map<out K, V>.filterValuesLaw(predicate: (V) -> Boolean): Map<K, V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filterValues(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <K, V> Map<out K, V>.filterKeysLaw(predicate: (K) -> Boolean): Map<K, V> =
-    filterKeys(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  inline fun <K, V> Map<out K, V>.filterKeysLaw(predicate: (K) -> Boolean): Map<K, V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return filterKeys(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
+  }
 
   @Law
   inline fun <K, V> Map<out K, V>.plusLaw(pair: Pair<K, V>): Map<K, V> =
@@ -590,17 +617,22 @@ object CollectionConversionsLaws {
   inline fun <K, V> Collection<Pair<K, V>>.toMapLaw(): Map<K, V> =
     toMap().post({ it.size <= this.size }) { "size bounded by collection" }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <T, K, V> Collection<T>.associateLaw(transform: (T) -> Pair<K, V>): Map<K, V> =
-    associate(transform).post({ it.size <= this.size }) { "size bounded by collection" }
+  inline fun <T, K, V> Collection<T>.associateLaw(transform: (T) -> Pair<K, V>): Map<K, V> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return associate(transform).post({ it.size <= this.size }) { "size bounded by collection" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <T, K> Collection<T>.associateByLaw(keySelector: (T) -> K): Map<K, T> =
-    associateBy(keySelector).post({ it.size <= this.size }) { "size bounded by collection" }
+  inline fun <T, K> Collection<T>.associateByLaw(keySelector: (T) -> K): Map<K, T> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return associateBy(keySelector).post({ it.size <= this.size }) { "size bounded by collection" }
+  }
   @Law
-  @DoesNothingOnEmptyCollection
-  inline fun <T, K> Collection<K>.associateWithLaw(valueSelector: (K) -> T): Map<K, T> =
-    associateWith(valueSelector).post({ it.size <= this.size }) { "size bounded by collection" }
+  inline fun <T, K> Collection<K>.associateWithLaw(valueSelector: (K) -> T): Map<K, T> {
+    doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
+    return associateWith(valueSelector).post({ it.size <= this.size }) {
+      "size bounded by collection"
+    }
+  }
 
   @Law
   inline fun <E> Collection<E>.toListLaw(): List<E> =

--- a/plugins/analysis/laws/src/commonMain/kotlin/arrow/analysis/laws/kotlin/Collections.kt
+++ b/plugins/analysis/laws/src/commonMain/kotlin/arrow/analysis/laws/kotlin/Collections.kt
@@ -3,6 +3,7 @@
 
 package arrow.analysis.laws.kotlin
 
+import arrow.analysis.DoesNothingOnEmptyCollection
 import arrow.analysis.Law
 import arrow.analysis.Laws
 import arrow.analysis.post
@@ -21,6 +22,7 @@ object CollectionLaws {
   inline fun <E> Collection<E>.countLaw(): Int =
     count().post({ it == this.size }) { "count is size" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E>.countLaw(predicate: (E) -> Boolean): Int =
     count(predicate).post({ it <= this.size }) { "count bounded by size" }
 
@@ -101,11 +103,13 @@ object CollectionLaws {
       "bounds for lastIndexOf"
     }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E>.indexOfFirstLaw(predicate: (x: E) -> Boolean): Int =
     indexOfFirst(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfFirst"
     }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E>.indexOfLastLaw(predicate: (x: E) -> Boolean): Int =
     indexOfLast(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfLast"
@@ -132,6 +136,7 @@ object CollectionLaws {
       "size bounded by the smallest"
     }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, R, V> Collection<T>.zipLaw(
     other: Collection<R>,
     transform: (a: T, b: R) -> V
@@ -145,6 +150,7 @@ object CollectionLaws {
       "size is one less"
     }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, V> Collection<T>.zipWithNextLaw(transform: (a: T, b: T) -> V): List<V> =
     zipWithNext(transform).post({
       if (this.size == 0) (it.size == 0) else (it.size == this.size - 1)
@@ -165,18 +171,23 @@ object CollectionLaws {
   }
 
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E>.filterLaw(predicate: (E) -> Boolean): List<E> =
     filter(predicate).post({ it.size <= this.size }) { "bounds after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E>.filterNotLaw(predicate: (E) -> Boolean): List<E> =
     filterNot(predicate).post({ it.size <= this.size }) { "bounds after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E?>.filterNotNullLaw(): List<E> =
     filterNotNull().post({ it.size <= this.size }) { "bounds after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> Collection<E>.filterIndexedLaw(predicate: (Int, E) -> Boolean): List<E> =
     filterIndexed(predicate).post({ it.size <= this.size }) { "bounds after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <reified R> Collection<*>.filterIsInstanceLaw(): List<R> =
     filterIsInstance<R>().post({ it.size <= this.size }) { "bounds after filter" }
 
@@ -184,6 +195,7 @@ object CollectionLaws {
   inline fun <E> Collection<E>.distinctLaw(): List<E> =
     distinct().post({ it.size <= this.size }) { "size bounded by original " }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, K> Collection<T>.distinctByLaw(selector: (T) -> K): List<T> =
     distinctBy(selector).post({ it.size <= this.size }) { "size bounded by original " }
 
@@ -218,10 +230,12 @@ object CollectionLaws {
   inline fun <E : Comparable<E>> Collection<E>.sortedDescendingLaw(): List<E> =
     sortedDescending().post({ it.size == this.size }) { "size remains after sorting" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, R : Comparable<R>> Collection<T>.sortedByLaw(
     crossinline selector: (T) -> R?
   ): List<T> = sortedBy(selector).post({ it.size == this.size }) { "size remains after sorting" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, R : Comparable<R>> Collection<T>.sortedByDescendingLaw(
     crossinline selector: (T) -> R?
   ): List<T> =
@@ -235,16 +249,20 @@ object CollectionLaws {
     shuffled().post({ it.size == this.size }) { "size remains after shuffle" }
 
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <A, B> Collection<A>.mapLaw(transform: (A) -> B): List<B> =
     map(transform).post({ it.size == this.size }) { "size remains after map" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <A, B> Collection<A>.mapIndexedLaw(transform: (Int, A) -> B): List<B> =
     mapIndexed(transform).post({ it.size == this.size }) { "size remains after map" }
 
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <A, B> Collection<A>.mapNotNullLaw(transform: (A) -> B?): List<B> =
     mapNotNull(transform).post({ it.size <= this.size }) { "size bounded by original" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <A, B> Collection<A>.mapIndexedNotNullLaw(transform: (Int, A) -> B?): List<B> =
     mapIndexedNotNull(transform).post({ it.size == this.size }) { "size bounded by original" }
 
@@ -304,6 +322,7 @@ object ListLaws {
     return last()
   }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> List<E>.lastLaw(predicate: (x: E) -> Boolean): E {
     pre(size >= 1) { "not empty" }
     return last(predicate)
@@ -335,11 +354,13 @@ object ListLaws {
   inline fun <E> List<E>.lastIndexLaw(): Int =
     lastIndex.post({ it == size - 1 }) { "last index is size - 1" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> List<E>.indexOfFirstLaw(predicate: (x: E) -> Boolean): Int =
     indexOfFirst(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfFirst"
     }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <E> List<E>.indexOfLastLaw(predicate: (x: E) -> Boolean): Int =
     indexOfLast(predicate).post({ if (this.size <= 0) (it == -1) else (it >= -1) }) {
       "bounds for indexOfLast"
@@ -504,22 +525,28 @@ object MapLaws {
     mutableMapOf(*elements).post({ it.size <= elements.size }) { "literal size" }
 
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <K, V, R> Map<out K, V>.mapValuesLaw(transform: (Map.Entry<K, V>) -> R): Map<K, R> =
     mapValues(transform).post({ it.size == this.size }) { "size remains after mapValues" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <K, V, R> Map<out K, V>.mapKeysLaw(transform: (Map.Entry<K, V>) -> R): Map<R, V> =
     mapKeys(transform).post({ it.size <= this.size }) { "size bounded after mapKeys" }
 
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <K, V> Map<out K, V>.filterLaw(predicate: (Map.Entry<K, V>) -> Boolean): Map<K, V> =
     filter(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <K, V> Map<out K, V>.filterNotLaw(predicate: (Map.Entry<K, V>) -> Boolean): Map<K, V> =
     filterNot(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <K, V> Map<out K, V>.filterValuesLaw(predicate: (V) -> Boolean): Map<K, V> =
     filterValues(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <K, V> Map<out K, V>.filterKeysLaw(predicate: (K) -> Boolean): Map<K, V> =
     filterKeys(predicate).post({ it.size <= this.size }) { "size bounded after filter" }
 
@@ -563,12 +590,15 @@ object CollectionConversionsLaws {
   inline fun <K, V> Collection<Pair<K, V>>.toMapLaw(): Map<K, V> =
     toMap().post({ it.size <= this.size }) { "size bounded by collection" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, K, V> Collection<T>.associateLaw(transform: (T) -> Pair<K, V>): Map<K, V> =
     associate(transform).post({ it.size <= this.size }) { "size bounded by collection" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, K> Collection<T>.associateByLaw(keySelector: (T) -> K): Map<K, T> =
     associateBy(keySelector).post({ it.size <= this.size }) { "size bounded by collection" }
   @Law
+  @DoesNothingOnEmptyCollection
   inline fun <T, K> Collection<K>.associateWithLaw(valueSelector: (K) -> T): Map<K, T> =
     associateWith(valueSelector).post({ it.size <= this.size }) { "size bounded by collection" }
 

--- a/plugins/analysis/types/src/commonMain/kotlin/arrow/analysis/RefinementDSL.kt
+++ b/plugins/analysis/types/src/commonMain/kotlin/arrow/analysis/RefinementDSL.kt
@@ -44,6 +44,9 @@ public annotation class Post(
 /** Annotation to flag ad-hoc refinements over third party functions */
 @Target(AnnotationTarget.FUNCTION) public annotation class Subject(val fqName: String)
 
+/** Annotation to flag functions which do not do anything on empty collections */
+@Target(AnnotationTarget.FUNCTION) public annotation class DoesNothingOnEmptyCollection
+
 /**
  * This is used to mark an object as containing only laws. This way you do not have to write the
  * annotation on every element, and you can group several of them together.

--- a/plugins/analysis/types/src/commonMain/kotlin/arrow/analysis/RefinementDSL.kt
+++ b/plugins/analysis/types/src/commonMain/kotlin/arrow/analysis/RefinementDSL.kt
@@ -12,6 +12,8 @@ public fun interface Predicate<A> {
 
 public inline fun pre(predicate: Boolean, msg: Messager): Unit = require(predicate) { msg() }
 
+public inline fun doNotLookAtArgumentsWhen(predicate: Boolean, msg: Messager): Unit = Unit
+
 public inline fun <A> A.post(predicate: Predicate<A>, msg: Messager): A {
   require(predicate(this)) { msg() }
   return this
@@ -38,14 +40,18 @@ public annotation class Post(
   val dependencies: Array<String>
 )
 
+@Target(AnnotationTarget.FUNCTION)
+public annotation class DoNotLookAtArguments(
+  val messages: Array<String>,
+  val formulae: Array<String>,
+  val dependencies: Array<String>
+)
+
 /** Annotation to flag ad-hoc refinements over third party functions */
 @Target(AnnotationTarget.FUNCTION) public annotation class Law
 
 /** Annotation to flag ad-hoc refinements over third party functions */
 @Target(AnnotationTarget.FUNCTION) public annotation class Subject(val fqName: String)
-
-/** Annotation to flag functions which do not do anything on empty collections */
-@Target(AnnotationTarget.FUNCTION) public annotation class DoesNothingOnEmptyCollection
 
 /**
  * This is used to mark an object as containing only laws. This way you do not have to write the


### PR DESCRIPTION
This fixes the problem with the following snippet:

```kotlin
fun <A> List<A>.allEqual = all { it == first() }
```

This would flag the call to `first()` as problematic, since we need to have a non-empty list. However, if the list if empty, `all` will never call the function, so we are good!

This is done by adding a new kind of annotation to explain in which cases the arguments are not evaluated, based on some property of the receiver:

```kotlin
@Law
inline fun <E> List<E>.allLaw(predicate: (x: E) -> Boolean): Boolean {
  doNotLookAtArgumentsWhen(isEmpty()) { "empty lists have no elements" }
  return all(predicate)
}
```