### PR TITLE
[Analysis] Find primary constructor instead of assuming it's the only one

### DIFF
--- a/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/EntryPoint.kt
+++ b/plugins/analysis/common/src/main/kotlin/arrow/meta/plugins/analysis/phases/analysis/solver/check/EntryPoint.kt
@@ -67,7 +67,11 @@ public fun SolverState.checkDeclarationConstraints(
             declaration.hasImplicitPrimaryConstructor() && !descriptor.hasPackageWithLawsAnnotation
           ) {
             descriptor as ClassDescriptor
-            checkImplicitPrimaryConstructor(context, descriptor.constructors.single(), declaration)
+            checkImplicitPrimaryConstructor(
+              context,
+              descriptor.constructors.single { it.isPrimary },
+              declaration
+            )
           }
         is Property ->
           when {


### PR DESCRIPTION
I think this fixes #1032, but I'm not 100% sure because I cannot test code with several plug-ins.

@mkotsbak would you be open to trying this version in your project? we can maybe merge and then you can try with the published snapshot.