### PR TITLE
[Analysis] Handle every declaration descriptor in Kotlin

### DIFF
--- a/docs/docs/analysis/README.md
+++ b/docs/docs/analysis/README.md
@@ -60,6 +60,20 @@ apply plugin: 'io.arrow-kt.analysis.kotlin'
 
 This adds both the Kotlin compiler plug-in -- which performs the checks -- and the pre and post-conditions for the Kotlin standard library. You are ready to get your first analysis results.
 
+### Λrrow Analysis + Android
+
+If you want to use the plug-in in an Android project, you may run into [this Kotlin compiler issue](https://youtrack.jetbrains.com/issue/KT-38576), characterized by the following error message:
+
+```
+java.lang.AssertionError: Duplicated JavaClassDescriptor ... reported to IC
+```
+
+To solve this problem you have to disable precise Java tracking, by adding the following line in your `gradle.properties` file:
+
+```kotlin
+kotlin.incremental.usePreciseJavaTracking=false
+```
+
 ## Running the analysis
 
 Open a new file and write the following line. This code is incorrect because you want to obtain the third element of an empty list.

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/ast/KotlinInterpreter.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/ast/KotlinInterpreter.kt
@@ -6,7 +6,6 @@ import arrow.meta.plugins.analysis.phases.analysis.solver.ast.context.elements.E
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.descriptors.*
 import arrow.meta.plugins.analysis.phases.analysis.solver.ast.kotlin.elements.*
 import org.jetbrains.kotlin.descriptors.*
-import org.jetbrains.kotlin.descriptors.impl.LazyClassReceiverParameterDescriptor
 import org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
 import org.jetbrains.kotlin.descriptors.impl.TypeAliasConstructorDescriptor
 import org.jetbrains.kotlin.psi.*
@@ -14,14 +13,11 @@ import org.jetbrains.kotlin.psi.psiUtil.isNull
 
 /* ktlint-enable no-wildcard-imports */
 
-private fun <
-  A : org.jetbrains.kotlin.descriptors.DeclarationDescriptor, B : DeclarationDescriptor> A.repr():
-  B = this as B
-
+@Suppress("UNUSED_PARAMETER", "UNCHECKED_CAST")
 private fun <A : DeclarationDescriptor, B : DeclarationDescriptor> A.repr(unit: Unit = Unit): B =
   this as B
 
-fun <A : Element, B : Element> A.repr(): B = this as B
+@Suppress("UNCHECKED_CAST") fun <A : Element, B : Element> A.repr(): B = this as B
 
 fun <
   A : org.jetbrains.kotlin.descriptors.DeclarationDescriptor, B : DeclarationDescriptor> A.model():
@@ -36,17 +32,18 @@ fun <
     is ClassDescriptor -> KotlinClassDescriptor(this).repr()
     is TypeAliasDescriptor -> KotlinTypeAliasDescriptor(this).repr()
     is ValueParameterDescriptor -> KotlinValueParameterDescriptor(this).repr()
-    // is ModuleDescriptor -> KotlinModuleDescriptor(this).repr()
-    is LazyClassReceiverParameterDescriptor -> KotlinReceiverParameterDescriptor(this).repr()
+    is ModuleDescriptor -> KotlinModuleDescriptor(this).repr()
     is ReceiverParameterDescriptor -> KotlinReceiverParameterDescriptor(this).repr()
     is LocalVariableDescriptor -> KotlinLocalVariableDescriptor(this).repr()
     is PackageFragmentDescriptor -> KotlinPackageFragmentDescriptor(this).repr()
     // fallback cases: we sometimes find unknown descriptors
     // and for those cases we need nothing else than what the
     // abstract classes provide
-    is FunctionDescriptor -> (object : KotlinFunctionDescriptor(this) {}).repr()
-    is VariableDescriptor -> (object : KotlinVariableDescriptor(this) {}).repr()
-    else -> TODO("Missing impl for $this (${this.javaClass.name})")
+    is FunctionDescriptor -> KotlinDefaultFunctionDescriptor(this).repr()
+    is VariableDescriptor -> KotlinDefaultVariableDescriptor(this).repr()
+    is DeclarationDescriptorWithVisibility ->
+      KotlinDefaultDeclarationDescriptorWithVisibility(this).repr()
+    else -> KotlinDefaultDeclarationDescriptor(this).repr()
   }
 
 fun <A : KtElement, B : Element> A.model(): B =
@@ -152,4 +149,4 @@ fun <A : KtElement, B : Element> A.model(): B =
       )
   }
 
-fun <A : Element, B : KtElement> A.element(): B = impl() as B
+@Suppress("UNCHECKED_CAST") fun <A : Element, B : KtElement> A.element(): B = impl() as B

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinDeclarationDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinDeclarationDescriptor.kt
@@ -30,3 +30,9 @@ fun interface KotlinDeclarationDescriptor : DeclarationDescriptor {
   override val name: Name
     get() = Name(impl().name.asString())
 }
+
+class KotlinDefaultDeclarationDescriptor(
+  val impl: org.jetbrains.kotlin.descriptors.DeclarationDescriptor
+) : KotlinDeclarationDescriptor {
+  override fun impl(): org.jetbrains.kotlin.descriptors.DeclarationDescriptor = impl
+}

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinDeclarationDescriptorWithVisibility.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinDeclarationDescriptorWithVisibility.kt
@@ -9,3 +9,9 @@ fun interface KotlinDeclarationDescriptorWithVisibility :
   override val visibility: Visibility
     get() = KotlinVisibility { impl().visibility.delegate }
 }
+
+class KotlinDefaultDeclarationDescriptorWithVisibility(
+  val impl: org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithVisibility
+) : KotlinDeclarationDescriptorWithVisibility {
+  override fun impl(): org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithVisibility = impl
+}

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinFunctionDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinFunctionDescriptor.kt
@@ -29,3 +29,6 @@ abstract class KotlinFunctionDescriptor(
   override val isSuspend: Boolean
     get() = impl().isSuspend
 }
+
+class KotlinDefaultFunctionDescriptor(impl: org.jetbrains.kotlin.descriptors.FunctionDescriptor) :
+  KotlinFunctionDescriptor(impl)

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinModuleDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinModuleDescriptor.kt
@@ -11,7 +11,7 @@ class KotlinModuleDescriptor(val impl: org.jetbrains.kotlin.descriptors.ModuleDe
 
   override fun impl(): org.jetbrains.kotlin.descriptors.ModuleDescriptor = impl
 
-  override fun getPackage(pck: String): PackageViewDescriptor? =
+  override fun getPackage(pck: String): PackageViewDescriptor =
     impl().getPackage(org.jetbrains.kotlin.name.FqName(pck)).model()
 
   override fun getSubPackagesOf(fqName: FqName): List<FqName> =

--- a/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinVariableDescriptor.kt
+++ b/plugins/analysis/kotlin-plugin/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/ast/kotlin/descriptors/KotlinVariableDescriptor.kt
@@ -15,3 +15,6 @@ abstract class KotlinVariableDescriptor(
   override val isLateInit: Boolean
     get() = impl().isLateInit
 }
+
+class KotlinDefaultVariableDescriptor(impl: org.jetbrains.kotlin.descriptors.VariableDescriptor) :
+  KotlinVariableDescriptor(impl)


### PR DESCRIPTION
Fixes #1001 

It also contains a small update to the docs that explains how to disable precise Java tracking, which is required for Arrow Analysis to work in Android projects