### PR TITLE
improve generate-tag worklfow

### DIFF
--- a/.github/workflows/generate-tag.yaml
+++ b/.github/workflows/generate-tag.yaml
@@ -2,7 +2,7 @@ name: generate-tag
 
 on:
   workflow_dispatch:
-    if: github.ref == 'refs/heads/main'
+    branches: [main]
     inputs:
       stage:
         description: 'Stage'
@@ -21,7 +21,6 @@ on:
         default: 'auto'
         type: choice
         options:
-          - 'patch'
           - 'minor'
           - 'major'
           - 'auto'


### PR DESCRIPTION
from our learning this is removing the possibility 
- to create tags on sub branches other than the "main" branch
- removes "patch" since `final` + `auto` is what you would choose to update from 1.0.1 to 1.0.2 instead `final` + `patch` results in an update from 1.0.1 to 1.0.3