### PR TITLE
[Analysis] Escape more internal names

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/Solver.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/smt/Solver.kt
@@ -109,9 +109,9 @@ class Solver(context: SolverContext, nameProvider: NameProvider) :
   val resultVariable = makeObjectVariable(RESULT_VAR_NAME)
   val thisVariable = makeObjectVariable(THIS_VAR_NAME)
 
-  // From SMTLIB docs
   private val forbiddenNames: List<String> =
     listOf(
+      // From SMTLIB docs
       "div",
       "mod",
       "abs",
@@ -124,7 +124,13 @@ class Solver(context: SolverContext, nameProvider: NameProvider) :
       "or",
       "xor",
       "distinct",
-      "ite"
+      "ite",
+      // from our own internal names
+      INT_VALUE_NAME,
+      BOOL_VALUE_NAME,
+      DECIMAL_VALUE_NAME,
+      FIELD_FUNCTION_NAME,
+      IS_NULL_FUNCTION_NAME
     )
 
   override fun escape(name: String): String =

--- a/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
+++ b/plugins/analysis/kotlin-plugin/src/test/kotlin/arrow/meta/plugins/analysis/AnalysisTests.kt
@@ -1927,6 +1927,22 @@ class AnalysisTests {
       isMultiplatform = true
     )
   }
+
+  @Test
+  fun `field named field (issue #1031)`() {
+    """
+      ${imports()}
+      
+      data class Field(val key: String, val value: String)
+      
+      private fun List<Int>.findField(tag: String, field: String): Field? =
+         Field(tag, field)
+      """(
+      withPlugin = { compilesNoUnreachable },
+      withoutPlugin = { compiles },
+      isMultiplatform = true
+    )
+  }
 }
 
 private val AssertSyntax.compilesNoUnreachable: Assert.SingleAssert


### PR DESCRIPTION
Fixes #1031 

The problem was that SMT names are escaped, but the ones we use internally (`field`, `int`, ...) were not. This PR adds them and a small test case.