### PR TITLE
[Analysis] Handle if without else, escape built-in names

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Declarations.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Declarations.kt
@@ -76,6 +76,7 @@ internal fun <A> SolverState.checkTopLevel(
           when (descriptor) {
             is ConstructorDescriptor ->
               ParamInfo(
+                solver,
                 THIS_VAR_NAME,
                 THIS_VAR_NAME,
                 descriptor.constructedClass.defaultType,
@@ -84,7 +85,7 @@ internal fun <A> SolverState.checkTopLevel(
               )
             else ->
               (descriptor.extensionReceiverParameter ?: descriptor.dispatchReceiverParameter)?.let {
-                ParamInfo(THIS_VAR_NAME, THIS_VAR_NAME, it.type, declaration)
+                ParamInfo(solver, THIS_VAR_NAME, THIS_VAR_NAME, it.type, declaration)
               }
           }
         val valueParams =
@@ -93,18 +94,18 @@ internal fun <A> SolverState.checkTopLevel(
               (declaration as? DeclarationWithBody)?.valueParameters?.firstOrNull {
                 it?.name == param.name.value
               }
-            ParamInfo(param.name.value, param.name.value, param.type, element)
+            ParamInfo(solver, param.name.value, param.name.value, param.type, element)
           }
         val returnParam =
           descriptor.returnType?.takeIf { descriptor !is ConstructorDescriptor }?.let {
-            ParamInfo(RESULT_VAR_NAME, RESULT_VAR_NAME, it, declaration)
+            ParamInfo(solver, RESULT_VAR_NAME, RESULT_VAR_NAME, it, declaration)
           }
         // additional for 'this@info'
         val additional =
           if (declaration is NamedDeclaration) {
             // Add 'this@functionName'
             declaration.nameAsName?.let { name ->
-              VarInfo("this@$name", THIS_VAR_NAME, declaration)
+              VarInfo(solver, "this@$name", THIS_VAR_NAME, declaration)
             }
           } else null
         // introduce non-nullability and invariants of parameters

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Parameters.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Parameters.kt
@@ -8,6 +8,7 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.collect.model.NamedCon
 import arrow.meta.plugins.analysis.phases.analysis.solver.search.fieldEqualitiesInvariants
 import arrow.meta.plugins.analysis.phases.analysis.solver.search.typeInvariants
 import arrow.meta.plugins.analysis.phases.analysis.solver.state.SolverState
+import arrow.meta.plugins.analysis.smt.Solver
 
 data class ParamInfo(
   val name: String,
@@ -15,7 +16,18 @@ data class ParamInfo(
   val type: Type?,
   val element: Element?,
   val thisFromConstructor: Boolean = false
-)
+) {
+  companion object {
+    public operator fun invoke(
+      solver: Solver,
+      name: String,
+      smtName: String,
+      type: Type?,
+      element: Element?,
+      thisFromConstructor: Boolean = false
+    ): ParamInfo = ParamInfo(name, solver.escape(smtName), type, element, thisFromConstructor)
+  }
+}
 
 /** Record the information about parameters and introduce the corresponding invariants */
 internal fun SolverState.initialParameters(
@@ -31,6 +43,6 @@ internal fun SolverState.initialParameters(
         if (param.thisFromConstructor) this::fieldEqualitiesInvariants else this::typeInvariants
       invariants(ty, param.smtName, context).forEach { addConstraint(it, context) }
     }
-    param.element?.let { element -> VarInfo(param.name, param.smtName, element) }
+    param.element?.let { element -> VarInfo.unsafeCreate(param.name, param.smtName, element) }
   }
 }

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/CheckData.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/CheckData.kt
@@ -3,6 +3,7 @@ package arrow.meta.plugins.analysis.phases.analysis.solver.check.model
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.ResolutionContext
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.Element
 import arrow.meta.plugins.analysis.smt.ObjectFormula
+import arrow.meta.plugins.analysis.smt.Solver
 import org.sosy_lab.java_smt.api.BooleanFormula
 
 data class CheckData(
@@ -18,11 +19,12 @@ data class CheckData(
     this.copy(returnPoints = returnPoints.replaceTopMost(scope, variableName))
 
   fun addVarInfo(
+    solver: Solver,
     name: String,
     smtName: String,
     origin: Element,
     invariant: BooleanFormula? = null
-  ): CheckData = this.copy(varInfo = varInfo.add(name, smtName, origin, invariant))
+  ): CheckData = this.copy(varInfo = varInfo.add(solver, name, smtName, origin, invariant))
 
   fun addVarInfos(vars: List<VarInfo>): CheckData = this.copy(varInfo = varInfo.add(vars))
 

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/Condition.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/Condition.kt
@@ -1,8 +1,14 @@
 package arrow.meta.plugins.analysis.phases.analysis.solver.check.model
 
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.ResolutionContext
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.ResolvedCall
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.descriptors.VariableDescriptor
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.BlockExpression
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.CompilerMessageSourceLocation
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.Element
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.Expression
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.WhenCondition
+import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.types.Type
 
 /** Data type used to handle `if` and `when` without subject uniformly. */
 sealed class Condition(
@@ -25,3 +31,26 @@ class SubjectCondition(
   body: Expression,
   whole: Element
 ) : Condition(check, isElse, body, whole)
+
+// wrapping for missing else
+class MissingElseBlockExpression(val whole: Expression, val thenExpression: Expression) :
+  BlockExpression {
+  override val firstStatement: Expression?
+    get() = null
+  override val statements: List<Expression>
+    get() = emptyList()
+  override val implicitReturnFromLast: Boolean
+    get() = false
+  override val text: String
+    get() = "<implicit empty else block>"
+
+  override fun impl(): Any = Unit
+  override val psiOrParent: Element = this
+  override fun parents(): List<Element> = thenExpression.parents()
+
+  override fun getResolvedCall(context: ResolutionContext): ResolvedCall? = null
+  override fun getVariableDescriptor(context: ResolutionContext): VariableDescriptor? = null
+  override fun location(): CompilerMessageSourceLocation? = whole.location()
+  override fun type(context: ResolutionContext): Type? = thenExpression.type(context)
+  override fun lastBlockStatementOrThis(): Expression = this
+}

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/CurrentVarInfo.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/CurrentVarInfo.kt
@@ -1,6 +1,7 @@
 package arrow.meta.plugins.analysis.phases.analysis.solver.check.model
 
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.Element
+import arrow.meta.plugins.analysis.smt.Solver
 import org.sosy_lab.java_smt.api.BooleanFormula
 
 data class CurrentVarInfo(private val varInfo: List<VarInfo>) {
@@ -8,11 +9,12 @@ data class CurrentVarInfo(private val varInfo: List<VarInfo>) {
   fun get(name: String): VarInfo? = varInfo.firstOrNull { it.name == name }
 
   fun add(
+    solver: Solver,
     name: String,
     smtName: String,
     origin: Element,
     invariant: BooleanFormula? = null
-  ): CurrentVarInfo = this.add(listOf(VarInfo(name, smtName, origin, invariant)))
+  ): CurrentVarInfo = this.add(listOf(VarInfo(solver, name, smtName, origin, invariant)))
 
   fun add(vars: List<VarInfo>): CurrentVarInfo = CurrentVarInfo(vars + varInfo)
 

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/VarInfo.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/model/VarInfo.kt
@@ -1,6 +1,7 @@
 package arrow.meta.plugins.analysis.phases.analysis.solver.check.model
 
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.Element
+import arrow.meta.plugins.analysis.smt.Solver
 import org.sosy_lab.java_smt.api.BooleanFormula
 
 /**
@@ -9,9 +10,27 @@ import org.sosy_lab.java_smt.api.BooleanFormula
  * - the element it came from
  * - invariants which may have been declared
  */
-data class VarInfo(
+data class VarInfo
+private constructor(
   val name: String,
   val smtName: String,
   val origin: Element,
   val invariant: BooleanFormula? = null
-)
+) {
+  companion object {
+    public operator fun invoke(
+      solver: Solver,
+      name: String,
+      smtName: String,
+      origin: Element,
+      invariant: BooleanFormula? = null
+    ): VarInfo = VarInfo(name, solver.escape(smtName), origin, invariant)
+
+    public fun unsafeCreate(
+      name: String,
+      smtName: String,
+      origin: Element,
+      invariant: BooleanFormula? = null
+    ): VarInfo = VarInfo(name, smtName, origin, invariant)
+  }
+}

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/Solver.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/Solver.kt
@@ -109,6 +109,30 @@ class Solver(context: SolverContext, nameProvider: NameProvider) :
   val resultVariable = makeObjectVariable(RESULT_VAR_NAME)
   val thisVariable = makeObjectVariable(THIS_VAR_NAME)
 
+  // From SMTLIB docs
+  private val forbiddenNames: List<String> =
+    listOf(
+      "div",
+      "mod",
+      "abs",
+      "select",
+      "store",
+      "true",
+      "false",
+      "not",
+      "and",
+      "or",
+      "xor",
+      "distinct",
+      "ite"
+    )
+
+  override fun escape(name: String): String =
+    when {
+      name in forbiddenNames -> "$name##"
+      else -> name
+    }.let { formulaManager.escape(it) }
+
   companion object {
 
     operator fun invoke(nameProvider: NameProvider): Solver =

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -1691,6 +1691,33 @@ class AnalysisTests {
       withoutPlugin = { compiles }
     )
   }
+
+  @Test
+  fun `escape known names`() {
+    """
+      ${imports()}
+      
+      fun f(div: Int, floor: Int): Int = div / floor 
+      """(
+      withPlugin = { compilesNoUnreachable },
+      withoutPlugin = { compiles }
+    )
+  }
+
+  @Test
+  fun `if without else`() {
+    """
+      ${imports()}
+      
+      fun f(x: Int): Int {
+        if (x > 0) { print("positive") }
+        return x + 1
+      }
+      """(
+      withPlugin = { compilesNoUnreachable },
+      withoutPlugin = { compiles }
+    )
+  }
 }
 
 private val AssertSyntax.compilesNoUnreachable: Assert.SingleAssert


### PR DESCRIPTION
This fixes two bugs which were found by @nomisRev:

1. Built-in names were not properly escaped; calling a parameter `div` conflicted with the built-in `div` function from integers;
2. `if` without an `else` was not handled, resulting in a `NullReferenceException`.