### PR TITLE
Fix broken documentation links

### DIFF
--- a/docs/docs/analysis/types/README.md
+++ b/docs/docs/analysis/types/README.md
@@ -47,8 +47,7 @@ class Positive(val value: Int) {
   constructor() : this(0) { }
 }
 ```
-
-Types like `Positive` above are a special case of [wrappers](({{ '/analysis/wrappers' | relative_url }}), a way to attach additional invariants to already existing types (`Int`in this case.)
+Types like `Positive` above are a special case of [wrappers]({{ '/analysis/wrappers' | relative_url }}), a way to attach additional invariants to already existing types (`Int`in this case.)
 
 ## Initializers with `pre` and `post`
 

--- a/docs/docs/analysis/wrappers/README.md
+++ b/docs/docs/analysis/wrappers/README.md
@@ -6,7 +6,7 @@ permalink: /analysis/wrappers/
 
 # Wrappers
 
-Λrrow Analysis supports the addition of [invariants to types](({{ '/analysis/types' | relative_url }}), but what happens when you _already_ have a type and want to add information relative to it? And when may that situation arise?
+Λrrow Analysis supports the addition of [invariants to types]({{ '/analysis/types' | relative_url }}), but what happens when you _already_ have a type and want to add information relative to it? And when may that situation arise?
 
 ## Inline classes
 


### PR DESCRIPTION
Hello

I saw following broken links on the Arrow Analysis docs.

![Broken link 1](https://user-images.githubusercontent.com/6739443/151673710-7ddfde3b-9f9d-4520-b92f-5b0ddb55be40.jpeg)
https://arrow-kt.io/docs/meta/analysis/wrappers/

![Broken link 2](https://user-images.githubusercontent.com/6739443/151673711-8d5caed3-dff6-4b78-8a89-83a4d399a123.jpeg)
https://arrow-kt.io/docs/meta/analysis/types/#types-and-invariants

I couldn't verify if this solves the issue locally as I was unable to 'build the site'
However I guess the dangling `(` is the culprit.
 