### PR TITLE
[Analysis] Disable times operator

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/Primitive.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/Primitive.kt
@@ -156,7 +156,7 @@ private fun Solver.integralFormula(
         1 -> intNegate(args)
         else -> throw IllegalArgumentException("- with weird # of parameters")
       }
-    "times", "*" -> intMultiply(args)
+    // "times", "*" -> intMultiply(args) // not all SMT solvers support multiplication
     // "div", "/" -> intDivide(args) // not all SMT solvers support div
     "inc",
     "++" -> intPlus(args + listOf(integerFormulaManager.makeNumber(1)))

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/Primitive.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/Primitive.kt
@@ -17,7 +17,6 @@ import arrow.meta.plugins.analysis.smt.intGreaterThanOrEquals
 import arrow.meta.plugins.analysis.smt.intLessThan
 import arrow.meta.plugins.analysis.smt.intLessThanOrEquals
 import arrow.meta.plugins.analysis.smt.intMinus
-import arrow.meta.plugins.analysis.smt.intMultiply
 import arrow.meta.plugins.analysis.smt.intNegate
 import arrow.meta.plugins.analysis.smt.intPlus
 import arrow.meta.plugins.analysis.smt.rationalEquals


### PR DESCRIPTION
For some reason formulae with `*` make the SMT solver throw an exception. This PR just disables it.