### PR TITLE
[Analysis] Be less picky about inconsistent nullability checks

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Expressions.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/Expressions.kt
@@ -769,7 +769,8 @@ private fun SolverState.checkReceiverWithPossibleSafeDot(
                     listOf(nullReceiver, nullResult),
                     dataAfterReceiver.context,
                     receiverExpr!!,
-                    dataAfterReceiver.branch.get()
+                    dataAfterReceiver.branch.get(),
+                    reportIfInconsistent = false
                   )
                 ensure(!inconsistent)
                 dataAfterReceiver.addBranch(solver.isNull(receiverName)).noReturn()
@@ -787,7 +788,8 @@ private fun SolverState.checkReceiverWithPossibleSafeDot(
                       listOf(notNullCstr),
                       data.context,
                       rcv,
-                      dataAfterReceiver.branch.get()
+                      dataAfterReceiver.branch.get(),
+                      reportIfInconsistent = false
                     )
                   ensure(!inconsistent)
                   dataAfterReceiver.addBranch(solver.isNotNull(receiverName)).noReturn()
@@ -827,7 +829,8 @@ private fun SolverState.checkElvisOperator(
                   listOf(nullLeft),
                   data.context,
                   leftExpr,
-                  data.branch.get()
+                  data.branch.get(),
+                  reportIfInconsistent = false
                 )
               ensure(!inconsistent)
             }
@@ -853,7 +856,8 @@ private fun SolverState.checkElvisOperator(
                   listOf(notNullLeft, resultIsLeft),
                   data.context,
                   leftExpr,
-                  data.branch.get()
+                  data.branch.get(),
+                  reportIfInconsistent = false
                 )
               ensure(!inconsistent)
             }
@@ -890,7 +894,8 @@ private fun SolverState.checkAsOperator(
                   listOf(nullResult),
                   data.context,
                   whole,
-                  data.branch.get()
+                  data.branch.get(),
+                  reportIfInconsistent = false
                 )
               ensure(!inconsistent)
             }
@@ -906,7 +911,8 @@ private fun SolverState.checkAsOperator(
                   listOf(resultEqualsLeft),
                   data.context,
                   whole,
-                  data.branch.get()
+                  data.branch.get(),
+                  reportIfInconsistent = false
                 )
               ensure(!inconsistent)
             }
@@ -1518,7 +1524,8 @@ private fun SolverState.checkConditional(
                     correspondingVars,
                     data.context,
                     cond.whole,
-                    data.branch.get()
+                    data.branch.get(),
+                    reportIfInconsistent = true
                   )
                 // it only makes sense to continue if we are not consistent
                 ensure(!inconsistentEnvironment)
@@ -1713,7 +1720,8 @@ private fun SolverState.checkWhileExpression(
                 listOf(NamedConstraint("inside the loop, condition is true", objVar)),
                 data.context,
                 condition,
-                data.branch.get()
+                data.branch.get(),
+                reportIfInconsistent = true
               )
               checkLoopBody(body, afterBody, data.addBranch(objVar))
             }
@@ -1726,7 +1734,8 @@ private fun SolverState.checkWhileExpression(
               listOf(NamedConstraint("loop is finished, condition is false", notVar)),
               data.context,
               condition,
-              data.branch.get()
+              data.branch.get(),
+              reportIfInconsistent = true
             )
             // add (not condition) to the data
             data.addBranch(notVar).noReturn()

--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/state/SolverInteraction.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/state/SolverInteraction.kt
@@ -209,12 +209,15 @@ internal fun SolverState.checkConditionsInconsistencies(
   formulae: List<NamedConstraint>,
   context: ResolutionContext,
   expression: Element,
-  branch: Branch
+  branch: Branch,
+  reportIfInconsistent: Boolean
 ): Boolean =
   solver.run {
     addAndCheckConsistency(formulae, context) { unsatCore ->
-      val msg = inconsistentConditions(unsatCore, branch)
-      context.handleError(ErrorIds.Inconsistency.InconsistentConditions, expression, msg)
+      if (reportIfInconsistent) {
+        val msg = inconsistentConditions(unsatCore, branch)
+        context.handleError(ErrorIds.Inconsistency.InconsistentConditions, expression, msg)
+      }
     }
   }
 

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -1746,7 +1746,7 @@ class AnalysisTests {
       fun f(x: Any): Int = (x as Int) + 1
       fun g(x: Any): Int? = (x as? Int)?.let { it + 1 }
       """(
-      withPlugin = { compiles },
+      withPlugin = { compilesNoUnreachable },
       withoutPlugin = { compiles }
     )
   }


### PR DESCRIPTION
The tests @nomisRev has been doing have shown that sometimes we are too noisy about conflicting information about nullability. This usually comes because each usage of a possibly-nullable value, `?.`, `?:` or `as?` generates two possible "branches of execution", but in many cases those are repetitive and conflict (for example, we have a parameter of type `Int?`, so we have two branches; but then if we use `n?.let { ... }` we generate yet another two branches, one conflicting with the fact that `n` is or is not null).

This PR makes the inconsistency warnings less noisy when dealing with those operators.