### PR TITLE
[WIP] Experiment - Update to Kotlin 1.9.20-Beta2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,11 +13,6 @@ plugins {
 }
 
 allprojects {
-  repositories {
-    mavenCentral()
-    maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
-  }
-
   group = property("projects.group").toString()
 }
 

--- a/gradle/projects.libs.versions.toml
+++ b/gradle/projects.libs.versions.toml
@@ -7,12 +7,12 @@ dokka = "1.8.10"
 intellijOpenApi = "7.0.3"
 javaAssist = "3.29.2-GA"
 junit = "5.9.2"
-kotlin = "1.8.21"
-kotlinCompileTesting = "1.5.0"
+kotlin = "1.9.20-Beta2"
+kotlinCompileTesting = "1.5.1-SNAPSHOT"
 javaCompileTesting = "0.21.0"
 kotlinBinaryCompatibilityValidator = "0.13.0"
 detekt = "1.22.0"
-ksp = "1.8.21-1.0.11"
+ksp = "1.9.20-Beta2-1.0.13"
 
 [libraries]
 arrowCore = { module = "io.arrow-kt:arrow-core", version.ref = "arrow" }
@@ -31,7 +31,7 @@ kotlin-stdlibCommon = { module = "org.jetbrains.kotlin:kotlin-stdlib-common", ve
 kotlin-stdlibJDK8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlin" }
 kotlin-stdlibJS = { module = "org.jetbrains.kotlin:kotlin-stdlib-js" }
 kotlin-scriptingCompilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable" }
-kotlin-scriptUtil = { module = "org.jetbrains.kotlin:kotlin-script-util" }
+kotlin-scriptUtil = { module = "org.jetbrains.kotlin:kotlin-script-util", version="1.8.22" }
 kotlin-gradlePluginX = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin" }
 kotlin-gradlePluginApi = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin-api" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/internal/registry/InternalRegistry.kt
@@ -17,6 +17,7 @@ import arrow.meta.phases.analysis.CollectAdditionalSources
 import arrow.meta.phases.analysis.ExtraImports
 import arrow.meta.phases.analysis.PreprocessedVirtualFileFactory
 import arrow.meta.phases.codegen.asm.ClassBuilder
+import arrow.meta.phases.codegen.asm.ClassGeneration
 import arrow.meta.phases.codegen.asm.Codegen
 import arrow.meta.phases.codegen.ir.IRGeneration
 import arrow.meta.phases.config.Config
@@ -29,13 +30,14 @@ import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.analyzer.ModuleInfo
 import org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension
 import org.jetbrains.kotlin.backend.common.extensions.IrPluginContext
+import org.jetbrains.kotlin.backend.jvm.extensions.ClassGenerator
+import org.jetbrains.kotlin.backend.jvm.extensions.ClassGeneratorExtension
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
 import org.jetbrains.kotlin.cli.common.messages.MessageCollector
 import org.jetbrains.kotlin.codegen.ClassBuilderFactory
 import org.jetbrains.kotlin.codegen.ImplementationBodyCodegen
 import org.jetbrains.kotlin.codegen.StackValue
-import org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension
 import org.jetbrains.kotlin.codegen.extensions.ExpressionCodegenExtension
 import org.jetbrains.kotlin.com.intellij.mock.MockProject
 import org.jetbrains.kotlin.com.intellij.openapi.project.Project
@@ -66,6 +68,7 @@ import org.jetbrains.kotlin.extensions.PreprocessedVirtualFileFactoryExtension
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
 import org.jetbrains.kotlin.incremental.components.LookupLocation
 import org.jetbrains.kotlin.incremental.components.LookupTracker
+import org.jetbrains.kotlin.ir.declarations.IrClass
 import org.jetbrains.kotlin.ir.declarations.IrModuleFragment
 import org.jetbrains.kotlin.name.Name
 import org.jetbrains.kotlin.platform.TargetPlatform
@@ -178,6 +181,7 @@ interface InternalRegistry : ConfigSyntax {
             is StorageComponentContainer -> registerStorageComponentContainer(this, ctx)
             is AnalysisHandler -> registerAnalysisHandler(this, ctx)
             is ClassBuilder -> registerClassBuilder(this, ctx)
+            is ClassGeneration -> registerClassGenerator(this, ctx)
             is Codegen -> registerCodegen(this, ctx)
             is DeclarationAttributeAlterer -> registerDeclarationAttributeAlterer(this, ctx)
             is PackageProvider -> packageFragmentProvider(this, ctx)
@@ -605,12 +609,29 @@ interface InternalRegistry : ConfigSyntax {
     }
   }
 
+  fun CompilerPluginRegistrar.ExtensionStorage.registerClassGenerator(
+    phase: ClassGeneration,
+    ctx: CompilerContext
+  ) {
+    ClassGeneratorExtension.registerExtension(
+      object : ClassGeneratorExtension {
+        override fun generateClass(
+          generator: ClassGenerator,
+          declaration: IrClass?
+        ): ClassGenerator = phase.run { ctx.interceptClassGenerator(generator, declaration) }
+      }
+    )
+  }
+
   fun CompilerPluginRegistrar.ExtensionStorage.registerClassBuilder(
     phase: ClassBuilder,
     ctx: CompilerContext
   ) {
-    ClassBuilderInterceptorExtension.registerExtension(
-      object : ClassBuilderInterceptorExtension {
+    @Suppress("DEPRECATION_ERROR")
+    org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension.registerExtension(
+      object :
+        @Suppress("DEPRECATION_ERROR")
+        org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension {
         override fun interceptClassBuilderFactory(
           interceptedFactory: ClassBuilderFactory,
           bindingContext: BindingContext,

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/codegen/asm/ClassBuilder.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/codegen/asm/ClassBuilder.kt
@@ -10,6 +10,11 @@ import org.jetbrains.kotlin.resolve.BindingContext
  * @see [ExtensionPhase]
  * @see [arrow.meta.dsl.codegen.asm.AsmSyntax]
  */
+@Deprecated(
+  "This extension is only supported in K1 and will not work properly in K2. " +
+    "Please migrate to ClassGeneration or IRGeneration extension points.",
+  level = DeprecationLevel.WARNING
+)
 interface ClassBuilder : ExtensionPhase {
   fun CompilerContext.interceptClassBuilder(
     interceptedFactory: ClassBuilderFactory,

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/codegen/asm/ClassGeneration.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/codegen/asm/ClassGeneration.kt
@@ -1,0 +1,17 @@
+package arrow.meta.phases.codegen.asm
+
+import arrow.meta.phases.CompilerContext
+import arrow.meta.phases.ExtensionPhase
+import org.jetbrains.kotlin.backend.jvm.extensions.ClassGenerator
+import org.jetbrains.kotlin.ir.declarations.IrClass
+
+/**
+ * @see [ExtensionPhase]
+ * @see [arrow.meta.dsl.codegen.asm.AsmSyntax]
+ */
+interface ClassGeneration : ExtensionPhase {
+  fun CompilerContext.interceptClassGenerator(
+    generator: ClassGenerator,
+    declaration: IrClass?
+  ): ClassGenerator
+}

--- a/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/codegen/ir/IrUtils.kt
+++ b/libs/arrow-meta/src/main/kotlin/arrow/meta/phases/codegen/ir/IrUtils.kt
@@ -70,7 +70,9 @@ class IrUtils(
   fun CallableDescriptor.irCall(): IrExpression =
     when (this) {
       is PropertyDescriptor -> {
-        val irField = pluginContext.symbols.externalSymbolTable.referenceField(this)
+        // warning: Please use IR declaration properties and not its descriptor properties
+        val irField =
+          pluginContext.symbols.externalSymbolTable.descriptorExtension.referenceField(this)
         irField.owner.correspondingPropertySymbol?.owner?.getter?.symbol?.let {
           irSimpleFunctionSymbol ->
           IrCallImpl(
@@ -85,7 +87,9 @@ class IrUtils(
           ?: TODO("Unsupported irCall for $this")
       }
       is ClassConstructorDescriptor -> {
-        val irSymbol = pluginContext.symbols.externalSymbolTable.referenceConstructor(this)
+        // warning: Please use IR declaration properties and not its descriptor properties
+        val irSymbol =
+          pluginContext.symbols.externalSymbolTable.descriptorExtension.referenceConstructor(this)
         IrConstructorCallImpl(
           startOffset = UNDEFINED_OFFSET,
           endOffset = UNDEFINED_OFFSET,
@@ -108,7 +112,11 @@ class IrUtils(
         )
       }
       is FakeCallableDescriptorForObject -> {
-        val irSymbol = pluginContext.symbols.externalSymbolTable.referenceClass(classDescriptor)
+        // warning: Please use IR declaration properties and not its descriptor properties
+        val irSymbol =
+          pluginContext.symbols.externalSymbolTable.descriptorExtension.referenceClass(
+            classDescriptor
+          )
         IrGetObjectValueImpl(
           startOffset = UNDEFINED_OFFSET,
           endOffset = UNDEFINED_OFFSET,
@@ -122,7 +130,8 @@ class IrUtils(
     }
 
   fun PropertyDescriptor.irGetterCall(): IrCall? {
-    val irField = pluginContext.symbols.externalSymbolTable.referenceField(this)
+    // warning: Please use IR declaration properties and not its descriptor properties
+    val irField = pluginContext.symbols.externalSymbolTable.descriptorExtension.referenceField(this)
     return irField.owner.correspondingPropertySymbol?.owner?.getter?.symbol?.let {
       irSimpleFunctionSymbol ->
       IrCallImpl(

--- a/libs/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
+++ b/libs/meta-test/src/main/kotlin/arrow/meta/plugin/testing/Compilation.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalCompilerApi::class)
+
 package arrow.meta.plugin.testing
 
 import com.tschuchort.compiletesting.KotlinCompilation
@@ -34,7 +36,6 @@ internal fun compile(data: CompilationData): Result {
   }
 }
 
-@OptIn(ExperimentalCompilerApi::class)
 private fun createKotlinCompilation(data: CompilationData) =
   KotlinCompilation().apply {
     val testSources = workingDir.resolve("sources")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -15,6 +15,17 @@ dependencyResolutionManagement {
       kotlinVersion?.let { version("kotlin", it) }
     }
   }
+
+  repositories {
+    mavenLocal {
+      content {
+        includeGroup("io.arrow-kt")
+        includeGroup("com.github.tschuchortdev")
+      }
+    }
+    mavenCentral()
+    maven(url = "https://oss.sonatype.org/content/repositories/snapshots/")
+  }
 }
 
 rootProject.name = "arrow-meta-workspace"


### PR DESCRIPTION
This PR is not meant to be merged, it is meant to be informational to see what the current state is for Arrow-Meta and latest Kotlin compilers.

Experiment to see the difference for upgrading to current Kotlin compiler from 1.9.20-Beta2.

Notes:

* Kotlin-Compiler-Testing will fail tests, but there is a branch that is close to working (https://github.com/tschuchortdev/kotlin-compile-testing/pull/388) and with one additional change to remove `useIR` setting in `KotlinCompilation.t` (`// args.useIR = useIR`) this branch works and tests pass again.

* `ClassBuilder` uses extension point that is K1 only, and not K2 compatible.  I marked it deprecated to leave the code, but it should be removed.  `ClassGeneration` is a new extension point.  `ClassBuilderInterceptorExtension` is the problematic class, which now has this deprecation eeror:  
	```
	@Deprecated(
	    "This extension is only supported in K1 and will not work properly in K2. " +
	            "Please migrate to org.jetbrains.kotlin.backend.common.extensions.IrGenerationExtension or " +
	            "org.jetbrains.kotlin.backend.jvm.extensions.ClassGeneratorExtension.",
	    level = DeprecationLevel.ERROR
	)
	```

* `IrUtils` becomes pretty suspect after this change since all of the utility functions based on descriptors access things like `pluginContext.symbols.externalSymbolTable.referenceSomething(this)` which moved one level deeper to ` pluginContext.symbols.externalSymbolTable.descriptorExtension.referenceSomething(this)` and produce deprecation warnings "Please use IR declaration properties and not its descriptor properties" which is referring to `IdSignature` instances which can be used in the original call `pluginContext.symbols.externalSymbolTable.referenceSomething(idSignature)`.  More info here:

	```
	/**
	 * This annotation is used on IR API elements which use front-end (FE) descriptors to obtain information, directly or indirectly.
	 *
	 * Descriptors are used in FE to represent main declaration properties and to refer declarations.
	 * Early IR versions were descriptor-based, so IR elements used descriptors to obtain some information about element properties.
	 * However, more correct and universal way is to store all necessary information inside IR elements themselves
	 * and do not use descriptors as some intermediate storage. It's planned to remove all descriptor usages from IR in future.
	 */
	@Target(
	    AnnotationTarget.CLASS,
	    AnnotationTarget.PROPERTY,
	    AnnotationTarget.VALUE_PARAMETER,
	    AnnotationTarget.FUNCTION,
	    AnnotationTarget.TYPEALIAS
	)
	@RequiresOptIn(message = "Please use IR declaration properties and not its descriptor properties", level = RequiresOptIn.Level.ERROR)
	annotation class ObsoleteDescriptorBasedAPI
	```
	and https://github.com/JetBrains/kotlin/blob/master/compiler/ir/ir.tree/src/org/jetbrains/kotlin/ir/util/IdSignature.kt
	
With this, all tests pass, but there is some ominous warnings there about `IrUtils` and the descriptors they were based upon.