### PR TITLE
Everything is SNAPSHOT again

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Package definitions
 projects.group=io.arrow-kt
-projects.version=1.6.0-RC
-projects.meta_version=1.6.0-RC
+projects.version=1.6.0-SNAPSHOT
+projects.meta_version=1.6.0-SNAPSHOT
 projects.optics_version=2.0-SNAPSHOT
 projects.analysis_version=2.0-SNAPSHOT
 projects.proofs_version=2.0-SNAPSHOT


### PR DESCRIPTION
After checking the docs, it turns out that you cannot deploy `1.6.0-RC` and `2.0-SNAPSHOT` on the same repository, either everything is release or everything is SNAPSHOT.